### PR TITLE
implement moveability for date_time

### DIFF
--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -601,6 +601,10 @@ namespace boost {
             ///
             date_time(date_time const &other);
             ///
+            /// move date_time
+            ///
+            date_time(date_time &&other);
+            ///
             /// copy date_time and change some fields according to the \a set
             ///
             date_time(date_time const &other,date_time_period_set const &set);
@@ -608,6 +612,10 @@ namespace boost {
             /// assign the date_time
             ///
             date_time const &operator=(date_time const &other);
+            ///
+            /// move assign the date_time
+            ///
+            date_time const &operator=(date_time &&other);
             ~date_time();
 
             ///

--- a/src/shared/date_time.cpp
+++ b/src/shared/date_time.cpp
@@ -148,6 +148,11 @@ date_time::date_time(date_time const &other)
     impl_.reset(other.impl_->clone());
 }
 
+date_time::date_time(date_time &&other)
+{
+    impl_.reset(other.impl_.release());
+}
+
 date_time::date_time(date_time const &other,date_time_period_set const &s)
 {
     impl_.reset(other.impl_->clone());
@@ -162,6 +167,14 @@ date_time const &date_time::operator = (date_time const &other)
     if(this != &other) {
         date_time tmp(other);
         swap(tmp);
+    }
+    return *this;
+}
+
+date_time const &date_time::operator = (date_time &&other)
+{
+    if(this != &other) {
+        impl_.reset(other.impl_.release());
     }
     return *this;
 }


### PR DESCRIPTION
We use boost::locale with the icu backend for message processing in our software. Enabling move semantics for the date_time type results in a speed up of about 2x in our codebase.