### PR TITLE
Fix compilation error on FreeBSD 10.2.

### DIFF
--- a/src/posix/collate.cpp
+++ b/src/posix/collate.cpp
@@ -6,6 +6,9 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 #define BOOST_LOCALE_SOURCE
+#if defined(__FreeBSD__)
+#include <xlocale.h>
+#endif
 #include <locale>
 #include <locale.h>
 #include <string.h>

--- a/src/posix/converter.cpp
+++ b/src/posix/converter.cpp
@@ -7,6 +7,9 @@
 //
 #define BOOST_LOCALE_SOURCE
 
+#if defined(__FreeBSD__)
+#include <xlocale.h>
+#endif
 #include <locale>
 #include <stdexcept>
 #include <boost/locale/generator.hpp>

--- a/src/posix/numeric.cpp
+++ b/src/posix/numeric.cpp
@@ -6,6 +6,9 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 #define BOOST_LOCALE_SOURCE
+#if defined(__FreeBSD__)
+#include <xlocale.h>
+#endif
 #include <locale>
 #include <string>
 #include <ios>

--- a/src/posix/posix_backend.cpp
+++ b/src/posix/posix_backend.cpp
@@ -6,6 +6,9 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 #define BOOST_LOCALE_SOURCE
+#if defined(__FreeBSD__)
+#include <xlocale.h>
+#endif
 #include <boost/locale/localization_backend.hpp>
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/locale/info.hpp>


### PR DESCRIPTION
Since r233600[1], BSD libc requires that include xlocale.h in the correct
order[2].

1. http://lists.freebsd.org/pipermail/svn-src-head/2012-March/035792.html
2. https://www.freebsd.org/cgi/man.cgi?query=xlocale&apropos=0&sektion=3&manpath=FreeBSD+10.2-RELEASE&arch=default&format=html