### PR TITLE
Fix visibility of classes

### DIFF
--- a/include/boost/locale/boundary/facets.hpp
+++ b/include/boost/locale/boundary/facets.hpp
@@ -131,6 +131,7 @@ namespace boost {
                 boundary_indexing(size_t refs=0) : std::locale::facet(refs)
                 {
                 }
+                ~boundary_indexing();
                 virtual index_type map(boundary_type t,char const *begin,char const *end) const = 0;
                 static std::locale::id id;
                 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
@@ -144,6 +145,7 @@ namespace boost {
                 boundary_indexing(size_t refs=0) : std::locale::facet(refs)
                 {
                 }
+                ~boundary_indexing();
                 virtual index_type map(boundary_type t,wchar_t const *begin,wchar_t const *end) const = 0;
 
                 static std::locale::id id;
@@ -159,6 +161,7 @@ namespace boost {
                 boundary_indexing(size_t refs=0) : std::locale::facet(refs)
                 {
                 }
+                ~boundary_indexing();
                 virtual index_type map(boundary_type t,char16_t const *begin,char16_t const *end) const = 0;
                 static std::locale::id id;
                 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
@@ -174,6 +177,7 @@ namespace boost {
                 boundary_indexing(size_t refs=0) : std::locale::facet(refs)
                 {
                 }
+                ~boundary_indexing();
                 virtual index_type map(boundary_type t,char32_t const *begin,char32_t const *end) const = 0;
                 static std::locale::id id;
                 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)

--- a/include/boost/locale/conversion.hpp
+++ b/include/boost/locale/conversion.hpp
@@ -83,6 +83,7 @@ namespace boost {
             converter(size_t refs = 0) : std::locale::facet(refs)
             {
             }
+            ~converter();
             virtual std::string convert(conversion_type how,char const *begin,char const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
             std::locale::id& __get_id (void) const { return id; }
@@ -96,6 +97,7 @@ namespace boost {
             converter(size_t refs = 0) : std::locale::facet(refs)
             {
             }
+            ~converter();
              virtual std::wstring convert(conversion_type how,wchar_t const *begin,wchar_t const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
             std::locale::id& __get_id (void) const { return id; }
@@ -110,6 +112,7 @@ namespace boost {
             converter(size_t refs = 0) : std::locale::facet(refs)
             {
             }
+            ~converter();
             virtual std::u16string convert(conversion_type how,char16_t const *begin,char16_t const *end,int flags = 0) const = 0; 
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
             std::locale::id& __get_id (void) const { return id; }
@@ -125,6 +128,7 @@ namespace boost {
             converter(size_t refs = 0) : std::locale::facet(refs)
             {
             }
+            ~converter();
             virtual std::u32string convert(conversion_type how,char32_t const *begin,char32_t const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
             std::locale::id& __get_id (void) const { return id; }

--- a/include/boost/locale/info.hpp
+++ b/include/boost/locale/info.hpp
@@ -27,6 +27,8 @@ namespace boost {
         class BOOST_LOCALE_DECL info : public std::locale::facet
         {
         public:
+            ~info();
+
             static std::locale::id id; ///< This member uniquely defines this facet, required by STL 
 
             ///

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -38,14 +38,21 @@ namespace boost {
         /// @{
         /// 
 
+        /// \cond INTERNAL 
+
+        template<typename CharType>
+        struct base_message_format;
+
+        /// \endcond
+
         ///
         /// \brief This facet provides message formatting abilities
         ///
         template<typename CharType>
-        class BOOST_LOCALE_DECL message_format : public std::locale::facet
+        class BOOST_LOCALE_DECL message_format : public base_message_format<CharType>
         {
         public:
-            static std::locale::id id;
+
             ///
             /// Character type
             ///
@@ -58,7 +65,7 @@ namespace boost {
             ///
             /// Default constructor
             ///
-            message_format(size_t refs = 0) : std::locale::facet(refs)
+            message_format(size_t refs = 0) : base_message_format<CharType>(refs)
             {
             }
 
@@ -693,6 +700,56 @@ namespace boost {
         {
             return basic_message<CharType>(context,s,p,n).str(loc,domain);
         }
+
+        ///
+        /// \cond INTERNAL
+        ///
+
+        template<>
+        struct BOOST_LOCALE_DECL base_message_format<char> : public std::locale::facet 
+        {
+            base_message_format(size_t refs = 0) : std::locale::facet(refs)
+            {
+            }
+            static std::locale::id id;
+        };
+
+        template<>
+        struct BOOST_LOCALE_DECL base_message_format<wchar_t> : public std::locale::facet 
+        {
+            base_message_format(size_t refs = 0) : std::locale::facet(refs)
+            {
+            }
+            static std::locale::id id;
+        };
+
+        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+
+        template<>
+        struct BOOST_LOCALE_DECL base_message_format<char16_t> : public std::locale::facet 
+        {
+            base_message_format(size_t refs = 0) : std::locale::facet(refs)
+            {
+            }
+            static std::locale::id id;
+        };
+
+        #endif
+
+        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+
+        template<>
+        struct BOOST_LOCALE_DECL base_message_format<char32_t> : public std::locale::facet 
+        {
+            base_message_format(size_t refs = 0) : std::locale::facet(refs)
+            {
+            }
+            static std::locale::id id;
+        };
+
+        #endif
+
+        /// \endcond
 
         ///
         /// @}

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -49,7 +49,7 @@ namespace boost {
         /// \brief This facet provides message formatting abilities
         ///
         template<typename CharType>
-        class BOOST_LOCALE_DECL message_format : public base_message_format<CharType>
+        class BOOST_SYMBOL_VISIBLE message_format : public base_message_format<CharType>
         {
         public:
 
@@ -114,7 +114,7 @@ namespace boost {
             std::locale::id& __get_id (void) const { return id; }
 #endif
         protected:
-            virtual ~message_format();
+            virtual ~message_format() {}
         };
         
         /// \cond INTERNAL

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -38,23 +38,14 @@ namespace boost {
         /// @{
         /// 
 
-        /// \cond INTERNAL 
-
-        template<typename CharType>
-        struct base_message_format: public std::locale::facet
-        {
-        };
-       
-        /// \endcond
-       
         ///
         /// \brief This facet provides message formatting abilities
         ///
         template<typename CharType>
-        class message_format : public base_message_format<CharType>
+        class BOOST_LOCALE_DECL message_format : public std::locale::facet
         {
         public:
-
+            static std::locale::id id;
             ///
             /// Character type
             ///
@@ -67,8 +58,7 @@ namespace boost {
             ///
             /// Default constructor
             ///
-            message_format(size_t refs = 0) : 
-                base_message_format<CharType>(refs)
+            message_format(size_t refs = 0) : std::locale::facet(refs)
             {
             }
 
@@ -117,10 +107,7 @@ namespace boost {
             std::locale::id& __get_id (void) const { return id; }
 #endif
         protected:
-            virtual ~message_format()
-            {
-            }
-
+            virtual ~message_format();
         };
         
         /// \cond INTERNAL
@@ -706,56 +693,6 @@ namespace boost {
         {
             return basic_message<CharType>(context,s,p,n).str(loc,domain);
         }
-
-        ///
-        /// \cond INTERNAL
-        ///
-        
-        template<>
-        struct BOOST_LOCALE_DECL base_message_format<char> : public std::locale::facet 
-        {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
-            static std::locale::id id;
-        };
-        
-        template<>
-        struct BOOST_LOCALE_DECL base_message_format<wchar_t> : public std::locale::facet 
-        {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
-            static std::locale::id id;
-        };
-        
-        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-
-        template<>
-        struct BOOST_LOCALE_DECL base_message_format<char16_t> : public std::locale::facet 
-        {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
-            static std::locale::id id;
-        };
-
-        #endif
-
-        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-
-        template<>
-        struct BOOST_LOCALE_DECL base_message_format<char32_t> : public std::locale::facet 
-        {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
-            static std::locale::id id;
-        };
-        
-        #endif
-
-        /// \endcond
 
         ///
         /// @}

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -74,7 +74,7 @@ namespace util {
     /// decompose them in case composite characters are found. So be very careful when implementing
     /// these converters for certain character set.
     ///
-    class base_converter {
+    class BOOST_LOCALE_DECL base_converter {
     public:
 
         ///
@@ -90,9 +90,7 @@ namespace util {
         ///
         static const uint32_t incomplete=utf::incomplete;
         
-        virtual ~base_converter() 
-        {
-        }
+        virtual ~base_converter();
         ///
         /// Return the maximal length that one Unicode code-point can be converted to, for example
         /// for UTF-8 it is 4, for Shift-JIS it is 2 and ISO-8859-1 is 1

--- a/src/shared/ids.cpp
+++ b/src/shared/ids.cpp
@@ -24,19 +24,16 @@ namespace boost {
         std::locale::id converter<char>::id;
         converter<char>::~converter() {}
         std::locale::id base_message_format<char>::id;
-        template<> message_format<char>::~message_format() {}
 
         std::locale::id converter<wchar_t>::id;
         converter<wchar_t>::~converter() {}
         std::locale::id base_message_format<wchar_t>::id;
-        template<> message_format<wchar_t>::~message_format() {}
 
         #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
 
         std::locale::id converter<char16_t>::id;
         converter<char16_t>::~converter() {}
         std::locale::id base_message_format<char16_t>::id;
-        template<> message_format<char16_t>::~message_format() {}
 
         #endif
 
@@ -45,7 +42,6 @@ namespace boost {
         std::locale::id converter<char32_t>::id;
         converter<char32_t>::~converter() {}
         std::locale::id base_message_format<char32_t>::id;
-        template<> message_format<char32_t>::~message_format() {}
 
         #endif
 

--- a/src/shared/ids.cpp
+++ b/src/shared/ids.cpp
@@ -17,40 +17,54 @@ namespace boost {
     namespace locale {
 
         std::locale::id info::id;
+        // Make sure we have the VTable here (Export/Import issues)
+        info::~info() {}
         std::locale::id calendar_facet::id;
 
         std::locale::id converter<char>::id;
-        std::locale::id base_message_format<char>::id;
+        converter<char>::~converter() {}
+        template<> std::locale::id message_format<char>::id;
+        template<> message_format<char>::~message_format() {}
 
         std::locale::id converter<wchar_t>::id;
-        std::locale::id base_message_format<wchar_t>::id;
+        converter<wchar_t>::~converter() {}
+        template<> std::locale::id message_format<wchar_t>::id;
+        template<> message_format<wchar_t>::~message_format() {}
 
         #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
 
         std::locale::id converter<char16_t>::id;
-        std::locale::id base_message_format<char16_t>::id;
+        converter<char16_t>::~converter() {}
+        template<> std::locale::id message_format<char16_t>::id;
+        template<> message_format<char16_t>::~message_format() {}
 
         #endif
 
         #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
 
         std::locale::id converter<char32_t>::id;
-        std::locale::id base_message_format<char32_t>::id;
+        converter<char32_t>::~converter() {}
+        template<> std::locale::id message_format<char32_t>::id;
+        template<> message_format<char32_t>::~message_format() {}
 
         #endif
 
         namespace boundary {        
 
             std::locale::id boundary_indexing<char>::id;
+            boundary_indexing<char>::~boundary_indexing() {}
 
             std::locale::id boundary_indexing<wchar_t>::id;
+            boundary_indexing<wchar_t>::~boundary_indexing() {}
 
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
             std::locale::id boundary_indexing<char16_t>::id;
+            boundary_indexing<char16_t>::~boundary_indexing() {}
             #endif
 
             #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             std::locale::id boundary_indexing<char32_t>::id;
+            boundary_indexing<char32_t>::~boundary_indexing() {}
             #endif
         }
 
@@ -77,7 +91,7 @@ namespace boost {
                     std::locale l = std::locale::classic();
                     std::has_facet<boundary::boundary_indexing<Char> >(l);
                     std::has_facet<converter<Char> >(l);
-                    std::has_facet<base_message_format<Char> >(l);
+                    std::has_facet<message_format<Char> >(l);
                 }
             } installer;
         }

--- a/src/shared/ids.cpp
+++ b/src/shared/ids.cpp
@@ -23,19 +23,19 @@ namespace boost {
 
         std::locale::id converter<char>::id;
         converter<char>::~converter() {}
-        template<> std::locale::id message_format<char>::id;
+        std::locale::id base_message_format<char>::id;
         template<> message_format<char>::~message_format() {}
 
         std::locale::id converter<wchar_t>::id;
         converter<wchar_t>::~converter() {}
-        template<> std::locale::id message_format<wchar_t>::id;
+        std::locale::id base_message_format<wchar_t>::id;
         template<> message_format<wchar_t>::~message_format() {}
 
         #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
 
         std::locale::id converter<char16_t>::id;
         converter<char16_t>::~converter() {}
-        template<> std::locale::id message_format<char16_t>::id;
+        std::locale::id base_message_format<char16_t>::id;
         template<> message_format<char16_t>::~message_format() {}
 
         #endif
@@ -44,7 +44,7 @@ namespace boost {
 
         std::locale::id converter<char32_t>::id;
         converter<char32_t>::~converter() {}
-        template<> std::locale::id message_format<char32_t>::id;
+        std::locale::id base_message_format<char32_t>::id;
         template<> message_format<char32_t>::~message_format() {}
 
         #endif

--- a/src/util/codecvt_converter.cpp
+++ b/src/util/codecvt_converter.cpp
@@ -32,6 +32,8 @@
 namespace boost {
 namespace locale {
 namespace util {
+
+    base_converter::~base_converter() {}
     
     class utf8_converter  : public base_converter {
     public:

--- a/src/util/info.cpp
+++ b/src/util/info.cpp
@@ -20,6 +20,7 @@
 namespace boost {
 namespace locale {
 namespace util {
+
     class simple_info : public info {
     public:
         simple_info(std::string const &name,size_t refs = 0) :


### PR DESCRIPTION
UBSAN on OSX reports some invalid downcasts, for example:

```
runtime error: downcast of address 0x7fdd33c08a40 which does not point to an object of type 'const boost::locale::info'
0x7fdd33c08a40: note: object is of type 'boost::locale::util::simple_info'
 dd 7f 00 00  28 ee fe 02 01 00 00 00  00 00 00 00 00 00 00 00  04 65 6e 00 ff 7f 00 00  10 b6 b2 93
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'boost::locale::util::simple_info'
    #0 0x102edf7a3 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > boost::locale::conv::from_utf<char>(char const*, char const*, std::__1::locale const&, boost::locale::conv::method_type)+0x153 (test_std_formatting:x86_64+0x1000207a3)
    #1 0x102edf5e2 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > boost::locale::conv::from_utf<char>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::locale const&, boost::locale::conv::method_type)+0x62 (test_std_formatting:x86_64+0x1000205e2)
    #2 0x102ec6a2b in void test_by_char<char, char>(std::__1::locale const&, std::__1::locale const&)+0x88b (test_std_formatting:x86_64+0x100007a2b)
    #3 0x102ec3db7 in main+0xb27 (test_std_formatting:x86_64+0x100004db7)
    #4 0x7fff6d62acc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)
```
Note that `boost::locale::util::simple_info` is a subclass of `boost::locale::info`, hence the cast is valid.

In most cases the classes were already correctly decorated with `BOOST_LOCALE_DECL` but as the whole class was defined inline the library and the executable linking to it may get different VTables (i.e. an own copy each which the runtime linker doesn't combine)

So far 2 solutions work:

- `BOOST_SYMBOL_VISIBLE` on the class and `BOOST_LOCALE_DECL` on members as required (e.g. static member variables)
- `BOOST_LOCALE_DECL` on the class and adding an out-of-line virtual destructor (likely any virtual method out-of-line will do)

@pdimov explained via Slack

> number two is the correct fix, as it emits the vtable in the library
without it, the vtable is emitted everywhere as a weak definition, and the one in the client isn't VISIBLE
so the types are considered different by ubsan
[number two] emits the vtable once, in the library, which is the right thing for classes that are supposed to reside in the library (what DECL implies)

Hence for most classes I made sure they are decorated with `BOOST_LOCALE_DECL` and have a (virtual) destructor defined in one of the libraries source files.

For template classes this doesn't work directly as defining a member requires defining the class specialization. Hence 2 solutions are used (I mostly kept what was used before):
- Explicitly specialize the template class for the relevant types basically using C&P of the template class body. Then the `BOOST_LOCALE_DECL` + defined (virtual) destructor approach can be used. See e.g. `boundary_indexing` & `converter`
- Use a (very small, templated) base class containing only the inheritance on `std::locale::facet` and the required `std::locale::id` and use the same approach as above (`BOOST_LOCALE_DECL` + dtor) to get the definitions of the ids then inherit from that and decorate that template class with `BOOST_SYMBOL_VISIBLE` to get (unified) VTables. See `(base_)message_format`

There might be a better solution which avoids that C&P specializations by only instantiating the template and [define the static data member specialization](https://en.cppreference.com/w/cpp/language/template_specialization):
> An explicit specialization of a static data member of a template is a definition if the declaration includes an initializer; otherwise, it is a declaration. These definitions must use braces for default initialization: 

But I can't do that for std::locale::id as it isn't copyable and brace-init is C++11 but we still support C++98. Also I'm not sure what happens to the VTable in that case, i.e. how to define and correctly export/import the virtual destructor (and with it the VTable)