### PR TITLE
Fix compilation error in GNU gettext backend

### DIFF
--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -436,8 +436,8 @@ namespace boost {
                         while(*e)
                             e++;
                         state = pj_winberger_hash::update_state(state,
-                                    static_cast<char const *>(p),
-                                    static_cast<char const *>(e));
+                                    reinterpret_cast<char const *>(p),
+                                    reinterpret_cast<char const *>(e));
                         state = pj_winberger_hash::update_state(state,'\4');
                     }
                     p = msg.key();
@@ -445,8 +445,8 @@ namespace boost {
                     while(*e)
                         e++;
                     state = pj_winberger_hash::update_state(state,
-                                static_cast<char const *>(p),
-                                static_cast<char const *>(e));
+                                reinterpret_cast<char const *>(p),
+                                reinterpret_cast<char const *>(e));
                     return state;
                 }
             };

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -10,6 +10,7 @@
 #include <boost/locale/message.hpp>
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/cstdint.hpp>
 #include <boost/locale/encoding.hpp>
 #ifdef BOOST_MSVC
 #  pragma warning(disable : 4996)
@@ -25,12 +26,19 @@
 #endif
 
 #include <map>
+#include <vector>
+#include <string>
+#include <memory>
+#include <utility>
 #include <iostream>
+#include <stdexcept>
+#include <algorithm>
 
 
 #include "mo_hash.hpp"
 #include "mo_lambda.hpp"
 
+#include <stddef.h>
 #include <stdio.h>
 
 #include <string.h>

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -6,6 +6,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 #define BOOST_LOCALE_SOURCE
+#include <boost/version.hpp>
 #include <boost/config.hpp>
 #include <boost/locale/message.hpp>
 #include <boost/locale/gnu_gettext.hpp>

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -22,10 +22,9 @@
 
 #ifdef BOOST_LOCALE_UNORDERED_CATALOG
 #include <boost/unordered_map.hpp>
-#else
-#include <map>
 #endif
 
+#include <map>
 #include <iostream>
 
 


### PR DESCRIPTION
Eventually, hash_function gets instantiated on wchar_t by create_messages_facet<wchar_t>(). The pointer conversion has to be a reinterpret_cast instead of static_cast.
