### PR TITLE
Remove linking with Boost.System

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -382,9 +382,6 @@ rule configure-full ( properties * : flags-only )
         result += <source>util/gregorian.cpp ;
     }
     
-    result += <library>../../system/build//boost_system ;
-
-
     if "$(flags-only)" = "flags" 
     {
         return $(flags-result) ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,6 +1,6 @@
 # copyright John Maddock 2003, Artyom Beilis 2010
-# Distributed under the Boost Software License, Version 1.0. 
-# (See accompanying file LICENSE_1_0.txt or copy at 
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt.
 
 
@@ -32,11 +32,11 @@ explicit has_iconv ;
 
 ICONV_PATH = [ modules.peek : ICONV_PATH ] ;
 
-lib iconv 
-  : 
+lib iconv
+  :
   : <search>$(ICONV_PATH)/lib <link>shared <runtime-link>shared
   :
-  : <include>$(ICONV_PATH)/include 
+  : <include>$(ICONV_PATH)/include
   ;
 
 explicit iconv ;
@@ -45,8 +45,8 @@ obj has_iconv_libc_ext : ../build/has_iconv.cpp iconv ;
 exe has_external_iconv : has_iconv_libc_ext iconv ;
 explicit has_external_iconv ;
 
-exe accepts_shared_option   : ../build/option.cpp 
-                            :   <cxxflags>-shared-libstdc++ 
+exe accepts_shared_option   : ../build/option.cpp
+                            :   <cxxflags>-shared-libstdc++
                                 <cxxflags>-shared-libgcc
                                 <linkflags>-shared-libstdc++
                                 <linkflags>-shared-libgcc
@@ -71,8 +71,8 @@ if $(ICU_LINK)
 else
 {
     searched-lib icuuc : :  <name>icuuc
-                            <search>$(ICU_PATH)/lib 
-                            <link>shared 
+                            <search>$(ICU_PATH)/lib
+                            <link>shared
                             <runtime-link>shared ;
 
     searched-lib icuuc : :  <toolset>msvc
@@ -120,9 +120,9 @@ else
 
     explicit icuuc icudt icuin ;
 
-    ICU_OPTS =   <include>$(ICU_PATH)/include 
-      <library>icuuc/<link>shared/<runtime-link>shared 
-      <library>icudt/<link>shared/<runtime-link>shared 
+    ICU_OPTS =   <include>$(ICU_PATH)/include
+      <library>icuuc/<link>shared/<runtime-link>shared
+      <library>icudt/<link>shared/<runtime-link>shared
       <library>icuin/<link>shared/<runtime-link>shared
       <dll-path>$(ICU_PATH)/bin
         <runtime-link>shared ;
@@ -130,8 +130,8 @@ else
 
 
     searched-lib icuuc_64 : :   <name>icuuc
-                                <search>$(ICU_PATH)/lib64 
-                                <link>shared 
+                                <search>$(ICU_PATH)/lib64
+                                <link>shared
                                 <runtime-link>shared ;
 
     searched-lib icuuc_64 : :   <toolset>msvc
@@ -179,14 +179,14 @@ else
 
     explicit icuuc_64 icudt_64 icuin_64 ;
 
-    ICU64_OPTS =   <include>$(ICU_PATH)/include 
-      <library>icuuc_64/<link>shared/<runtime-link>shared 
-      <library>icudt_64/<link>shared/<runtime-link>shared 
+    ICU64_OPTS =   <include>$(ICU_PATH)/include
+      <library>icuuc_64/<link>shared/<runtime-link>shared
+      <library>icudt_64/<link>shared/<runtime-link>shared
       <library>icuin_64/<link>shared/<runtime-link>shared
       <dll-path>$(ICU_PATH)/bin64
         <runtime-link>shared ;
- 
-    
+
+
 }
 
 obj has_icu_obj     : ../build/has_icu_test.cpp : $(ICU_OPTS)   ;
@@ -206,11 +206,11 @@ rule configure-full ( properties * : flags-only )
 
     local result ;
     local flags-result ;
-    
+
     local found-iconv ;
-    
+
     if <boost.locale.iconv>on in $(properties)
-      || ! <boost.locale.iconv> in $(properties:G) 
+      || ! <boost.locale.iconv> in $(properties:G)
         && ! <target-os>solaris in $(properties)
     {
         # See if iconv is bundled with standard library.
@@ -218,7 +218,7 @@ rule configure-full ( properties * : flags-only )
         {
             found-iconv = true ;
         }
-        else 
+        else
         {
             if [ configure.builds has_external_iconv : $(properties) : "iconv (separate)" ]
             {
@@ -226,8 +226,8 @@ rule configure-full ( properties * : flags-only )
                 result += <library>iconv ;
             }
         }
-    }        
-    if $(found-iconv) 
+    }
+    if $(found-iconv)
     {
         flags-result += <define>BOOST_LOCALE_WITH_ICONV=1 ;
     }
@@ -249,7 +249,7 @@ rule configure-full ( properties * : flags-only )
 
         if $(found-icu)
         {
-            ICU_SOURCES = 
+            ICU_SOURCES =
                 boundary
                 codecvt
                 collator
@@ -260,20 +260,20 @@ rule configure-full ( properties * : flags-only )
                 numeric
                 time_zone
                 ;
-            
-            result += <source>icu/$(ICU_SOURCES).cpp 
-                      <library>../../thread/build//boost_thread 
+
+            result += <source>icu/$(ICU_SOURCES).cpp
+                      <library>../../thread/build//boost_thread
                       ;
         }
 
     }
