### PR TITLE
Fix hidden visibility symbols for mac/clang

### DIFF
--- a/include/boost/locale/definitions.hpp
+++ b/include/boost/locale/definitions.hpp
@@ -15,15 +15,13 @@
 # define BOOST_SYMBOL_VISIBLE
 #endif
 
-#ifdef BOOST_HAS_DECLSPEC 
-#   if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_LOCALE_DYN_LINK)
-#       ifdef BOOST_LOCALE_SOURCE
-#           define BOOST_LOCALE_DECL BOOST_SYMBOL_EXPORT
-#       else
-#           define BOOST_LOCALE_DECL BOOST_SYMBOL_IMPORT
-#       endif  // BOOST_LOCALE_SOURCE
-#   endif  // DYN_LINK
-#endif  // BOOST_HAS_DECLSPEC
+#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_LOCALE_DYN_LINK)
+#   ifdef BOOST_LOCALE_SOURCE
+#       define BOOST_LOCALE_DECL BOOST_SYMBOL_EXPORT
+#   else
+#       define BOOST_LOCALE_DECL BOOST_SYMBOL_IMPORT
+#   endif  // BOOST_LOCALE_SOURCE
+#endif  // DYN_LINK
 
 #ifndef BOOST_LOCALE_DECL
 #   define BOOST_LOCALE_DECL


### PR DESCRIPTION
There is a requirement for BOOST_HAS_DECLSPEC in order to reach the symbol visibility settings. This is only set for Win/gcc builds, and can't be executed for Mac OS/Clang builds. Removing that outside requirement, which was already done for the config files in the other Boost libraries.