### PR TITLE
fix build error on windows with boost::mutex and unique_lock

### DIFF
--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -20,6 +20,13 @@
 #include <memory>
 #include <boost/locale/formatting.hpp>
 
+// glibc < 2.3.4 declares those as macros if compiled with optimization turned on
+#ifdef gettext
+#  undef gettext
+#  undef ngettext
+#  undef dgettext
+#  undef dngettext
+#endif
 
 namespace boost {
     namespace locale {

--- a/src/win32/lcid.cpp
+++ b/src/win32/lcid.cpp
@@ -20,6 +20,7 @@
 #include <windows.h>
 
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/locks.hpp>
 
 namespace boost {
 namespace locale {


### PR DESCRIPTION
when compiling on windows (vs2017/vs2015), there are errors:
locale\src\win32\lcid.cpp(89): error C2039: “unique_lock”: not a member of boost
locale\src\win32\lcid.cpp(89): error C2065: “unique_lock”: undefined
locale\src\win32\lcid.cpp(89): error C2275: “boost::mutex”: illegal
locale\src\win32\lcid.cpp(89): error C3861: “lock”: cannot find

errors are fixed by adding the proper header.