### PR TITLE
Fix order of environment variables when getting system default locale

### DIFF
--- a/doc/locale_gen.txt
+++ b/doc/locale_gen.txt
@@ -49,8 +49,8 @@ Of course we can also specify the locale manually
 -   Even if your application uses wide strings everywhere, you should specify the
     8-bit encoding to use for 8-bit stream IO operations like \c cout or \c fstream.
     \n
--   The default locale is defined by the environment variables \c LC_CTYPE , \c LC_ALL , and \c LANG
-    in that order (i.e. \c LC_CTYPE first and \c LANG last). On Windows, the library
+-   The default locale is defined by the environment variables \c LC_ALL , \c LC_CTYPE , and \c LANG
+    in that order (i.e. \c LC_ALL first and \c LANG last). On Windows, the library
     also queries the \c LOCALE_USER_DEFAULT option in the Win32 API when these variables
     are not set.
 

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -26,7 +26,7 @@ namespace util {
     ///
     /// \brief Return default system locale name in POSIX format.
     ///
-    /// This function tries to detect the locale using, LC_CTYPE, LC_ALL and LANG environment
+    /// This function tries to detect the locale using, LC_ALL, LC_CTYPE and LANG environment
     /// variables in this order and if all of them unset, in POSIX platforms it returns "C"
     /// 
     /// On Windows additionally to check the above environment variables, this function

--- a/src/util/default_locale.cpp
+++ b/src/util/default_locale.cpp
@@ -30,9 +30,9 @@ namespace boost {
             {
                 char const *lang = 0;
                 if(!lang || !*lang)
-                    lang = getenv("LC_CTYPE");
-                if(!lang || !*lang)
                     lang = getenv("LC_ALL");
+                if(!lang || !*lang)
+                    lang = getenv("LC_CTYPE");
                 if(!lang || !*lang)
                     lang = getenv("LANG");
                 #ifndef BOOST_LOCALE_USE_WIN32_API


### PR DESCRIPTION
Fixes bug documented here https://svn.boost.org/trac10/ticket/13289