### PR TITLE
Do not try to access element when vector is empty

### DIFF
--- a/src/icu/collator.cpp
+++ b/src/icu/collator.cpp
@@ -93,7 +93,7 @@ namespace boost {
                     std::vector<uint8_t> tmp;
                     tmp.resize(str.length());
                     icu::Collator *collate = get_collator(level);
-                    int len = collate->getSortKey(str,&tmp[0],tmp.size());
+                    int len = collate->getSortKey(str,tmp.empty()?NULL:&tmp[0],tmp.size());
                     if(len > int(tmp.size())) {
                         tmp.resize(len);
                         collate->getSortKey(str,&tmp[0],tmp.size());


### PR DESCRIPTION
Trying to access tmp[0] causes a crash on Fedora when assertion on STL
are enabled.

/usr/include/c++/10/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector<_Tp, _Alloc>::reference = unsigned char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.

This patch just passes nullptr as pointer to getSortKey() when tmp size
is 0, preventing dereferencing elements in empty vector.

I guess that &tmp[0] should be optimized as 'no real access' when
disabling assertion, but actually leads to crash when assert are
enabled.