### PR TITLE
Missing includes

### DIFF
--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -16,12 +16,10 @@
 #include <string>
 #include <locale>
 #include <memory>
+#include <boost/shared_ptr.hpp>
 #include <boost/locale/hold_ptr.hpp>
 
 namespace boost {
-
-    template<typename Type>
-    class shared_ptr;
 
     ///
     /// \brief This is the main namespace that encloses all localization classes 

--- a/src/encoding/codepage.cpp
+++ b/src/encoding/codepage.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/hold_ptr.hpp>
+#include "conv.hpp"
 
 #include <string>
 #include <cstring>

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -29,6 +29,7 @@
 #include <map>
 #endif
 
+#include <algorithm>
 #include <iostream>
 
 


### PR DESCRIPTION
`#include <algorithm>` for `std::find()` (line 521 without patch, 522 with patch).

I'm guessing it was included in `locale/boundary/index.hpp` which i don't include during build, then included by `locale/boundary.hpp` and then included by something else. Or maybe it was included in `boost/function.hpp`.

When compiled without `locale/boundary/index.hpp`, `boost/function.hpp`, `boost/shared_ptr.hpp` and couple other headers, it shows the following error (GCC 8):

```gcc
boost-locale/src/shared/message.cpp: In instantiation of ‘const char_type* boost::locale::gnu_gettext::mo_message<CharType>::get(int, const char_type*, const char_type*, int) const [with CharType = wchar_t; boost::locale::gnu_gettext::mo_message<CharType>::char_type = wchar_t]’:
boost-locale/src/shared/message.cpp:508:42:   required from here
boost-locale/src/shared/message.cpp:521:36: error: no matching function for call to ‘find(const wchar_t*&, const wchar_t*&, int)’
                         p=std::find(p,ptr.second,0);
```