### PR TITLE
New build-option ICU_LIBPATH to manually provide path to libs of ICU.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -60,8 +60,9 @@ explicit has_xlocale ;
 #end xlocale
 
 
-ICU_PATH =  [ modules.peek : ICU_PATH ] ;
-ICU_LINK =  [ modules.peek : ICU_LINK ] ;
+ICU_PATH    =  [ modules.peek : ICU_PATH ] ;
+ICU_LIBPATH =  [ modules.peek : ICU_LIBPATH ] ;
+ICU_LINK    =  [ modules.peek : ICU_LINK ] ;
 
 if $(ICU_LINK)
 {
@@ -71,25 +72,25 @@ if $(ICU_LINK)
 else
 {
     searched-lib icuuc : :  <name>icuuc
-                            <search>$(ICU_PATH)/lib 
+                            <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <link>shared 
                             <runtime-link>shared ;
 
     searched-lib icuuc : :  <toolset>msvc
                             <variant>debug
                             <name>icuucd
-                            <search>$(ICU_PATH)/lib
+                            <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <link>shared
                             <runtime-link>shared ;
 
     searched-lib icuuc : :  <name>this_is_an_invalid_library_name ;
 
-    searched-lib icudt : :  <search>$(ICU_PATH)/lib
+    searched-lib icudt : :  <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <name>icudata
                             <link>shared
                             <runtime-link>shared ;
 
-    searched-lib icudt : :  <search>$(ICU_PATH)/lib
+    searched-lib icudt : :  <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <name>icudt
                             <toolset>msvc
                             <link>shared
@@ -97,7 +98,7 @@ else
 
     searched-lib icudt : :  <name>this_is_an_invalid_library_name ;
 
-    searched-lib icuin : :  <search>$(ICU_PATH)/lib
+    searched-lib icuin : :  <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <name>icui18n
                             <link>shared
                             <runtime-link>shared ;
@@ -105,14 +106,14 @@ else
     searched-lib icuin : :  <toolset>msvc
                             <variant>debug
                             <name>icuind
-                            <search>$(ICU_PATH)/lib
+                            <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <link>shared
                             <runtime-link>shared ;
 
     searched-lib icuin : :  <toolset>msvc
                             <variant>release
                             <name>icuin
-                            <search>$(ICU_PATH)/lib
+                            <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib
                             <link>shared
                             <runtime-link>shared ;
 
@@ -130,25 +131,25 @@ else
 
 
     searched-lib icuuc_64 : :   <name>icuuc
-                                <search>$(ICU_PATH)/lib64 
+                                <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <link>shared 
                                 <runtime-link>shared ;
 
     searched-lib icuuc_64 : :   <toolset>msvc
                                 <variant>debug
                                 <name>icuucd
-                                <search>$(ICU_PATH)/lib64
+                                <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <link>shared
                                 <runtime-link>shared ;
 
     searched-lib icuuc_64 : :   <name>this_is_an_invalid_library_name ;
 
-    searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
+    searched-lib icudt_64 : :   <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <name>icudata
                                 <link>shared
                                 <runtime-link>shared ;
 
-    searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
+    searched-lib icudt_64 : :   <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <name>icudt
                                 <toolset>msvc
                                 <link>shared
@@ -156,7 +157,7 @@ else
 
     searched-lib icudt_64 : :   <name>this_is_an_invalid_library_name ;
 
-    searched-lib icuin_64 : :   <search>$(ICU_PATH)/lib64
+    searched-lib icuin_64 : :   <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <name>icui18n
                                 <link>shared
                                 <runtime-link>shared ;
@@ -164,14 +165,14 @@ else
     searched-lib icuin_64 : :   <toolset>msvc
                                 <variant>debug
                                 <name>icuind
-                                <search>$(ICU_PATH)/lib64
+                                <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <link>shared
                                 <runtime-link>shared ;
 
     searched-lib icuin_64 : :   <toolset>msvc
                                 <variant>release
                                 <name>icuin
-                                <search>$(ICU_PATH)/lib64
+                                <search>$(ICU_LIBPATH)&&$(ICU_PATH)/lib64
                                 <link>shared
                                 <runtime-link>shared ;
 

--- a/doc/building_boost_locale.txt
+++ b/doc/building_boost_locale.txt
@@ -90,6 +90,9 @@ For example:
 when using Microsoft Visual Studio  so Boost.Build will link correctly debug and release
 versions of boost_locale library.
 
+\note If ICU libraries are located at some other (sub)directory you can provide this
+location by additionally using \c -sICU_LIBPATH option.
+
 \section bb_build_opts Build Options
 
 Boost.Locale supports following options with values \c off or \c on
@@ -106,6 +109,7 @@ Boost.Locale supports following options with values \c off or \c on
 Also Boost.Locale supports following options
 
 - \c -sICU_PATH=/path/to/location/of/icu - the location of custom ICU library
+- \c -sICU_LIBPATH=/path/to/location/of/icu/libraries - the location of custom ICU library libs
 - \c -sICONV_PATH=/path/to/location/of/iconv - the location of custom iconv library
 
 

--- a/doc/html/building_boost_locale.html
+++ b/doc/html/building_boost_locale.html
@@ -121,6 +121,7 @@ Building Process</h2>
  then you need to provide an option <code>-sICU_PATH=c:\icu46</code> <pre class="fragment">    .\bjam --with-locale -sICU_PATH=c:\icu46  stage</pre></li>
 </ul>
 <dl class="section note"><dt>Note</dt><dd>Don't forget to put both debug and release versions of ICU libraries in this path when using Microsoft Visual Studio so Boost.Build will link correctly debug and release versions of boost_locale library.</dd></dl>
+<dl class="section note"><dt>Note</dt><dd>If ICU libraries are located at some other (sub)directory you can provide this location by additionally using <code>-sICU_LIBPATH</code> option.</dd></dl>
 <h1><a class="anchor" id="bb_build_opts"></a>
 Build Options</h1>
 <p>Boost.Locale supports following options with values <code>off</code> or <code>on</code> </p>
@@ -134,6 +135,7 @@ Build Options</h1>
 <p>Also Boost.Locale supports following options</p>
 <ul>
 <li><code>-sICU_PATH=/path/to/location/of/icu</code> - the location of custom ICU library</li>
+<li><code>-sICU_LIBPATH=/path/to/location/of/icu/libraries</code> - the location of custom ICU library libs</li>
 <li><code>-sICONV_PATH=/path/to/location/of/iconv</code> - the location of custom iconv library</li>
 </ul>
 <p>For example:</p>


### PR DESCRIPTION
When using _Boost.Build_ to build _**Boost.Locale**_ one can build and link with the external library **ICU** and provide the path to its (root-)directory using the option `ICU_PATH`. The ICU library files are searched in a sub-directory `lib` (or in some situations in `lib64`) of _`<ICU_PATH>`_.
However, that only works if the library files are directly located in `<ICU_PATH>/lib` (or `<ICU_PATH>/lib64`).

If they are installed in a custom location,
* either a totally different location,
* another named sub-directory (e.g. `<ICU_PATH>/libraries` ) or
* even in a sub-directory of the expected sub-directory (e.g. `<ICU_PATH>/lib/x86_64-linux-gnu`),

this does no longer work and the ICU libs cannot be found.

Therefore, this pull-request provides an additional _Boost.Build_ option `ICU_LIBPATH` with which one can provide the path to the directory where the **ICU** libraries are located.