### PR TITLE
- change ICU_LINK configuration

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -14,6 +14,7 @@ import os ;
 import toolset ;
 import project ;
 import feature ;
+import errors ;
 # Features
 
 feature.feature boost.locale.iconv : on off : optional propagated ;
@@ -65,8 +66,37 @@ ICU_LINK =  [ modules.peek : ICU_LINK ] ;
 
 if $(ICU_LINK)
 {
-    ICU_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK) <dll-path>$(ICU_PATH)/bin <runtime-link>shared ;
-    ICU64_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK) <dll-path>$(ICU_PATH)/bin64 <runtime-link>shared ;
+    errors.user-error : "The ICU_LINK option is no longer supported by the Boost.Locale build - please refer to the documentation for equivalent options" ;
+}
+
+if [ modules.peek : ICU_ICUUC_NAME ]
+{
+   ICU_ICUUC_NAME =  [ modules.peek : ICU_ICUUC_NAME ] ;
+}
+if [ modules.peek : ICU_ICUDT_NAME ]
+{
+   ICU_ICUDT_NAME =  [ modules.peek : ICU_ICUDT_NAME ] ;
+}
+if [ modules.peek : ICU_ICUIN_NAME ]
+{
+   ICU_ICUIN_NAME =  [ modules.peek : ICU_ICUIN_NAME ] ;
+}
+if [ modules.peek : ICU_ICUUC_NAME64 ]
+{
+   ICU_ICUUC_NAME64 =  [ modules.peek : ICU_ICUUC_NAME64 ] ;
+}
+if [ modules.peek : ICU_ICUDT_NAME64 ]
+{
+   ICU_ICUDT_NAME64 =  [ modules.peek : ICU_ICUDT_NAME64 ] ;
+}
+if [ modules.peek : ICU_ICUIN_NAME64 ]
+{
+   ICU_ICUIN_NAME64 =  [ modules.peek : ICU_ICUIN_NAME64 ] ;
+}
+
+if $(ICU_ICUUC_NAME)
+{
+    lib icuuc : : <name>$(ICU_ICUUC_NAME) ;
 }
 else
 {
@@ -83,7 +113,15 @@ else
                             <runtime-link>shared ;
 
     searched-lib icuuc : :  <name>this_is_an_invalid_library_name ;
+}
 
+
+if $(ICU_ICUDT_NAME)
+{
+  lib icudt : : <name>$(ICU_ICUDT_NAME) ;
+}
+else
+{
     searched-lib icudt : :  <search>$(ICU_PATH)/lib
                             <name>icudata
                             <link>shared
@@ -96,7 +134,14 @@ else
                             <runtime-link>shared ;
 
     searched-lib icudt : :  <name>this_is_an_invalid_library_name ;
+}
 
+if $(ICU_ICUIN_NAME)
+{
+  lib icuin : : <name>$(ICU_ICUIN_NAME) ;
+}
+else
+{
     searched-lib icuin : :  <search>$(ICU_PATH)/lib
                             <name>icui18n
                             <link>shared
@@ -117,77 +162,108 @@ else
                             <runtime-link>shared ;
 
     searched-lib icuin : :  <name>this_is_an_invalid_library_name ;
-
-    explicit icuuc icudt icuin ;
-
-    ICU_OPTS =   <include>$(ICU_PATH)/include
-      <library>icuuc/<link>shared/<runtime-link>shared
-      <library>icudt/<link>shared/<runtime-link>shared
-      <library>icuin/<link>shared/<runtime-link>shared
-      <dll-path>$(ICU_PATH)/bin
-        <runtime-link>shared ;
-
-
-
-    searched-lib icuuc_64 : :   <name>icuuc
-                                <search>$(ICU_PATH)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuuc_64 : :   <toolset>msvc
-                                <variant>debug
-                                <name>icuucd
-                                <search>$(ICU_PATH)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuuc_64 : :   <name>this_is_an_invalid_library_name ;
-
-    searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
-                                <name>icudata
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
-                                <name>icudt
-                                <toolset>msvc
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icudt_64 : :   <name>this_is_an_invalid_library_name ;
-
-    searched-lib icuin_64 : :   <search>$(ICU_PATH)/lib64
-                                <name>icui18n
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuin_64 : :   <toolset>msvc
-                                <variant>debug
-                                <name>icuind
-                                <search>$(ICU_PATH)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuin_64 : :   <toolset>msvc
-                                <variant>release
-                                <name>icuin
-                                <search>$(ICU_PATH)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuin_64 : :   <name>this_is_an_invalid_library_name ;
-
-    explicit icuuc_64 icudt_64 icuin_64 ;
-
-    ICU64_OPTS =   <include>$(ICU_PATH)/include
-      <library>icuuc_64/<link>shared/<runtime-link>shared
-      <library>icudt_64/<link>shared/<runtime-link>shared
-      <library>icuin_64/<link>shared/<runtime-link>shared
-      <dll-path>$(ICU_PATH)/bin64
-        <runtime-link>shared ;
-
-
 }
