### PR TITLE
Remove mentions of deprecated macros

### DIFF
--- a/src/std/codecvt.cpp
+++ b/src/std/codecvt.cpp
@@ -35,11 +35,11 @@ namespace impl_std {
             return codecvt_bychar<char>(in,locale_name);
         case wchar_t_facet:
             return codecvt_bychar<wchar_t>(in,locale_name);
-        #if defined(BOOST_HAS_CHAR16_T) && !defined(BOOST_NO_CHAR16_T_CODECVT)
+        #if !defined(BOOST_NO_CXX11_CHAR16_T) && !defined(BOOST_NO_CHAR16_T_CODECVT)
         case char16_t_facet:
             return codecvt_bychar<char16_t>(in,locale_name);
         #endif
-        #if defined(BOOST_HAS_CHAR32_T) && !defined(BOOST_NO_CHAR32_T_CODECVT)
+        #if !defined(BOOST_NO_CXX11_CHAR32_T) && !defined(BOOST_NO_CHAR32_T_CODECVT)
         case char32_t_facet:
             return codecvt_bychar<char32_t>(in,locale_name);
         #endif

--- a/src/util/codecvt_converter.cpp
+++ b/src/util/codecvt_converter.cpp
@@ -649,11 +649,11 @@ namespace util {
             return std::locale(in,new code_converter<char>(cvt));
         case wchar_t_facet:
             return std::locale(in,new code_converter<wchar_t>(cvt));
-        #if defined(BOOST_HAS_CHAR16_T) && !defined(BOOST_NO_CHAR16_T_CODECVT)
+        #if !defined(BOOST_NO_CXX11_CHAR16_T) && !defined(BOOST_NO_CHAR16_T_CODECVT)
         case char16_t_facet:
             return std::locale(in,new code_converter<char16_t>(cvt));
         #endif
-        #if defined(BOOST_HAS_CHAR32_T) && !defined(BOOST_NO_CHAR32_T_CODECVT)
+        #if !defined(BOOST_NO_CXX11_CHAR32_T) && !defined(BOOST_NO_CHAR32_T_CODECVT)
         case char32_t_facet:
             return std::locale(in,new code_converter<char32_t>(cvt));
         #endif

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -162,11 +162,11 @@ void test_wide_io()
     std::cout << "  wchar_t" << std::endl;
     test_for_char<wchar_t>();
     
-    #if defined BOOST_HAS_CHAR16_T && !defined(BOOST_NO_CHAR16_T_CODECVT)
+    #if !defined(BOOST_NO_CXX11_CHAR16_T) && !defined(BOOST_NO_CHAR16_T_CODECVT)
     std::cout << "  char16_t" << std::endl;
     test_for_char<char16_t>();
     #endif
-    #if defined BOOST_HAS_CHAR32_T && !defined(BOOST_NO_CHAR32_T_CODECVT)
+    #if !defined(BOOST_NO_CXX11_CHAR32_T) && !defined(BOOST_NO_CHAR32_T_CODECVT)
     std::cout << "  char32_t" << std::endl;
     test_for_char<char32_t>();
     #endif


### PR DESCRIPTION
In Boost 1.51 the macros `BOOST_NO_CHAR16_T` and `BOOST_NO_CHAR32_T` were deprecated, and the replacements `BOOST_NO_CXX11_CHAR16_T` and `BOOST_NO_CXX11_CHAR32_T` wee introduced.  

I would like to remove the deprecated macros, so this change uses them instead of the old names.

No functionality change.