### PR TITLE
Add support for C++11 UTF string literals

### DIFF
--- a/include/boost/locale/utf.hpp
+++ b/include/boost/locale/utf.hpp
@@ -9,6 +9,7 @@
 #define BOOST_LOCALE_UTF_HPP_INCLUDED
 
 #include <boost/cstdint.hpp>
+#include <boost/config.hpp>
 
 namespace boost {
 namespace locale {
@@ -27,6 +28,20 @@ namespace utf {
     #   define BOOST_LOCALE_UNLIKELY(x) (x)
     #endif
     /// \endcond
+
+    ///
+    /// \brief Format of the UTF encoding used by utf_traits class
+    ///
+    /// Can be used like a scoped enum (e.g. format::UTF8) but is an int for
+    /// backwards compatibility. The values correspond to the size of 1 unit.
+    ///
+    struct format {
+        enum {
+            UTF8 = 1,
+            UTF16 = 2,
+            UTF32 = 4
+        };
+    };
 
     ///
     /// \brief The integral type that can hold a Unicode code point
@@ -55,11 +70,24 @@ namespace utf {
         return true;
     }
 
+    ///
+    /// \brief Trait to return the encoding of a char type
+    ///
+    template<typename CharType>
+    struct encoding {
+        ///
+        /// \brief Encoding of CharType - Member of \ref format enum
+        ///
+        /// The default is the size of the type which is usually OK
+        /// due to the definition of \ref format values.
+        BOOST_STATIC_CONSTEXPR int value = sizeof(CharType);
+    };
+
     #ifdef BOOST_LOCALE_DOXYGEN
     ///
     /// \brief UTF Traits class - functions to convert UTF sequences to and from Unicode code points
     ///
-    template<typename CharType,int size=sizeof(CharType)>
+    template<typename CharType, int Encoding = encoding<CharType>::value>
     struct utf_traits {
         ///
         /// The type of the character
@@ -136,11 +164,11 @@ namespace utf {
     
     #else
 
-    template<typename CharType,int size=sizeof(CharType)>
+    template<typename CharType, int Encoding = encoding<CharType>::value>
     struct utf_traits;
 
     template<typename CharType>
-    struct utf_traits<CharType,1> {
+    struct utf_traits<CharType, format::UTF8> {
 
         typedef CharType char_type;
         
@@ -309,7 +337,7 @@ namespace utf {
     }; // utf8
 
     template<typename CharType>
-    struct utf_traits<CharType,2> {
+    struct utf_traits<CharType, format::UTF16> {
         typedef CharType char_type;
 
         // See RFC 2781
@@ -399,7 +427,7 @@ namespace utf {
 
         
     template<typename CharType>
-    struct utf_traits<CharType,4> {
+    struct utf_traits<CharType, format::UTF32> {
         typedef CharType char_type;
         static int trail_length(char_type c)
         {
@@ -448,6 +476,18 @@ namespace utf {
 
     #endif
 
+#ifndef BOOST_NO_CXX11_CHAR16_T
+    template<>
+    struct encoding<char16_t>{
+        BOOST_STATIC_CONSTEXPR int value = format::UTF16;
+    };
+#endif
+#ifndef BOOST_NO_CXX11_CHAR32_T
+    template<>
+    struct encoding<char32_t>{
+        BOOST_STATIC_CONSTEXPR int value = format::UTF32;
+    };
+#endif
 
 } // utf
 } // locale

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -65,6 +65,25 @@ boost::uint16_t const *u16_seq(boost::uint16_t a,boost::uint16_t b)
     return buf;
 }
 
+#ifndef BOOST_NO_CXX11_CHAR16_T
+char16_t const *c16_seq(boost::uint16_t a)
+{
+    static char16_t buf[2];
+    buf[0]=static_cast<char16_t>(a);
+    buf[1]=0;
+    return buf;
+}
+#endif
+#ifndef BOOST_NO_CXX11_CHAR32_T
+char32_t const *c32_seq(boost::uint32_t a)
+{
+    static char32_t buf[2];
+    buf[0]=static_cast<char32_t>(a);
+    buf[1]=0;
+    return buf;
+}
+#endif
+
 template<typename CharType>
 void test_to(CharType const *s,unsigned codepoint)
 {
@@ -250,10 +269,10 @@ int main()
 
         std::cout << "-- Test correct" << std::endl;
 
-        test_to(u16_seq(0x10),0x10);
-        test_to(u16_seq(0xffff),0xffff);
-        test_to(u16_seq(0xD800,0xDC00),0x10000);
-        test_to(u16_seq(0xDBFF,0xDFFF),0x10FFFF);
+        test_from(u16_seq(0x10),0x10);
+        test_from(u16_seq(0xffff),0xffff);
+        test_from(u16_seq(0xD800,0xDC00),0x10000);
+        test_from(u16_seq(0xDBFF,0xDFFF),0x10FFFF);
 
 
         std::cout << "Test UTF-32" << std::endl;
@@ -285,12 +304,41 @@ int main()
 
         std::cout << "-- Test correct" << std::endl;
 
-        test_to(u32_seq(0x10),0x10);
-        test_to(u32_seq(0xffff),0xffff);
-        test_to(u32_seq(0x10ffff),0x10ffff);
+        test_from(u32_seq(0x10),0x10);
+        test_from(u32_seq(0xffff),0xffff);
+        test_from(u32_seq(0x10ffff),0x10ffff);
 
+#ifndef BOOST_NO_CXX11_CHAR16_T
+        std::cout << "-- Test char16_t" << std::endl;
+        test_to(u"\u0010",0x10);
+        test_to(u"\uffff",0xffff);
+        test_to(u"\U00010000",0x10000);
+        test_to(u"\U0010FFFF",0x10FFFF);
+        test_to(c16_seq(0xDFFF),illegal);
+        test_to(c16_seq(0xDC00),illegal);
 
+        test_from(u"\u0010",0x10);
+        test_from(u"\uffff",0xffff);
+        test_from(u"\U00010000",0x10000);
+        test_from(u"\U0010FFFF",0x10FFFF);
+#endif
+#ifndef BOOST_NO_CXX11_CHAR32_T
+        std::cout << "-- Test char32_t" << std::endl;
+        test_to(U"\U00000010",0x10);
+        test_to(U"\U0000ffff",0xffff);
+        test_to(U"\U00010000",0x10000);
+        test_to(U"\U0010ffff",0x10ffff);
+        test_to(c32_seq(0xD800),illegal);
+        test_to(c32_seq(0xDBFF),illegal);
+        test_to(c32_seq(0xDFFF),illegal);
+        test_to(c32_seq(0xDC00),illegal);
+        test_to(c32_seq(0x110000),illegal);
 
+        test_from(U"\U00000010",0x10);
+        test_from(U"\U0000ffff",0xffff);
+        test_from(U"\U00010000",0x10000);
+        test_from(U"\U0010ffff",0x10ffff);
+#endif
     }
     catch(std::exception const &e) {
         std::cerr << "Failed " << e.what() << std::endl;


### PR DESCRIPTION
Use a trait to select the correct encoding.
Defaults to current 'sizeof(T)' but is specialized for char16_t/char32_t

Note that this is fully backwards compatible except for ` char16_t/char32_t` with sizes different of `2/4` (unlikely but possible)

Fixes #47