### PR TITLE
Add support for en_001 and en_150 locales

### DIFF
--- a/src/util/locale_data.cpp
+++ b/src/util/locale_data.cpp
@@ -59,6 +59,8 @@ namespace util {
         for(unsigned i=0;i<tmp.size();i++) {
             if('a' <= tmp[i] && tmp[i]<='z')
                 tmp[i]=tmp[i]-'a'+'A';
+            else if('0' <= tmp[i] && tmp[i] <= '9')
+                continue;
             else if(tmp[i] < 'A' || 'Z' < tmp[i])
                 return;
         }


### PR DESCRIPTION
This addresses #58, by allowing 0-9 in the range of characters for the country of a locale.