### PR TITLE
Fix access to first element of empty vector

### DIFF
--- a/src/icu/collator.cpp
+++ b/src/icu/collator.cpp
@@ -91,9 +91,9 @@ namespace boost {
                 {
                     icu::UnicodeString str=cvt_.icu(b,e);
                     std::vector<uint8_t> tmp;
-                    tmp.resize(str.length());
+                    tmp.resize(str.length() + 1u);
                     icu::Collator *collate = get_collator(level);
-                    int len = collate->getSortKey(str,&tmp[0],tmp.size());
+                    const int len = collate->getSortKey(str,&tmp[0],tmp.size());
                     if(len > int(tmp.size())) {
                         tmp.resize(len);
                         collate->getSortKey(str,&tmp[0],tmp.size());


### PR DESCRIPTION
Supersedes #60. Using original commit message (part) of @OznOg

Trying to access tmp[0] causes a crash on Fedora when assertion on STL are enabled.

`/usr/include/c++/10/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; std::vector<_Tp, _Alloc>::reference = unsigned char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.`

Fix is to never have an empty vector as ICU sort keys include the NULL terminator, hence we need at least `length + 1` bytes which means the vector has at least 1 element: The NULL terminator

@OznOg Would you mind verifying this works for you?