### PR TITLE
Make basic_format moveable

### DIFF
--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -270,7 +270,11 @@ namespace boost {
 
             }
                         
-            
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+#ifndef BOOST_NO_DEFAULTED_FUNCTIONS
+            basic_format(basic_format&&) = default;
+#endif
+#endif
         private:
 
             class format_guard {


### PR DESCRIPTION
Currently basic_format can't be returned from a function, which can be fixed with a default move constructor. 
