### PR TITLE
Add a workaround for compilation failure on MinGW in strict ANSI mode

### DIFF
--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -67,7 +67,7 @@ namespace boost {
                     }
                 }
 
-                #if defined(BOOST_WINDOWS)
+                #if defined(BOOST_WINDOWS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && defined(__STRICT_ANSI__))
 
                 bool open(std::string const &file_name,std::string const &encoding)
                 {


### PR DESCRIPTION
When GNU extensions are disabled, `stdio.h` in legacy MinGW does not declare non-standard wide character functions, including `_wfopen`. Use the standard `fopen` in that case.