-        
-    if ! $(found-iconv) && ! $(found-icu) && ! <target-os>windows in $(properties) && ! <target-os>cygwin in $(properties) 
+
+    if ! $(found-iconv) && ! $(found-icu) && ! <target-os>windows in $(properties) && ! <target-os>cygwin in $(properties)
     {
         ECHO "- Boost.Locale needs either iconv or ICU library to be built." ;
         result += <build>no ;
     }
-    
+
     if ! <boost.locale.std> in $(properties:G)
     {
         if <toolset>sun in $(properties)
@@ -283,9 +283,9 @@ rule configure-full ( properties * : flags-only )
         else
         {
             properties += <boost.locale.std>on ;
-        }                
+        }
     }
-    
+
     if <boost.locale.std>off in $(properties)
     {
         flags-result += <define>BOOST_LOCALE_NO_STD_BACKEND=1 ;
@@ -301,38 +301,38 @@ rule configure-full ( properties * : flags-only )
           ;
         result += <source>std/$(STD_SOURCES).cpp ;
     }
-    
+
     if ! <boost.locale.winapi> in $(properties:G)
     {
-        if <target-os>windows in $(properties) 
+        if <target-os>windows in $(properties)
           || <target-os>cygwin in $(properties)
         {
             properties += <boost.locale.winapi>on ;
-        }      
+        }
         else
         {
             properties += <boost.locale.winapi>off ;
-        }                
+        }
     }
-    if  <target-os>windows in $(properties) 
-        && <toolset>gcc in $(properties) 
+    if  <target-os>windows in $(properties)
+        && <toolset>gcc in $(properties)
         && <link>shared in $(properties)
         && [ configure.builds accepts_shared_option : $(properties) : "g++ -shared-* supported" ]
     {
-        flags-result += <cxxflags>-shared-libstdc++ 
+        flags-result += <cxxflags>-shared-libstdc++
                         <cxxflags>-shared-libgcc
                         <linkflags>-shared-libstdc++
                         <linkflags>-shared-libgcc
                         ;
     }
-    
+
     if <boost.locale.winapi>off in $(properties)
     {
         flags-result += <define>BOOST_LOCALE_NO_WINAPI_BACKEND=1 ;
     }
     else
     {
-        WINAPI_SOURCES = 
+        WINAPI_SOURCES =
             collate
             converter
             numeric
@@ -340,34 +340,34 @@ rule configure-full ( properties * : flags-only )
           ;
         result += <source>win32/$(WINAPI_SOURCES).cpp ;
     }
-    
+
     if ( ! <boost.locale.winapi>off in $(properties) || ! <boost.locale.std>off in $(properties) )
        && ( <target-os>windows in $(properties) || <target-os>cygwin in $(properties) )
     {
         result += <source>win32/lcid.cpp ;
     }
- 
+
     if ! <boost.locale.posix> in $(properties:G)
     {
-        if <target-os>linux in $(properties) 
-            || <target-os>darwin in $(properties) 
+        if <target-os>linux in $(properties)
+            || <target-os>darwin in $(properties)
             || ( <target-os>freebsd in $(properties) && [ configure.builds has_xlocale : $(properties) : "xlocale supported" ] )
         {
             properties += <boost.locale.posix>on ;
         }
         else
         {
-            properties += <boost.locale.posix>off ;            
-        }        
+            properties += <boost.locale.posix>off ;
+        }
     }
-    
+
     if <boost.locale.posix>off in $(properties)
     {
-        flags-result += <define>BOOST_LOCALE_NO_POSIX_BACKEND=1 ;        
+        flags-result += <define>BOOST_LOCALE_NO_POSIX_BACKEND=1 ;
     }
     else
     {
-        POSIX_SOURCES = 
+        POSIX_SOURCES =
           collate
           converter
           numeric
@@ -381,12 +381,13 @@ rule configure-full ( properties * : flags-only )
     {
         result += <source>util/gregorian.cpp ;
     }
-    
-    if "$(flags-only)" = "flags" 
+
+    if "$(flags-only)" = "flags"
     {
         return $(flags-result) ;
     }
-    else {
+    else
+    {
         result += $(flags-result) ;
         return $(result) ;
     }
@@ -396,7 +397,6 @@ rule configure ( properties * )
 {
     local result = [ configure-full $(properties) : "all" ] ;
     return $(result) ;
-    
 }
 
 rule configure-flags ( properties * )
@@ -404,15 +404,14 @@ rule configure-flags ( properties * )
     local result ;
     result = [ configure-full $(properties) : "flags" ] ;
     return $(result) ;
-    
 }
 
 
 alias build_options : : : : <conditional>@configure ;
 alias build_flags : : : : <conditional>@configure-flags ;
 
-lib boost_locale 
-    : 
+lib boost_locale
+    :
         encoding/codepage.cpp
         shared/date_time.cpp
         shared/format.cpp
@@ -425,7 +424,7 @@ lib boost_locale
         util/codecvt_converter.cpp
         util/default_locale.cpp
         util/info.cpp
-        util/locale_data.cpp  
+        util/locale_data.cpp
     :
       # Don't link explicitly, not required
       <define>BOOST_THREAD_NO_LIB=1


### PR DESCRIPTION
Since Boost.System is header-only now, no need to link with the library.

Also, trim trailing spaces in the jamfile.
