### PR TITLE
Use __linux__ instead of __linux.

### DIFF
--- a/src/icu/time_zone.cpp
+++ b/src/icu/time_zone.cpp
@@ -19,7 +19,7 @@
 //
 
 #if U_ICU_VERSION_MAJOR_NUM == 4 && (U_ICU_VERSION_MINOR_NUM * 100 + U_ICU_VERSION_PATCHLEVEL_NUM) <= 402
-# if defined(__linux) || defined(__FreeBSD__) || defined(__APPLE__)
+# if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 #   define BOOST_LOCALE_WORKAROUND_ICU_BUG
 # endif
 #endif

--- a/src/posix/numeric.cpp
+++ b/src/posix/numeric.cpp
@@ -29,7 +29,7 @@
 #include "all_generator.hpp"
 
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__)
 #define BOOST_LOCALE_HAVE_WCSFTIME_L
 #endif
 

--- a/src/util/numeric.hpp
+++ b/src/util/numeric.hpp
@@ -190,7 +190,7 @@ private:
     {
         std::string tz = ios_info::get(ios).time_zone();
         std::tm tm;
-        #if defined(__linux) || defined(__FreeBSD__) || defined(__APPLE__) 
+        #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) 
         std::vector<char> tmp_buf(tz.c_str(),tz.c_str()+tz.size()+1);
         #endif
         if(tz.empty()) {
@@ -211,7 +211,7 @@ private:
             gmtime_r(&time,&tm);
             #endif
             
-            #if defined(__linux) || defined(__FreeBSD__) || defined(__APPLE__) 
+            #if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) 
             // These have extra fields to specify timezone
             if(gmtoff!=0) {
                 // bsd and apple want tm_zone be non-const


### PR DESCRIPTION
The macro __linux is less portable and, for example, is not defined on
some architectures.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=28314.