### PR TITLE
Fix compilation without auto-ptr

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,137 @@
+# Copyright 2016, 2017 Peter Dimov
+# Copyright 2017 - 2019 James E. King III
+# Copyright 2019 - 2021 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+#
+# Generic Appveyor build script for boostorg repositories
+# See: https://github.com/boostorg/boost-ci/
+#
+# Instructions for customizing this script for your library:
+#
+# 1. Customize the compilers and language levels you want.
+# 2. If you have more than include/, src/, test/, example/, examples/,
+#    benchmark/ or tools/ directories, set the environment variable DEPINST.
+#    For example if your build uses code in "bench/" and "fog/" directories:
+#      - DEPINST: --include bench --include fog
+# 3. Enable pull request builds in your boostorg/<library> account.
+#
+# That's it - the script will do everything else for you.
+#
+
+version: 1.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - master
+    - develop
+    - /bugfix\/.*/
+    - /feature\/.*/
+    - /fix\/.*/
+    - /pr\/.*/
+
+matrix:
+  fast_finish: false
+  # Adding MAYFAIL to any matrix job allows it to fail but the build stays green:
+  allow_failures:
+    - MAYFAIL: true
+
+environment:
+  global:
+    B2_CI_VERSION: 1
+    GIT_FETCH_JOBS: 4
+    # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+    # to use the default for a given environment, comment it out; recommend you build debug and release however:
+    # on Windows it is important to exercise all the possibilities, especially shared vs static, however most
+    # libraries that care about this exercise it in their Jamfiles...
+    B2_ADDRESS_MODEL: 32,64
+    B2_LINK: shared,static
+    # B2_THREADING: threading=multi,single
+    B2_VARIANT: release
+
+  matrix:
+    - FLAVOR: Visual Studio 2022
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: 14,17,20
+      B2_TOOLSET: msvc-14.3
+
+    - FLAVOR: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: 14,17,2a
+      B2_TOOLSET: msvc-14.2
+
+    - FLAVOR: Visual Studio 2017 C++2a Strict
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: 2a
+      B2_TOOLSET: msvc-14.1
+
+    - FLAVOR: Visual Studio 2017 C++14/17
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_CXXSTD: 14,17
+      B2_TOOLSET: msvc-14.1
+
+    - FLAVOR: clang-cl
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 11,14,17
+      B2_TOOLSET: clang-win
+
+    - FLAVOR: Visual Studio 2015, 2013
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_TOOLSET: msvc-12.0,msvc-14.0
+
+    - FLAVOR: Visual Studio 2008, 2010, 2012
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
+      B2_ADDRESS_MODEL: 32 # No 64bit support
+
+    - FLAVOR: cygwin (32-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin\bin;
+      B2_ADDRESS_MODEL: 32
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
+    - FLAVOR: cygwin (64-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
+    - FLAVOR: mingw32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_ADDRESS_MODEL: 32
+      ADDPATH: C:\mingw\bin;
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
+    - FLAVOR: mingw64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ADDPATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 03,11,14,17,2a
+      B2_TOOLSET: gcc
+
+install:
+  - git clone --depth 1 https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned
+  # Copy ci folder if not testing Boost.CI
+  - if NOT "%APPVEYOR_PROJECT_NAME%" == "boost-ci" xcopy /s /e /q /i /y C:\boost-ci-cloned\ci .\ci
+  - rmdir /s /q C:\boost-ci-cloned
+  - ci\appveyor\install.bat
+
+build: off
+
+test_script: ci\build.bat
+
+for:
+  # CodeCov coverage build
+  - matrix:
+      only: [COVERAGE: true]
+    test_script: [ps: ci\codecov.ps1]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,401 @@
+# Copyright 2020-2021 Peter Dimov
+# Copyright 2021 Andrey Semashev
+# Copyright 2021 Alexander Grund
+# Copyright 2022 James E. King III
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+---
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+      - bugfix/**
+      - feature/**
+      - fix/**
+      - pr/**
+
+concurrency:
+  group: ${{format('{0}:{1}', github.repository, github.ref)}}
+  cancel-in-progress: true
+
+env:
+  GIT_FETCH_JOBS: 8
+  NET_RETRY_COUNT: 5
+  B2_CI_VERSION: 1
+  B2_VARIANT: debug,release
+  B2_LINK: shared,static
+  LCOV_BRANCH_COVERAGE: 0
+  CODECOV_NAME: Github Actions
+
+jobs:
+  posix:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux, gcc
+          - { compiler: gcc-4.4,   cxxstd: '98,0x',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.6,   cxxstd: '03,0x',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.7,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.8,   cxxstd: '03,11',          os: ubuntu-18.04 }
+          - { compiler: gcc-4.9,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-5,     cxxstd: '03,11,14,1z',    os: ubuntu-18.04 }
+          - { compiler: gcc-6,     cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
+          - { compiler: gcc-7,     cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
+          - { compiler: gcc-8,     cxxstd: '03,11,14,17,2a', os: ubuntu-18.04 }
+          - { compiler: gcc-9,     cxxstd: '03,11,14,17,2a', os: ubuntu-18.04 }
+          - { compiler: gcc-10,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { name: GCC w/ sanitizers, sanitize: yes,
+              compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { name: Collect coverage, coverage: yes,
+              compiler: gcc-8,     cxxstd: '03,11',          os: ubuntu-20.04, install: 'g++-8-multilib', address-model: '32,64' }
+
+          # Linux, clang
+          - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.6, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.7, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.8, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.9, cxxstd: '03,11,14',       os: ubuntu-18.04 }
+          - { compiler: clang-4.0, cxxstd: '03,11,14',       os: ubuntu-18.04 }
+          - { compiler: clang-5.0, cxxstd: '03,11,14,1z',    os: ubuntu-18.04 }
+          - { compiler: clang-6.0, cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
+          - { compiler: clang-7,   cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
+          # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
+          - { compiler: clang-8,   cxxstd: '03,11,14,17,2a', os: ubuntu-18.04, install: 'clang-8 g++-7', gcc_toolchain: 7 }
+          - { compiler: clang-9,   cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
+          - { compiler: clang-10,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-11,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+
+          # libc++
+          - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-18.04, stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
+          - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
+          - { name: Clang w/ sanitizers, sanitize: yes,
+              compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
+
+          # OSX, clang
+          - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-10.15, sanitize: yes }
+
+    timeout-minutes: 120
+    runs-on: ${{matrix.os}}
+    container: ${{matrix.container}}
+    env: {B2_USE_CCACHE: 1}
+
+    steps:
+      - name: Setup environment
+        run: |
+            if [ -f "/etc/debian_version" ]; then
+                echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+                export DEBIAN_FRONTEND=noninteractive
+            fi
+            if [ -n "${{matrix.container}}" ] && [ -f "/etc/debian_version" ]; then
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common
+                # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
+                apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
+                for i in {1..${NET_RETRY_COUNT:-3}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
+            fi
+            # For jobs not compatible with ccache, use "ccache: no" in the matrix
+            if [[ "${{ matrix.ccache }}" == "no" ]]; then
+                echo "B2_USE_CCACHE=0" >> $GITHUB_ENV
+            fi
+            git config --global pack.threads 0
+
+      - uses: actions/checkout@v2
+        with:
+          # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
+          fetch-depth: ${{ matrix.coverage && '0' || '1' }}
+
+      - name: Cache ccache
+        uses: actions/cache@v2
+        if: env.B2_USE_CCACHE
+        with:
+          path: ~/.ccache
+          key: ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}
+
+      - name: Fetch Boost.CI
+        uses: actions/checkout@v2
+        with:
+          repository: boostorg/boost-ci
+          ref: master
+          path: boost-ci-cloned
+
+      - name: Get CI scripts folder
+        run: |
+            # Copy ci folder if not testing Boost.CI
+            [[ "$GITHUB_REPOSITORY" =~ "boost-ci" ]] || cp -r boost-ci-cloned/ci .
+            rm -rf boost-ci-cloned
+
+      - name: Install packages
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+            SOURCE_KEYS=(${{join(matrix.source_keys, ' ')}})
+            SOURCES=(${{join(matrix.sources, ' ')}})
+            # Add this by default
+            SOURCES+=(ppa:ubuntu-toolchain-r/test)
+            for key in "${SOURCE_KEYS[@]}"; do
+                for i in {1..$NET_RETRY_COUNT}; do
+                    wget -O - "$key" | sudo apt-key add - && break || sleep 10
+                done
+            done
+            for source in "${SOURCES[@]}"; do
+                for i in {1..$NET_RETRY_COUNT}; do
+                    sudo add-apt-repository $source && break || sleep 10
+                done
+            done
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+            if [[ -z "${{matrix.install}}" ]]; then
+                pkgs="${{matrix.compiler}}"
+                pkgs="${pkgs/gcc-/g++-}"
+            else
+                pkgs="${{matrix.install}}"
+            fi
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y $pkgs
+
+      - name: Setup GCC Toolchain
+        if: matrix.gcc_toolchain
+        run: |
+            GCC_TOOLCHAIN_ROOT="$HOME/gcc-toolchain"
+            echo "GCC_TOOLCHAIN_ROOT=$GCC_TOOLCHAIN_ROOT" >> $GITHUB_ENV
+            MULTIARCH_TRIPLET="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+            mkdir -p "$GCC_TOOLCHAIN_ROOT"
+            ln -s /usr/include "$GCC_TOOLCHAIN_ROOT/include"
+            ln -s /usr/bin "$GCC_TOOLCHAIN_ROOT/bin"
+            mkdir -p "$GCC_TOOLCHAIN_ROOT/lib/gcc/$MULTIARCH_TRIPLET"
+            ln -s "/usr/lib/gcc/$MULTIARCH_TRIPLET/${{matrix.gcc_toolchain}}" "$GCC_TOOLCHAIN_ROOT/lib/gcc/$MULTIARCH_TRIPLET/${{matrix.gcc_toolchain}}"
+
+      - name: Setup multiarch
+        if: matrix.multiarch
+        run: |
+          sudo apt-get install --no-install-recommends -y binfmt-support qemu-user-static
+          sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          git clone https://github.com/jeking3/bdde.git
+          echo "$(pwd)/bdde/bin/linux" >> ${GITHUB_PATH}
+          echo "BDDE_DISTRO=${{ matrix.distro }}" >> ${GITHUB_ENV}
+          echo "BDDE_EDITION=${{ matrix.edition }}" >> ${GITHUB_ENV}
+          echo "BDDE_ARCH=${{ matrix.arch }}" >> ${GITHUB_ENV}
+          echo "B2_WRAPPER=bdde" >> ${GITHUB_ENV}
+
+      - name: Setup Boost
+        env:
+          B2_ADDRESS_MODEL: ${{matrix.address-model}}
+          B2_COMPILER: ${{matrix.compiler}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_SANITIZE: ${{matrix.sanitize}}
+          B2_STDLIB: ${{matrix.stdlib}}
+          # More entries can be added in the same way, see the B2_ARGS assignment in ci/enforce.sh for the possible keys.
+          # B2_DEFINES: ${{matrix.defines}}
+          # Variables set here (to non-empty) will override the top-level environment variables, e.g.
+          # B2_VARIANT: ${{matrix.variant}}
+        run: source ci/github/install.sh
+
+      - name: Setup coverage collection
+        if: matrix.coverage
+        run: ci/github/codecov.sh "setup"
+
+      - name: Run tests
+        if: '!matrix.coverity'
+        run: ci/build.sh
+
+      - name: Upload coverage
+        if: matrix.coverage
+        run: ci/codecov.sh "upload"
+
+      - name: Run coverity
+        if: matrix.coverity && github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
+        run: ci/github/coverity.sh
+        env:
+          COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+  windows:
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
+          - { name: Collect coverage, coverage: yes,
+              toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
+          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch Boost.CI
+        uses: actions/checkout@v2
+        with:
+          repository: boostorg/boost-ci
+          ref: master
+          path: boost-ci-cloned
+      - name: Get CI scripts folder
+        run: |
+            REM Copy ci folder if not testing Boost.CI
+            if "%GITHUB_REPOSITORY%" == "%GITHUB_REPOSITORY:boost-ci=%" xcopy /s /e /q /i /y boost-ci-cloned\ci .\ci
+            rmdir /s /q boost-ci-cloned
+
+      - name: Setup Boost
+        run: ci\github\install.bat
+
+      - name: Run tests
+        if: '!matrix.coverage'
+        run: ci\build.bat
+        env:
+          B2_TOOLSET: ${{matrix.toolset}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+      - name: Collect coverage
+        shell: powershell
+        if: matrix.coverage
+        run: ci\opencppcoverage.ps1
+        env:
+          B2_TOOLSET: ${{matrix.toolset}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+      - name: Upload coverage
+        if: matrix.coverage
+        uses: codecov/codecov-action@v2
+        with:
+          files: __out/cobertura.xml
+
+  MSYS2:
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: MINGW32, compiler: gcc, cxxstd: '03,11,17,20' }
+          - { sys: MINGW64, compiler: gcc, cxxstd: '03,11,17,20' }
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup MSYS2 environment
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: git python
+          pacboy: gcc:p cmake:p ninja:p
+
+      - name: Fetch Boost.CI
+        uses: actions/checkout@v2
+        with:
+          repository: boostorg/boost-ci
+          ref: master
+          path: boost-ci-cloned
+      - name: Get CI scripts folder
+        run: |
+            # Copy ci folder if not testing Boost.CI
+            [[ "$GITHUB_REPOSITORY" =~ "boost-ci" ]] || cp -r boost-ci-cloned/ci .
+            rm -rf boost-ci-cloned
+
+      - name: Setup Boost
+        env:
+          B2_COMPILER: ${{matrix.compiler}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_SANITIZE: ${{matrix.sanitize}}
+          B2_STDLIB: ${{matrix.stdlib}}
+        run: ci/github/install.sh
+
+      - name: Run tests
+        run: ci/build.sh
+
+      # Run also the CMake tests to avoid having to setup another matrix for CMake on MSYS
+      - name: Run CMake tests
+        run: |
+            cd "$BOOST_ROOT"
+            mkdir __build_cmake_test__ && cd __build_cmake_test__
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
+            cmake --build . --target tests --config Debug
+            ctest --output-on-failure --build-config Debug
+
+  CMake:
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-20.04, build_shared: ON,  build_type: Debug, generator: 'Unix Makefiles' }
+          - { os: ubuntu-20.04, build_shared: OFF, build_type: Debug, generator: 'Unix Makefiles' }
+          - { os: windows-2019, build_shared: ON,  build_type: Debug, generator: 'Visual Studio 16 2019' }
+          - { os: windows-2019, build_shared: OFF, build_type: Debug, generator: 'Visual Studio 16 2019' }
+
+    timeout-minutes: 120
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch Boost.CI
+        uses: actions/checkout@v2
+        with:
+          repository: boostorg/boost-ci
+          ref: master
+          path: boost-ci-cloned
+      - name: Get CI scripts folder
+        run: |
+            # Copy ci folder if not testing Boost.CI
+            [[ "$GITHUB_REPOSITORY" =~ "boost-ci" ]] || cp -r boost-ci-cloned/ci .
+            rm -rf boost-ci-cloned
+      - name: Setup Boost
+        env: {B2_DONT_BOOTSTRAP: 1}
+        run: source ci/github/install.sh
+
+      - name: Run CMake tests
+        run: |
+            cd "$BOOST_ROOT"
+            mkdir __build_cmake_test__ && cd __build_cmake_test__
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
+            cmake --build . --target tests --config ${{matrix.build_type}} -j3
+            ctest --output-on-failure --build-config ${{matrix.build_type}}
+
+      - name: Run CMake subdir tests
+        run: |
+            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
+            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_subdir_test"
+            cd "$cmake_test_folder"
+            mkdir __build_cmake_subdir_test__ && cd __build_cmake_subdir_test__
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} ..
+            cmake --build . --config ${{matrix.build_type}} -j3
+            ctest --output-on-failure --build-config ${{matrix.build_type}}
+
+      - name: Install Library
+        run: |
+            cd "$BOOST_ROOT"
+            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX=~/.local -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
+            cmake --build . --target install --config ${{matrix.build_type}} -j3
+      - name: Run CMake install tests
+        run: |
+            cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_test" # New unified folder
+            [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_install_test"
+            cd "$cmake_test_folder"
+            mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_PREFIX_PATH=~/.local ..
+            cmake --build . --config ${{matrix.build_type}} -j3
+            ctest --output-on-failure --build-config ${{matrix.build_type}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             else
                 pkgs="${{matrix.install}}"
             fi
-            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y $pkgs
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y $pkgs libicu-dev
 
       - name: Setup GCC Toolchain
         if: matrix.gcc_toolchain
@@ -205,9 +205,22 @@ jobs:
         if: matrix.coverage
         run: ci/github/codecov.sh "setup"
 
-      - name: Run tests
+      - name: Run tests no ICU/iconv
         if: '!matrix.coverity'
         run: ci/build.sh
+        env: {B2_FLAGS: -a boost.locale.icu=off boost.locale.iconv=off}
+      - name: Run tests with iconv
+        if: '!matrix.coverity'
+        run: ci/build.sh
+        env: {B2_FLAGS: -a boost.locale.icu=off boost.locale.iconv=on}
+      - name: Run tests with ICU
+        if: '!matrix.coverity'
+        run: ci/build.sh
+        env: {B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=off}
+      - name: Run tests with ICU/iconv
+        if: '!matrix.coverity'
+        run: ci/build.sh
+        env: {B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=on}
 
       - name: Upload coverage
         if: matrix.coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,15 +393,17 @@ jobs:
             [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_subdir_test"
             cd "$cmake_test_folder"
             mkdir __build_cmake_subdir_test__ && cd __build_cmake_subdir_test__
-            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} ..
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_RUNTIME_OUTPUT_DIRECTORY="$(pwd)/bin" ..
             cmake --build . --config ${{matrix.build_type}} -j3
             ctest --output-on-failure --build-config ${{matrix.build_type}}
 
       - name: Install Library
         run: |
+            BCM_INSTALL_PATH=/tmp/boost_install
+            echo "BCM_INSTALL_PATH=$BCM_INSTALL_PATH" >> $GITHUB_ENV
             cd "$BOOST_ROOT"
             mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
-            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX=~/.local -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX="$BCM_INSTALL_PATH" -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
             cmake --build . --target install --config ${{matrix.build_type}} -j3
       - name: Run CMake install tests
         run: |
@@ -409,6 +411,14 @@ jobs:
             [ -d "$cmake_test_folder" ] || cmake_test_folder="$BOOST_ROOT/libs/$SELF/test/cmake_install_test"
             cd "$cmake_test_folder"
             mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
-            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_PREFIX_PATH=~/.local ..
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_PREFIX_PATH="$BCM_INSTALL_PATH" ..
             cmake --build . --config ${{matrix.build_type}} -j3
+            if [[ "${{matrix.build_shared}}" == "ON" ]]; then
+                # Make sure shared libs can be found at runtime
+                if [ "$RUNNER_OS" == "Windows" ]; then
+                    export PATH="$BCM_INSTALL_PATH/bin:$PATH"
+                else
+                    export LD_LIBRARY_PATH="$BCM_INSTALL_PATH/lib:$LD_LIBRARY_PATH"
+                fi
+            fi
             ctest --output-on-failure --build-config ${{matrix.build_type}}

--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -31,6 +31,11 @@
 #include <boost/config/auto_link.hpp>
 #endif  // auto-linking disabled
 
+#if defined(BOOST_LOCALE_HIDE_AUTO_PTR) || defined(BOOST_NO_AUTO_PTR)
+#define BOOST_LOCALE_USE_AUTO_PTR 0
+#else
+#define BOOST_LOCALE_USE_AUTO_PTR 1
+#endif
 
 #endif // boost/locale/config.hpp
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -102,7 +102,7 @@ namespace boost {
             ///
             ~localization_backend_manager();
 
-            #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+            #if BOOST_LOCALE_USE_AUTO_PTR
             ///
             /// Create new localization backend according to current settings.
             ///

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -172,7 +172,7 @@ namespace util {
         }
     };
 
-    #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+    #if BOOST_LOCALE_USE_AUTO_PTR
     ///
     /// This function creates a \a base_converter that can be used for conversion between UTF-8 and
     /// unicode code points

--- a/src/shared/localization_backend.cpp
+++ b/src/shared/localization_backend.cpp
@@ -181,7 +181,7 @@ namespace boost {
         }
 
 
-        #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+        #if BOOST_LOCALE_USE_AUTO_PTR
         std::auto_ptr<localization_backend> localization_backend_manager::get() const
         {
             std::auto_ptr<localization_backend> r(pimpl_->create());

--- a/src/util/codecvt_converter.cpp
+++ b/src/util/codecvt_converter.cpp
@@ -269,7 +269,7 @@ namespace util {
         return 0;
     }
     
-    #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+    #if BOOST_LOCALE_USE_AUTO_PTR
     std::auto_ptr<base_converter> create_utf8_converter()
     {
         std::auto_ptr<base_converter> res(create_utf8_converter_new_ptr());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Copyright 2022 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# https://www.boost.org/LICENSE_1_0.txt
+
+if(NOT TARGET tests)
+  add_custom_target(tests)
+endif()
+
+function(boost_locale_add_test name)
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "COMPILE_ONLY" "SRC" "")
+
+  if(NOT ARG_SRC)
+    set(ARG_SRC ${name}.cpp)
+  endif()
+  set(name ${PROJECT_NAME}-${name})
+  
+  add_executable(${name} ${ARG_SRC})
+  add_dependencies(tests ${name})
+  target_link_libraries(${name} PRIVATE Boost::locale)
+  
+  if(BOOST_LOCALE_ENABLE_ICONV)
+    target_compile_definitions(${name} PRIVATE BOOST_LOCALE_WITH_ICONV=1)
+  endif()
+  if(BOOST_LOCALE_ENABLE_ICU)
+    target_compile_definitions(${name} PRIVATE BOOST_LOCALE_WITH_ICU=1)
+  endif()
+  if(NOT BOOST_LOCALE_ENABLE_STD)
+    target_compile_definitions(${name} PRIVATE BOOST_LOCALE_NO_STD_BACKEND=1)
+  endif()
+  if(NOT BOOST_LOCALE_ENABLE_WINAPI)
+    target_compile_definitions(${name} PRIVATE BOOST_LOCALE_NO_WINAPI_BACKEND=1)
+  endif()
+  if(NOT BOOST_LOCALE_ENABLE_POSIX)
+    target_compile_definitions(${name} PRIVATE BOOST_LOCALE_NO_POSIX_BACKEND=1)
+  endif()
+
+  if(NOT ARG_COMPILE_ONLY)
+    add_test(NAME ${name} COMMAND ${name} ${ARG_ARGS})
+  endif()
+endfunction()
+
+boost_locale_add_test(test_config)
+# Shared
+boost_locale_add_test(test_utf COMPILE_ONLY)
+boost_locale_add_test(test_date_time COMPILE_ONLY)
+boost_locale_add_test(test_ios_prop COMPILE_ONLY)
+boost_locale_add_test(test_codecvt COMPILE_ONLY)
+boost_locale_add_test(test_codepage_converter COMPILE_ONLY)
+boost_locale_add_test(test_codepage COMPILE_ONLY)
+boost_locale_add_test(test_message COMPILE_ONLY)
+boost_locale_add_test(test_generator COMPILE_ONLY)
+# icu
+boost_locale_add_test(test_collate COMPILE_ONLY)
+boost_locale_add_test(test_convert COMPILE_ONLY)
+boost_locale_add_test(test_boundary COMPILE_ONLY)
+boost_locale_add_test(test_formatting COMPILE_ONLY)
+boost_locale_add_test(test_icu_vs_os_timezone COMPILE_ONLY)
+# winapi
+boost_locale_add_test(test_winapi_collate COMPILE_ONLY)
+boost_locale_add_test(test_winapi_convert COMPILE_ONLY)
+boost_locale_add_test(test_winapi_formatting COMPILE_ONLY)
+# posix
+boost_locale_add_test(test_posix_collate COMPILE_ONLY)
+boost_locale_add_test(test_posix_convert COMPILE_ONLY)
+boost_locale_add_test(test_posix_formatting COMPILE_ONLY)
+# std
+boost_locale_add_test(test_std_collate COMPILE_ONLY)
+boost_locale_add_test(test_std_convert COMPILE_ONLY)
+boost_locale_add_test(test_std_formatting COMPILE_ONLY)

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -1,0 +1,82 @@
+# Copyright 2022 Alexander Grund
+# Distributed under the Boost Software License, Version 1.0.
+# https://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5...3.16)
+
+project(cmake_subdir_test LANGUAGES CXX)
+
+# Those 2 should work the same
+if(DEFINED BOOST_CI_INSTALL_TEST AND BOOST_CI_INSTALL_TEST)
+    message("Using installed Boost")
+    find_package(boost_locale REQUIRED)
+else()
+    message("Building Boost")
+    add_subdirectory(../.. boostorg/locale)
+    set(deps
+      # Primary dependencies
+      assert
+      config
+      function
+      iterator
+      smart_ptr
+      static_assert
+      type_traits
+      thread
+      unordered
+
+      # Secondary dependencies
+      algorithm
+      align
+      array
+      atomic
+      bind
+      chrono
+      concept_check
+      container
+      container_hash
+      conversion
+      core
+      date_time
+      detail
+      exception
+      function_types
+      fusion
+      integer
+      intrusive
+      io
+      lexical_cast
+      move
+      mp11
+      mpl
+      numeric/conversion
+      optional
+      predef
+      preprocessor
+      range
+      ratio
+      rational
+      regex
+      system
+      throw_exception
+      tokenizer
+      tuple
+      type_index
+      typeof
+      utility
+      variant2
+      winapi
+    )
+
+    foreach(dep IN LISTS deps)
+      add_subdirectory(../../../${dep} boostorg/${dep})
+    endforeach()
+endif()
+
+add_executable(main main.cpp)
+target_link_libraries(main Boost::locale Boost::system)
+
+enable_testing()
+add_test(NAME main COMMAND main)
+
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>)

--- a/test/cmake_test/main.cpp
+++ b/test/cmake_test/main.cpp
@@ -1,0 +1,38 @@
+//
+//  Copyright (c) 2022 Alexander Grund
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/locale/util.hpp>
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+    // Simple test that including a library header and using an exported function works
+    #ifndef BOOST_NO_CXX11_SMART_PTR
+    std::cout << "create_utf8_converter_unique_ptr" << std::endl;
+    std::unique_ptr<boost::locale::util::base_converter> cvt = boost::locale::util::create_utf8_converter_unique_ptr();
+    #elif BOOST_LOCALE_USE_AUTO_PTR
+    std::cout << "create_utf8_converter" << std::endl;
+    std::auto_ptr<boost::locale::util::base_converter> cvt = boost::locale::util::create_utf8_converter();
+    #else
+    std::cout << "create_utf8_converter_new_ptr" << std::endl;
+    boost::locale::hold_ptr<boost::locale::util::base_converter> cvt(boost::locale::util::create_utf8_converter_new_ptr());
+    #endif
+
+    if(cvt.get())
+    {
+        std::cout << "Created..." << std::endl;
+        assert(cvt->is_thread_safe());
+        assert(cvt->max_len() == 4);
+    }else
+    {
+        std::cout << "Failed creation..." << std::endl;
+    }
+    
+    return cvt.get() ? 0 : 1;
+}

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -14,6 +14,9 @@
 #if defined(BOOST_LOCALE_WITH_ICONV) && !defined(BOOST_LOCALE_NO_POSIX_BACKEND)
 #include "../src/posix/codecvt.hpp"
 #endif
+#if defined(BOOST_NO_CXX11_SMART_PTR) && !BOOST_LOCALE_USE_AUTO_PTR
+#include <boost/locale/hold_ptr.hpp>
+#endif
 
 #include <string.h>
 
@@ -115,20 +118,16 @@ int main()
     try {
         using namespace boost::locale::util;
 
-        #ifndef BOOST_NO_CXX11_SMART_PTR
-        std::unique_ptr<base_converter> cvt;
-        #else
-        std::auto_ptr<base_converter> cvt;
-        #endif
-
         std::cout << "Test UTF-8" << std::endl;
         std::cout << "- From UTF-8" << std::endl;
 
 
         #ifndef BOOST_NO_CXX11_SMART_PTR
-        cvt = std::move(create_utf8_converter_unique_ptr());
+        std::unique_ptr<base_converter> cvt = create_utf8_converter_unique_ptr();
+        #elif BOOST_LOCALE_USE_AUTO_PTR
+        std::auto_ptr<base_converter> cvt = create_utf8_converter();
         #else
-        cvt = create_utf8_converter();
+        boost::locale::hold_ptr<base_converter> cvt(create_utf8_converter_new_ptr());
         #endif
 
         TEST(cvt.get());
@@ -262,9 +261,11 @@ int main()
         std::cout << "Test windows-1255" << std::endl;
 
         #ifndef BOOST_NO_CXX11_SMART_PTR
-        cvt = std::move(create_simple_converter_unique_ptr("windows-1255"));
-        #else
+        cvt = create_simple_converter_unique_ptr("windows-1255");
+        #elif BOOST_LOCALE_USE_AUTO_PTR
         cvt = create_simple_converter("windows-1255");
+        #else
+        cvt.reset(create_simple_converter_new_ptr("windows-1255"));
         #endif
 
         TEST(cvt.get());


### PR DESCRIPTION
Unify the 2 defines `BOOST_LOCALE_HIDE_AUTO_PTR` & `BOOST_NO_AUTO_PTR` to a new `BOOST_LOCALE_USE_AUTO_PTR` then use this consistently.

Especially test/test_codepage_converter.cpp was missing any guarding and failed to compile.

Requires:

- [ ] #76
- [ ] #77