### PR TITLE
Fix compilation with hidden visibility by default

### DIFF
--- a/include/boost/locale/definitions.hpp
+++ b/include/boost/locale/definitions.hpp
@@ -15,15 +15,13 @@
 # define BOOST_SYMBOL_VISIBLE
 #endif
 
-#ifdef BOOST_HAS_DECLSPEC 
-#   if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_LOCALE_DYN_LINK)
-#       ifdef BOOST_LOCALE_SOURCE
-#           define BOOST_LOCALE_DECL BOOST_SYMBOL_EXPORT
-#       else
-#           define BOOST_LOCALE_DECL BOOST_SYMBOL_IMPORT
-#       endif  // BOOST_LOCALE_SOURCE
-#   endif  // DYN_LINK
-#endif  // BOOST_HAS_DECLSPEC
+#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_LOCALE_DYN_LINK)
+#    ifdef BOOST_LOCALE_SOURCE
+#        define BOOST_LOCALE_DECL BOOST_SYMBOL_EXPORT
+#    else
+#        define BOOST_LOCALE_DECL BOOST_SYMBOL_IMPORT
+#    endif  // BOOST_LOCALE_SOURCE
+#endif  // DYN_LINK
 
 #ifndef BOOST_LOCALE_DECL
 #   define BOOST_LOCALE_DECL


### PR DESCRIPTION
The commit removes the useless check for __declspec presence so that symbol
visibility attributes are applied on platforms other than Windows. This fixes
library compilation when hidden visibility is in effect.

Related to https://github.com/boostorg/boost/pull/190.
