### PR TITLE
Add missing include

### DIFF
--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -22,10 +22,9 @@
 
 #ifdef BOOST_LOCALE_UNORDERED_CATALOG
 #include <boost/unordered_map.hpp>
-#else
-#include <map>
 #endif
 
+#include <map>
 #include <iostream>
 
 


### PR DESCRIPTION
map is needed for mo_message::domains_map_type.

The missing include currently prevents the develop branch from compiling with MSVC 14 RC.