### PR TITLE
Use unique_ptr instead of auto_ptr

### DIFF
--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -121,7 +121,7 @@ namespace boost {
 
                 std::ios_base &ios_;
                 struct data;
-                std::auto_ptr<data> d;
+                std::unique_ptr<data> d;
             };
 
         }

--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -220,7 +220,7 @@ namespace boost {
             void operator=(generator const &);
 
             struct data;
-            std::auto_ptr<data> d;
+            std::unique_ptr<data> d;
         };
 
     }

--- a/include/boost/locale/hold_ptr.hpp
+++ b/include/boost/locale/hold_ptr.hpp
@@ -11,7 +11,7 @@
 namespace boost { 
 namespace locale {
     ///
-    /// \brief a smart pointer similar to std::auto_ptr but it is non-copyable and the
+    /// \brief a smart pointer similar to std::unique_ptr but it is non-copyable and the
     /// underlying object has the same constness as the pointer itself (unlike an ordinary pointer).
     ///
     template<typename T>

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -104,14 +104,14 @@ namespace boost {
             ///
             /// Create new localization backend according to current settings.
             ///
-            std::auto_ptr<localization_backend> get() const;
+            std::unique_ptr<localization_backend> get() const;
 
             ///
             /// Add new backend to the manager, each backend should be uniquely defined by its name.
             ///
             /// This library provides: "icu", "posix", "winapi" and "std" backends.
             ///
-            void add_backend(std::string const &name,std::auto_ptr<localization_backend> backend);
+            void add_backend(std::string const &name,std::unique_ptr<localization_backend> backend);
 
             ///
             /// Clear backend
@@ -143,7 +143,7 @@ namespace boost {
             static localization_backend_manager global();
         private:
             class impl;
-            std::auto_ptr<impl> pimpl_;
+            std::unique_ptr<impl> pimpl_;
         };
 
     } // locale

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -176,15 +176,15 @@ namespace util {
     /// This function creates a \a base_converter that can be used for conversion between UTF-8 and
     /// unicode code points
     ///
-    BOOST_LOCALE_DECL std::auto_ptr<base_converter> create_utf8_converter();
+    BOOST_LOCALE_DECL std::unique_ptr<base_converter> create_utf8_converter();
     ///
     /// This function creates a \a base_converter that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
     /// 
     /// If \a encoding is not supported, empty pointer is returned. You should check if
-    /// std::auto_ptr<base_converter>::get() != 0
+    /// std::unique_ptr<base_converter>::get() != 0
     ///
-    BOOST_LOCALE_DECL std::auto_ptr<base_converter> create_simple_converter(std::string const &encoding);
+    BOOST_LOCALE_DECL std::unique_ptr<base_converter> create_simple_converter(std::string const &encoding);
 
 
     ///
@@ -199,7 +199,7 @@ namespace util {
     /// of wide encoding type
     ///
     BOOST_LOCALE_DECL
-    std::locale create_codecvt(std::locale const &in,std::auto_ptr<base_converter> cvt,character_facet_type type);
+    std::locale create_codecvt(std::locale const &in,std::unique_ptr<base_converter> cvt,character_facet_type type);
 
     /// 
     /// Install utf8 codecvt to UTF-16 or UTF-32 into locale \a in and return


### PR DESCRIPTION
I tried compiling gnucash-2.6.99 with gcc-5.4.0. This fails because the compiler complains about auto_ptr being deprecated. Replacing auto_ptr with unique_ptr makes the compilation of gnucash work.