### PR TITLE
Replace /bin/bash with /bin/sh

### DIFF
--- a/doc/gendoc.sh
+++ b/doc/gendoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
 #

--- a/tools/cross-compile-gettext.sh
+++ b/tools/cross-compile-gettext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
 #


### PR DESCRIPTION
/bin/bash is a Linuxism, but /bin/sh is available everywhere