+explicit icuuc icudt icuin ;
+
+ICU_OPTS =
+  <include>$(ICU_PATH)/include
+  <runtime-link>shared:<library>icuuc/<link>shared
+  <runtime-link>shared:<library>icudt/<link>shared
+  <runtime-link>shared:<library>icuin/<link>shared
+  <runtime-link>static:<library>icuuc
+  <runtime-link>static:<library>icudt
+  <runtime-link>static:<library>icuin
+  <dll-path>$(ICU_PATH)/bin
+  <define>BOOST_HAS_ICU=1
+  <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
+  <toolset>msvc:<find-static-library>advapi32
+  ;
+
+
+if $(ICU_ICUUC_NAME64)
+{
+    lib icuuc_64 : : <name>$(ICU_ICUUC_NAME64) ;
+}
+else
+{
+	searched-lib icuuc_64 : :   <name>icuuc
+								<search>$(ICU_PATH)/lib64
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icuuc_64 : :   <toolset>msvc
+								<variant>debug
+								<name>icuucd
+								<search>$(ICU_PATH)/lib64
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icuuc_64 : :   <name>this_is_an_invalid_library_name ;
+}
+
+if $(ICU_ICUDT_NAME64)
+{
+  lib icudt_64 : : <name>$(ICU_ICUDT_NAME64) ;
+}
+else
+{
+	searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
+								<name>icudata
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
+								<name>icudt
+								<toolset>msvc
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icudt_64 : :   <name>this_is_an_invalid_library_name ;
+}
+
+if $(ICU_ICUIN_NAME64)
+{
+  lib icuin_64 : : <name>$(ICU_ICUIN_NAME64) ;
+}
+else
+{
+	searched-lib icuin_64 : :   <search>$(ICU_PATH)/lib64
+								<name>icui18n
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icuin_64 : :   <toolset>msvc
+								<variant>debug
+								<name>icuind
+								<search>$(ICU_PATH)/lib64
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icuin_64 : :   <toolset>msvc
+								<variant>release
+								<name>icuin
+								<search>$(ICU_PATH)/lib64
+								<link>shared
+								<runtime-link>shared ;
+
+	searched-lib icuin_64 : :   <name>this_is_an_invalid_library_name ;
+}
+explicit icuuc_64 icudt_64 icuin_64 ;
+
+ICU64_OPTS =
+  <include>$(ICU_PATH)/include
+  <runtime-link>shared:<library>icuuc_64/<link>shared
+  <runtime-link>shared:<library>icudt_64/<link>shared
+  <runtime-link>shared:<library>icuin_64/<link>shared
+  <runtime-link>static:<library>icuuc_64
+  <runtime-link>static:<library>icudt_64
+  <runtime-link>static:<library>icuin_64
+  <dll-path>$(ICU_PATH)/bin64
+  <define>BOOST_HAS_ICU=1
+  <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
+  <toolset>msvc:<find-static-library>advapi32
+  ;
+
 
 obj has_icu_obj     : ../build/has_icu_test.cpp : $(ICU_OPTS)   ;
 obj has_icu64_obj   : ../build/has_icu_test.cpp : $(ICU64_OPTS) ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -60,13 +60,26 @@ explicit has_xlocale ;
 
 #end xlocale
 
-
 ICU_PATH =  [ modules.peek : ICU_PATH ] ;
 ICU_LINK =  [ modules.peek : ICU_LINK ] ;
 
 if $(ICU_LINK)
 {
     errors.user-error : "The ICU_LINK option is no longer supported by the Boost.Locale build - please refer to the documentation for equivalent options" ;
+}
+
+rule path_options ( properties * )
+{
+    local result ;
+    result = <search>$(ICU_PATH)/bin <search>$(ICU_PATH)/lib ;
+    return $(result) ;
+}
+
+rule path_options64 ( properties * )
+{
+    local result ;
+    result = <search>$(ICU_PATH)/bin64 <search>$(ICU_PATH)/lib64 ;
+    return $(result) ;
 }
 
 if [ modules.peek : ICU_ICUUC_NAME ]
