### PR TITLE
fixed compilation error ocurring with clang 4.0.1 and libc++

### DIFF
--- a/src/icu/boundary.cpp
+++ b/src/icu/boundary.cpp
@@ -135,11 +135,7 @@ index_type do_map(boundary_type t,CharType const *begin,CharType const *end,icu:
 {
     index_type indx;
 
-# if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-    std::auto_ptr<icu::BreakIterator> bi(std::move(get_iterator(t,loc)));
-# else
-    std::auto_ptr<icu::BreakIterator> bi(get_iterator(t,loc));
-# endif
+    std::auto_ptr<icu::BreakIterator> bi = get_iterator(t,loc);
 
 #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 306
     UErrorCode err=U_ZERO_ERROR;

--- a/src/icu/boundary.cpp
+++ b/src/icu/boundary.cpp
@@ -134,8 +134,13 @@ template<typename CharType>
 index_type do_map(boundary_type t,CharType const *begin,CharType const *end,icu::Locale const &loc,std::string const &encoding)
 {
     index_type indx;
+
+# if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    std::auto_ptr<icu::BreakIterator> bi(std::move(get_iterator(t,loc)));
+# else
     std::auto_ptr<icu::BreakIterator> bi(get_iterator(t,loc));
-   
+# endif
+
 #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 306
     UErrorCode err=U_ZERO_ERROR;
     if(sizeof(CharType) == 2 || (sizeof(CharType)==1 && encoding=="UTF-8"))


### PR DESCRIPTION
I'm building the boost library myself and am now newly using boost.locale.
I'm using clang 4.0.1 with the llvm C++ standard library libc++ and using the -std=c++1z compiler flag. With that combination the following error occurs:
`libs/locale/src/icu/boundary.cpp:137:39: error: no viable conversion from 'auto_ptr<...>' to 'auto_ptr<...>'`

Complete error message:
[error.txt](https://github.com/boostorg/locale/files/1197507/error.txt)
