### PR TITLE
Fix compilation against Boost Thread v4

### DIFF
--- a/src/shared/date_time.cpp
+++ b/src/shared/date_time.cpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_SOURCE
 #include <boost/locale/date_time.hpp>
 #include <boost/locale/formatting.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <math.h>
 

--- a/src/shared/generator.cpp
+++ b/src/shared/generator.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <algorithm>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace boost {

--- a/src/shared/localization_backend.cpp
+++ b/src/shared/localization_backend.cpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_SOURCE
 #include <boost/locale/localization_backend.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <vector>
 


### PR DESCRIPTION
The modified files use boost::unique_lock and don't include the
proper header. In Boost Thread <4, it would be transitively included
from <boost/thread/mutex.hpp> but no longer with v4 by default.