@@ -100,68 +113,48 @@ if $(ICU_ICUUC_NAME)
 }
 else
 {
-    searched-lib icuuc : :  <name>icuuc
-                            <search>$(ICU_PATH)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuuc : :  <toolset>msvc
-                            <variant>debug
-                            <name>icuucd
-                            <search>$(ICU_PATH)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuuc : :  <name>this_is_an_invalid_library_name ;
+	lib icuuc : :                                                               <runtime-link>shared <conditional>@path_options ;
+	lib icuuc : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
+	lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
+	lib icuuc : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options ;
+	lib icuuc : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
+	lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
+	lib icuuc : : <name>this_is_an_invalid_library_name ;
 }
 
 
 if $(ICU_ICUDT_NAME)
 {
-  lib icudt : : <name>$(ICU_ICUDT_NAME) ;
+	lib icudt : : <name>$(ICU_ICUDT_NAME) ;
 }
 else
 {
-    searched-lib icudt : :  <search>$(ICU_PATH)/lib
-                            <name>icudata
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icudt : :  <search>$(ICU_PATH)/lib
-                            <name>icudt
-                            <toolset>msvc
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icudt : :  <name>this_is_an_invalid_library_name ;
+	lib icudt : : <name>icudata                                   <runtime-link>shared <conditional>@path_options ;
+	lib icudt : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options ;
+	lib icudt : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options ;
+	lib icudt : : <name>sicudata                                   <runtime-link>static <conditional>@path_options ;
+	lib icudt : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options ;
+	lib icudt : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options ;
+	lib icudt : : <name>this_is_an_invalid_library_name ;
 }
 
 if $(ICU_ICUIN_NAME)
 {
-  lib icuin : : <name>$(ICU_ICUIN_NAME) ;
+	lib icuin : : <name>$(ICU_ICUIN_NAME) ;
 }
 else
 {
-    searched-lib icuin : :  <search>$(ICU_PATH)/lib
-                            <name>icui18n
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuin : :  <toolset>msvc
-                            <variant>debug
-                            <name>icuind
-                            <search>$(ICU_PATH)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuin : :  <toolset>msvc
-                            <variant>release
-                            <name>icuin
-                            <search>$(ICU_PATH)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuin : :  <name>this_is_an_invalid_library_name ;
+	lib icuin : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options ;
+	lib icuin : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <name>this_is_an_invalid_library_name ;
 }
 explicit icuuc icudt icuin ;
 
@@ -186,67 +179,47 @@ if $(ICU_ICUUC_NAME64)
 }
 else
 {
-	searched-lib icuuc_64 : :   <name>icuuc
-								<search>$(ICU_PATH)/lib64
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icuuc_64 : :   <toolset>msvc
-								<variant>debug
-								<name>icuucd
-								<search>$(ICU_PATH)/lib64
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icuuc_64 : :   <name>this_is_an_invalid_library_name ;
+	lib icuuc_64 : :                                                               <runtime-link>shared <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options64 ;
+	lib icuuc_64 : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options64 ;
+	lib icuuc_64 : : <name>this_is_an_invalid_library_name ;
 }
 
 if $(ICU_ICUDT_NAME64)
 {
-  lib icudt_64 : : <name>$(ICU_ICUDT_NAME64) ;
+	lib icudt_64 : : <name>$(ICU_ICUDT_NAME64) ;
 }
 else
 {
-	searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
-								<name>icudata
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icudt_64 : :   <search>$(ICU_PATH)/lib64
-								<name>icudt
-								<toolset>msvc
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icudt_64 : :   <name>this_is_an_invalid_library_name ;
+	lib icudt_64 : : <name>icudata                                   <runtime-link>shared <conditional>@path_options64 ;
+	lib icudt_64 : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options64 ;
+	lib icudt_64 : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options64 ;
+	lib icudt_64 : : <name>sicudata                                   <runtime-link>static <conditional>@path_options64 ;
+	lib icudt_64 : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options64 ;
+	lib icudt_64 : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options64 ;
+	lib icudt_64 : : <name>this_is_an_invalid_library_name ;
 }
 
 if $(ICU_ICUIN_NAME64)
 {
-  lib icuin_64 : : <name>$(ICU_ICUIN_NAME64) ;
+	lib icuin_64 : : <name>$(ICU_ICUIN_NAME64) ;
 }
 else
 {
-	searched-lib icuin_64 : :   <search>$(ICU_PATH)/lib64
-								<name>icui18n
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icuin_64 : :   <toolset>msvc
-								<variant>debug
-								<name>icuind
-								<search>$(ICU_PATH)/lib64
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icuin_64 : :   <toolset>msvc
-								<variant>release
-								<name>icuin
-								<search>$(ICU_PATH)/lib64
-								<link>shared
-								<runtime-link>shared ;
-
-	searched-lib icuin_64 : :   <name>this_is_an_invalid_library_name ;
+	lib icuin_64 : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <name>this_is_an_invalid_library_name ;
 }
 explicit icuuc_64 icudt_64 icuin_64 ;
 

--- a/build/has_icu_test.cpp
+++ b/build/has_icu_test.cpp
@@ -16,7 +16,7 @@
 #include <unicode/coll.h>
 
 #if defined(_MSC_VER) && !defined(_DLL)
-#error "Mixing ICU with a static runtime doesn't work"
+//#error "Mixing ICU with a static runtime doesn't work"
 #endif
 
 int main()


### PR DESCRIPTION
closes: #55 

this is basically a port of the following `boost.regex` commit: https://github.com/boostorg/regex/commit/fc4dc17dc745a9fc4ab1849cef3710354a6b7782

summary:
- `ICU_LINK` is deprecated
- added more granular variables to control ICU library names (`ICU_ICUUC_NAME`, `ICU_ICUDT_NAME`, `ICU_ICUIN_NAME`)
- static ICU is allowed (it's already allowed in regex, no reason to forbid it)

/cc @grafikrobot