### PR TITLE
(Better) support for modern C++

### DIFF
--- a/include/boost/locale/boundary/segment.hpp
+++ b/include/boost/locale/boundary/segment.hpp
@@ -220,13 +220,13 @@ namespace boundary {
         // make sure we override std::pair's operator==
 
         /// Compare two segments
-        bool operator==(segment const &other)
+        bool operator==(segment const &other) const
         {
             return details::compare_text(*this,other) == 0;
         }
 
         /// Compare two segments
-        bool operator!=(segment const &other)
+        bool operator!=(segment const &other) const
         {
             return details::compare_text(*this,other) != 0;
         }

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -152,17 +152,13 @@ namespace locale {
         collator(size_t refs = 0) : std::collate<CharType>(refs) 
         {
         }
-
-        virtual ~collator()
-        {
-        }
         
         ///
         /// This function is used to override default collation function that does not take in account collation level.
         /// Uses primary level
         ///
-        virtual int do_compare( char_type const *b1,char_type const *e1,
-                                char_type const *b2,char_type const *e2) const
+        int do_compare( char_type const *b1,char_type const *e1,
+                        char_type const *b2,char_type const *e2) const BOOST_OVERRIDE
         {
             return do_compare(identical,b1,e1,b2,e2);
         }
@@ -170,7 +166,7 @@ namespace locale {
         /// This function is used to override default collation function that does not take in account collation level.
         /// Uses primary level
         ///
-        virtual string_type do_transform(char_type const *b,char_type const *e) const
+        string_type do_transform(char_type const *b,char_type const *e) const BOOST_OVERRIDE
         {
             return do_transform(identical,b,e);
         }
@@ -178,7 +174,7 @@ namespace locale {
         /// This function is used to override default collation function that does not take in account collation level.
         /// Uses primary level
         ///
-        virtual long do_hash(char_type const *b,char_type const *e) const
+        long do_hash(char_type const *b,char_type const *e) const BOOST_OVERRIDE
         {
             return do_hash(identical,b,e);
         }

--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -31,6 +31,11 @@
 #include <boost/config/auto_link.hpp>
 #endif  // auto-linking disabled
 
+#if defined(BOOST_LOCALE_HIDE_AUTO_PTR) || defined(BOOST_NO_AUTO_PTR)
+#define BOOST_LOCALE_USE_AUTO_PTR 0
+#else
+#define BOOST_LOCALE_USE_AUTO_PTR 1
+#endif
 
 #endif // boost/locale/config.hpp
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/include/boost/locale/date_time_facet.hpp
+++ b/include/boost/locale/date_time_facet.hpp
@@ -222,10 +222,7 @@ namespace boost {
             ///
             virtual bool same(abstract_calendar const *other) const = 0;
 
-            virtual ~abstract_calendar()
-            {
-            }
-
+            virtual ~abstract_calendar() {}
         };
 
         ///

--- a/include/boost/locale/generic_codecvt.hpp
+++ b/include/boost/locale/generic_codecvt.hpp
@@ -166,7 +166,7 @@ public:
 protected:
 
 
-    virtual std::codecvt_base::result do_unshift(std::mbstate_t &s,char *from,char * /*to*/,char *&next) const
+    std::codecvt_base::result do_unshift(std::mbstate_t &s,char *from,char * /*to*/,char *&next) const BOOST_OVERRIDE
     {
         boost::uint16_t &state = *reinterpret_cast<boost::uint16_t *>(&s);
 #ifdef DEBUG_CODECVT            
@@ -177,20 +177,20 @@ protected:
         next=from;
         return std::codecvt_base::ok;
     }
-    virtual int do_encoding() const throw()
+    int do_encoding() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     {
         return 0;
     }
-    virtual int do_max_length() const throw()
+    int do_max_length() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     {
         return implementation().max_encoding_length();
     }
-    virtual bool do_always_noconv() const throw()
+    bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     {
         return false;
     }
 
-    virtual int
+    int
     do_length(  std::mbstate_t 
     #ifdef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
             const   
@@ -198,7 +198,7 @@ protected:
             &std_state,
             char const *from,
             char const *from_end,
-            size_t max) const
+            size_t max) const BOOST_OVERRIDE
     {
         #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
         char const *save_from = from;
@@ -236,14 +236,14 @@ protected:
     }
 
     
-    virtual std::codecvt_base::result 
+    std::codecvt_base::result
     do_in(  std::mbstate_t &std_state,
             char const *from,
             char const *from_end,
             char const *&from_next,
             uchar *to,
             uchar *to_end,
-            uchar *&to_next) const
+            uchar *&to_next) const BOOST_OVERRIDE
     {
         std::codecvt_base::result r=std::codecvt_base::ok;
         
@@ -332,19 +332,19 @@ protected:
         return r;
     }
     
-    virtual std::codecvt_base::result 
+    std::codecvt_base::result
     do_out( std::mbstate_t &std_state,
             uchar const *from,
             uchar const *from_end,
             uchar const *&from_next,
             char *to,
             char *to_end,
-            char *&to_next) const
+            char *&to_next) const BOOST_OVERRIDE
     {
         std::codecvt_base::result r=std::codecvt_base::ok;
         // mbstate_t is POD type and should be initialized to 0 (i.a. state = stateT())
         // according to standard. We assume that sizeof(mbstate_t) >=2 in order
-        // to be able to store first observerd surrogate pair
+        // to be able to store first observed surrogate pair
         //
         // State: state!=0 - a first surrogate pair was observerd (state = first pair),
         // we expect the second one to come and then zero the state
@@ -468,25 +468,25 @@ public:
     
 protected:
 
-    virtual std::codecvt_base::result do_unshift(std::mbstate_t &/*s*/,char *from,char * /*to*/,char *&next) const
+    std::codecvt_base::result do_unshift(std::mbstate_t &/*s*/,char *from,char * /*to*/,char *&next) const BOOST_OVERRIDE
     {
         next=from;
         return std::codecvt_base::ok;
     }
-    virtual int do_encoding() const throw()
+    int do_encoding() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     {
         return 0;
     }
-    virtual int do_max_length() const throw()
+    int do_max_length() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     {
         return implementation().max_encoding_length();
     }
-    virtual bool do_always_noconv() const throw()
+    bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE
     {
         return false;
     }
 
-    virtual int
+    int
     do_length(  std::mbstate_t 
     #ifdef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
             const   
@@ -494,7 +494,7 @@ protected:
             &/*state*/,
             char const *from,
             char const *from_end,
-            size_t max) const
+            size_t max) const BOOST_OVERRIDE
     {
         #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST 
         char const *start_from = from;
@@ -520,14 +520,14 @@ protected:
     }
 
     
-    virtual std::codecvt_base::result 
+    std::codecvt_base::result
     do_in(  std::mbstate_t &/*state*/,
             char const *from,
             char const *from_end,
             char const *&from_next,
             uchar *to,
             uchar *to_end,
-            uchar *&to_next) const
+            uchar *&to_next) const BOOST_OVERRIDE
     {
         std::codecvt_base::result r=std::codecvt_base::ok;
         
@@ -587,14 +587,14 @@ protected:
         return r;
     }
     
-    virtual std::codecvt_base::result 
+    std::codecvt_base::result
     do_out( std::mbstate_t &/*std_state*/,
             uchar const *from,
             uchar const *from_end,
             uchar const *&from_next,
             char *to,
             char *to_end,
-            char *&to_next) const
+            char *&to_next) const BOOST_OVERRIDE
     {
         std::codecvt_base::result r=std::codecvt_base::ok;
         typedef typename CodecvtImpl::state_type state_type;

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -102,7 +102,7 @@ namespace boost {
             ///
             ~localization_backend_manager();
 
-            #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+            #if BOOST_LOCALE_USE_AUTO_PTR
             ///
             /// Create new localization backend according to current settings.
             ///

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -46,13 +46,9 @@ namespace boost {
             void operator=(localization_backend const &);
         public:
 
-            localization_backend()
-            {
-            }
+            localization_backend() {}
             
-            virtual ~localization_backend()
-            {
-            }
+            virtual ~localization_backend() {}
 
             ///
             /// Make a polymorphic copy of the backend

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -170,7 +170,7 @@ namespace util {
         }
     };
 
-    #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+    #if BOOST_LOCALE_USE_AUTO_PTR
     ///
     /// This function creates a \a base_converter that can be used for conversion between UTF-8 and
     /// unicode code points

--- a/src/encoding/conv.hpp
+++ b/src/encoding/conv.hpp
@@ -73,9 +73,7 @@ namespace boost {
                     
                     virtual std::string convert(char const *begin,char const *end) = 0;
                     
-                    virtual ~converter_between()
-                    {
-                    }
+                    virtual ~converter_between() {}
                 };
 
                 template<typename CharType>
@@ -89,9 +87,7 @@ namespace boost {
                     
                     virtual std::string convert(CharType const *begin,CharType const *end) = 0;
                     
-                    virtual ~converter_from_utf()
-                    {
-                    }
+                    virtual ~converter_from_utf() {}
                 };
 
                 template<typename CharType>
@@ -105,9 +101,7 @@ namespace boost {
 
                     virtual string_type convert(char const *begin,char const *end) = 0;
 
-                    virtual ~converter_to_utf()
-                    {
-                    }
+                    virtual ~converter_to_utf() {}
                 };
             }
         }

--- a/src/encoding/iconv_codepage.ipp
+++ b/src/encoding/iconv_codepage.ipp
@@ -147,16 +147,15 @@ public:
 
     typedef CharType char_type;
 
-    virtual bool open(char const *charset,method_type how)
+    bool open(char const *charset,method_type how) BOOST_OVERRIDE
     {
         return self_.do_open(charset,utf_name<CharType>(),how);
     }
 
-    virtual std::string convert(char_type const *ubegin,char_type const *uend)
+    std::string convert(char_type const *ubegin,char_type const *uend) BOOST_OVERRIDE
     {
         return self_.template real_convert<char,char_type>(ubegin,uend);
     }
-    virtual ~iconv_from_utf() {}
 private:
     iconverter_base self_;
 };
@@ -164,15 +163,14 @@ private:
 class iconv_between:  public converter_between
 {
 public:
-    virtual bool open(char const *to_charset,char const *from_charset,method_type how)
+    bool open(char const *to_charset,char const *from_charset,method_type how) BOOST_OVERRIDE
     {
         return self_.do_open(to_charset,from_charset,how);
     }
-    virtual std::string convert(char const *begin,char const *end)
+    std::string convert(char const *begin,char const *end) BOOST_OVERRIDE
     {
         return self_.real_convert<char,char>(begin,end);
     }
-    virtual ~iconv_between() {}
 private:
     iconverter_base self_;
 
@@ -186,16 +184,15 @@ public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
 
-    virtual bool open(char const *charset,method_type how)
+    bool open(char const *charset,method_type how) BOOST_OVERRIDE
     {
         return self_.do_open(utf_name<CharType>(),charset,how);
     }
 
-    virtual string_type convert(char const *begin,char const *end)
+    string_type convert(char const *begin,char const *end) BOOST_OVERRIDE
     {
         return self_.template real_convert<char_type,char>(begin,end);
     }
-    virtual ~iconv_to_utf() {}
 private:
     iconverter_base self_;
 };

--- a/src/encoding/uconv_codepage.ipp
+++ b/src/encoding/uconv_codepage.ipp
@@ -29,7 +29,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        virtual bool open(char const *charset,method_type how)
+        bool open(char const *charset,method_type how) BOOST_OVERRIDE
         {
             close();
             try {
@@ -48,7 +48,7 @@ namespace impl {
             cvt_to_.reset();
         }
 
-        virtual string_type convert(char const *begin,char const *end) 
+        string_type convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             try {
                 return cvt_to_->std(cvt_from_->icu_checked(begin,end));
@@ -73,7 +73,7 @@ namespace impl {
     class uconv_from_utf : public converter_from_utf<CharType> {
     public:
         typedef CharType char_type;
-        virtual bool open(char const *charset,method_type how)
+        bool open(char const *charset,method_type how) BOOST_OVERRIDE
         {
             close();
             try {
@@ -92,7 +92,7 @@ namespace impl {
             cvt_to_.reset();
         }
 
-        virtual std::string convert(CharType const *begin,CharType const *end) 
+        std::string convert(CharType const *begin,CharType const *end) BOOST_OVERRIDE 
         {
             try {
                 return cvt_to_->std(cvt_from_->icu_checked(begin,end));
@@ -114,7 +114,7 @@ namespace impl {
 
     class uconv_between : public converter_between {
     public:
-        virtual bool open(char const *to_charset,char const *from_charset,method_type how)
+        bool open(char const *to_charset,char const *from_charset,method_type how) BOOST_OVERRIDE
         {
             close();
             try {
@@ -133,7 +133,7 @@ namespace impl {
             cvt_to_.reset();
         }
 
-        virtual std::string convert(char const *begin,char const *end) 
+        std::string convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             try {
                 return cvt_to_->std(cvt_from_->icu(begin,end));

--- a/src/encoding/wconv_codepage.ipp
+++ b/src/encoding/wconv_codepage.ipp
@@ -268,7 +268,7 @@ namespace impl {
                 return false;
             return true;
         }
-        virtual std::string convert(char const *begin,char const *end)
+        std::string convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             if(to_code_page_ == 65001 && from_code_page_ == 65001)
                 return utf_to_utf<char>(begin,end,how_);
@@ -321,11 +321,11 @@ namespace impl {
     template<>
     class wconv_to_utf<char,1> : public  converter_to_utf<char> , public wconv_between {
     public:
-        virtual bool open(char const *cs,method_type how) 
+        bool open(char const *cs,method_type how) BOOST_OVERRIDE
         {
             return wconv_between::open("UTF-8",cs,how);
         }
-        virtual std::string convert(char const *begin,char const *end)
+        std::string convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             return wconv_between::convert(begin,end);
         }
@@ -334,11 +334,11 @@ namespace impl {
     template<>
     class wconv_from_utf<char,1> : public  converter_from_utf<char> , public wconv_between {
     public:
-        virtual bool open(char const *cs,method_type how) 
+        bool open(char const *cs,method_type how) BOOST_OVERRIDE
         {
             return wconv_between::open(cs,"UTF-8",how);
         }
-        virtual std::string convert(char const *begin,char const *end)
+        std::string convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             return wconv_between::convert(begin,end);
         }
@@ -357,14 +357,14 @@ namespace impl {
         {
         }
 
-        virtual bool open(char const *charset,method_type how)
+        bool open(char const *charset,method_type how) BOOST_OVERRIDE
         {
             how_ = how;
             code_page_ = encoding_to_windows_codepage(charset);
             return code_page_ != -1;
         }
 
-        virtual string_type convert(char const *begin,char const *end) 
+        string_type convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             if(code_page_ == 65001) {
                 return utf_to_utf<char_type>(begin,end,how_);
@@ -395,14 +395,14 @@ namespace impl {
         {
         }
 
-        virtual bool open(char const *charset,method_type how)
+        bool open(char const *charset,method_type how) BOOST_OVERRIDE
         {
             how_ = how;
             code_page_ = encoding_to_windows_codepage(charset);
             return code_page_ != -1;
         }
 
-        virtual std::string convert(CharType const *begin,CharType const *end) 
+        std::string convert(CharType const *begin,CharType const *end) BOOST_OVERRIDE
         {
             if(code_page_ == 65001) {
                 return utf_to_utf<char>(begin,end,how_);
@@ -459,14 +459,14 @@ namespace impl {
         {
         }
 
-        virtual bool open(char const *charset,method_type how)
+        bool open(char const *charset,method_type how) BOOST_OVERRIDE
         {
             how_ = how;
             code_page_ = encoding_to_windows_codepage(charset);
             return code_page_ != -1;
         }
 
-        virtual string_type convert(char const *begin,char const *end) 
+        string_type convert(char const *begin,char const *end) BOOST_OVERRIDE
         {
             if(code_page_ == 65001) {
                 return utf_to_utf<char_type>(begin,end,how_);
@@ -497,14 +497,14 @@ namespace impl {
         {
         }
 
-        virtual bool open(char const *charset,method_type how)
+        bool open(char const *charset,method_type how) BOOST_OVERRIDE
         {
             how_ = how;
             code_page_ = encoding_to_windows_codepage(charset);
             return code_page_ != -1;
         }
 
-        virtual std::string convert(CharType const *begin,CharType const *end) 
+        std::string convert(CharType const *begin,CharType const *end) BOOST_OVERRIDE
         {
             if(code_page_ == 65001) {
                 return utf_to_utf<char>(begin,end,how_);

--- a/src/icu/codecvt.cpp
+++ b/src/icu/codecvt.cpp
@@ -49,17 +49,17 @@ namespace impl_icu {
             max_len_ = ucnv_getMaxCharSize(cvt_);
         }
         
-        virtual ~uconv_converter()
+        ~uconv_converter()
         {
             ucnv_close(cvt_);
         }
 
-        virtual bool is_thread_safe() const
+        bool is_thread_safe() const BOOST_OVERRIDE
         {
             return false;
         }
 
-        virtual uconv_converter *clone() const
+        uconv_converter *clone() const BOOST_OVERRIDE
         {
             return new uconv_converter(encoding_);
         }
@@ -107,7 +107,7 @@ namespace impl_icu {
             return olen;
         }
 
-        virtual int max_len() const
+        int max_len() const BOOST_OVERRIDE
         {
             return max_len_;
         }

--- a/src/icu/collator.cpp
+++ b/src/icu/collator.cpp
@@ -70,9 +70,9 @@ namespace boost {
                     return do_ustring_compare(level,b1,e1,b2,e2,status);
                 }
 
-                virtual int do_compare( level_type level,
-                                        CharType const *b1,CharType const *e1,
-                                        CharType const *b2,CharType const *e2) const
+                int do_compare(level_type level,
+                               CharType const *b1,CharType const *e1,
+                               CharType const *b2,CharType const *e2) const BOOST_OVERRIDE
                 {
                     UErrorCode status=U_ZERO_ERROR;
                     

--- a/src/icu/conversion.cpp
+++ b/src/icu/conversion.cpp
@@ -69,7 +69,7 @@ namespace impl_icu {
         {
         }
 
-        virtual string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int flags = 0) const
+        string_type convert(converter_base::conversion_type how, char_type const* begin, char_type const* end, int flags = 0) const BOOST_OVERRIDE
         {
             icu_std_converter<char_type> cvt(encoding_);
             icu::UnicodeString str=cvt.icu(begin,end);
@@ -145,7 +145,7 @@ namespace impl_icu {
         {
         }
 
-        virtual std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const
+        std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const BOOST_OVERRIDE
         {
             
             if(how == converter_base::normalization) {

--- a/src/icu/date_time.cpp
+++ b/src/icu/date_time.cpp
@@ -135,14 +135,14 @@ namespace impl_icu {
             return v;
         }
 
-        virtual void set_time(posix_time const &p)
+        void set_time(posix_time const &p) BOOST_OVERRIDE
         {
             double utime = p.seconds * 1000.0 + p.nanoseconds / 1000000.0;
             UErrorCode code=U_ZERO_ERROR;
             calendar_->setTime(utime,code);
             check_and_throw_dt(code);
         }
-        virtual void normalize()
+        void normalize() BOOST_OVERRIDE
         {
             // Can't call complete() explicitly (protected)
             // calling get wich calls complete
@@ -150,7 +150,7 @@ namespace impl_icu {
             calendar_->get(UCAL_YEAR,code);
             check_and_throw_dt(code);
         }
-        virtual posix_time get_time() const
+        posix_time get_time() const BOOST_OVERRIDE
         {
             
             UErrorCode code=U_ZERO_ERROR;
@@ -169,7 +169,7 @@ namespace impl_icu {
                 res.nanoseconds = 999999999;
             return res;
         }
-        virtual void set_option(calendar_option_type opt,int /*v*/) 
+        void set_option(calendar_option_type opt,int /*v*/) BOOST_OVERRIDE
         {
             switch(opt) {
             case is_gregorian:
@@ -180,7 +180,7 @@ namespace impl_icu {
                 ;
             }
         }
-        virtual int get_option(calendar_option_type opt) const
+        int get_option(calendar_option_type opt) const BOOST_OVERRIDE
         {
             switch(opt) {
             case is_gregorian:
@@ -197,7 +197,7 @@ namespace impl_icu {
                 return 0;
             }
         }
-        virtual void adjust_value(period::marks::period_mark p,update_type u,int difference)
+        void adjust_value(period::marks::period_mark p,update_type u,int difference) BOOST_OVERRIDE
         {
             UErrorCode err=U_ZERO_ERROR;
             switch(u) {
@@ -210,7 +210,7 @@ namespace impl_icu {
             }
             check_and_throw_dt(err);
         }
-        virtual int difference(abstract_calendar const *other_ptr,period::marks::period_mark p) const
+        int difference(abstract_calendar const *other_ptr,period::marks::period_mark p) const BOOST_OVERRIDE
         {
             UErrorCode err=U_ZERO_ERROR;
             double other_time = 0;
@@ -236,18 +236,18 @@ namespace impl_icu {
             check_and_throw_dt(err);
             return diff;
         }
-        virtual void set_timezone(std::string const &tz)
+        void set_timezone(std::string const &tz) BOOST_OVERRIDE
         {
             calendar_->adoptTimeZone(get_time_zone(tz));
         }
-        virtual std::string get_timezone() const 
+        std::string get_timezone() const BOOST_OVERRIDE
         {
             icu::UnicodeString tz;
             calendar_->getTimeZone().getID(tz);
             icu_std_converter<char> cvt(encoding_);
             return cvt.std(tz);
         }
-        virtual bool same(abstract_calendar const *other) const 
+        bool same(abstract_calendar const *other) const BOOST_OVERRIDE
         {
             calendar_impl const *oc=dynamic_cast<calendar_impl const *>(other);
             if(!oc)
@@ -269,7 +269,7 @@ namespace impl_icu {
             data_(d)
         {
         }
-        virtual abstract_calendar *create_calendar() const
+        abstract_calendar *create_calendar() const BOOST_OVERRIDE
         {
             return new calendar_impl(data_);
         }

--- a/src/icu/formatter.cpp
+++ b/src/icu/formatter.cpp
@@ -48,14 +48,14 @@ namespace locale {
             typedef CharType char_type;
             typedef std::basic_string<CharType> string_type;
             
-            virtual string_type format(double value,size_t &code_points) const
+            string_type format(double value,size_t &code_points) const BOOST_OVERRIDE
             {
                 icu::UnicodeString tmp;
                 icu_fmt_->format(value,tmp);
                 code_points=tmp.countChar32();
                 return cvt_.std(tmp);
             }
-            virtual string_type format(int64_t value,size_t &code_points) const
+            string_type format(int64_t value,size_t &code_points) const BOOST_OVERRIDE
             {
                 icu::UnicodeString tmp;
                 icu_fmt_->format(static_cast< ::int64_t>(value),tmp);
@@ -63,7 +63,7 @@ namespace locale {
                 return cvt_.std(tmp);
             }
 
-            virtual string_type format(int32_t value,size_t &code_points) const
+            string_type format(int32_t value,size_t &code_points) const BOOST_OVERRIDE
             {
                 icu::UnicodeString tmp;
                 #ifdef __SUNPRO_CC 
@@ -75,16 +75,16 @@ namespace locale {
                 return cvt_.std(tmp);
             }
 
-            virtual size_t parse(string_type const &str,double &value) const 
+            size_t parse(string_type const &str,double &value) const BOOST_OVERRIDE
             {
                 return do_parse(str,value);
             }
 
-            virtual size_t parse(string_type const &str,int64_t &value) const 
+            size_t parse(string_type const &str,int64_t &value) const BOOST_OVERRIDE
             {
                 return do_parse(str,value);
             }
-            virtual size_t parse(string_type const &str,int32_t &value) const
+            size_t parse(string_type const &str,int32_t &value) const BOOST_OVERRIDE
             {
                 return do_parse(str,value);
             }
@@ -155,29 +155,29 @@ namespace locale {
             typedef CharType char_type;
             typedef std::basic_string<CharType> string_type;
             
-            virtual string_type format(double value,size_t &code_points) const
+            string_type format(double value,size_t &code_points) const BOOST_OVERRIDE
             {
                 return do_format(value,code_points);
             }
-            virtual string_type format(int64_t value,size_t &code_points) const
-            {
-                return do_format(value,code_points);
-            }
-
-            virtual string_type format(int32_t value,size_t &code_points) const
+            string_type format(int64_t value,size_t &code_points) const BOOST_OVERRIDE
             {
                 return do_format(value,code_points);
             }
 
-            virtual size_t parse(string_type const &str,double &value) const 
+            string_type format(int32_t value,size_t &code_points) const BOOST_OVERRIDE
+            {
+                return do_format(value,code_points);
+            }
+
+            size_t parse(string_type const &str,double &value) const BOOST_OVERRIDE
             {
                 return do_parse(str,value);
             }
-            virtual size_t parse(string_type const &str,int64_t &value) const 
+            size_t parse(string_type const &str,int64_t &value) const BOOST_OVERRIDE
             {
                 return do_parse(str,value);
             }
-            virtual size_t parse(string_type const &str,int32_t &value) const
+            size_t parse(string_type const &str,int32_t &value) const BOOST_OVERRIDE
             {
                 return do_parse(str,value);
             }

--- a/src/icu/formatter.hpp
+++ b/src/icu/formatter.hpp
@@ -24,9 +24,7 @@ namespace impl_icu {
 
     class base_formatter {
     public:
-        virtual ~base_formatter()
-        {
-        }
+        virtual ~base_formatter() {}
     };
 
     ///
@@ -88,10 +86,6 @@ namespace impl_icu {
         /// Would create a new spelling formatter only once.
         ///
         static formatter *create(std::ios_base &ios,icu::Locale const &l,std::string const &enc);
-
-        virtual ~formatter()
-        {
-        }
     }; // class formatter
     
     ///

--- a/src/icu/icu_backend.cpp
+++ b/src/icu/icu_backend.cpp
@@ -37,7 +37,7 @@ namespace impl_icu {
             use_ansi_encoding_(other.use_ansi_encoding_)
         {
         }
-        virtual icu_localization_backend *clone() const
+        icu_localization_backend *clone() const BOOST_OVERRIDE
         {
             return new icu_localization_backend(*this);
         }
@@ -86,9 +86,9 @@ namespace impl_icu {
             variant_ = d.variant;
         }
         
-        virtual std::locale install(std::locale const &base,
-                                    locale_category_type category,
-                                    character_facet_type type = nochar_facet)
+        std::locale install(std::locale const &base,
+                            locale_category_type category,
+                            character_facet_type type = nochar_facet) BOOST_OVERRIDE
         {
             prepare_data();
 

--- a/src/icu/numeric.cpp
+++ b/src/icu/numeric.cpp
@@ -127,29 +127,29 @@ public:
 protected: 
     
 
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long val) const
+    iter_type do_put(iter_type out, std::ios_base& ios, char_type fill, long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, double val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, double val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long double val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long double val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
     
     #ifndef BOOST_NO_LONG_LONG 
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
@@ -226,48 +226,48 @@ protected:
     typedef hold_ptr<formatter_type> formatter_ptr;
     typedef std::basic_istream<CharType> stream_type;
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned short &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned short &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned int &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned int &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,float &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,float &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,double &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,double &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long double &val) const
+    iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long double &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
     #ifndef BOOST_NO_LONG_LONG 
-    virtual iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long long &val) const
+    iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long long &val) const
+    iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }

--- a/src/posix/codecvt.cpp
+++ b/src/posix/codecvt.cpp
@@ -96,26 +96,25 @@ namespace impl_posix {
         {
         }
         
-        virtual ~mb2_iconv_converter()
+        ~mb2_iconv_converter()
         {
             if(to_utf_ != (iconv_t)(-1))
                 iconv_close(to_utf_);
             if(from_utf_ != (iconv_t)(-1))
                 iconv_close(from_utf_);
-
         }
 
-        virtual bool is_thread_safe() const
+        bool is_thread_safe() const BOOST_OVERRIDE
         {
             return false;
         }
 
-        virtual mb2_iconv_converter *clone() const
+        mb2_iconv_converter *clone() const BOOST_OVERRIDE
         {
             return new mb2_iconv_converter(*this);
         }
 
-        uint32_t to_unicode(char const *&begin,char const *end)
+        uint32_t to_unicode(char const *&begin,char const *end) BOOST_OVERRIDE
         {
             if(begin == end)
                 return incomplete;
@@ -149,7 +148,7 @@ namespace impl_posix {
             return illegal;
         }
 
-        uint32_t from_unicode(uint32_t cp,char *begin,char const *end)
+        uint32_t from_unicode(uint32_t cp,char *begin,char const *end) BOOST_OVERRIDE
         {
             if(cp == 0) {
                 if(begin!=end) {
@@ -200,7 +199,7 @@ namespace impl_posix {
                 return "UTF-32BE";
         }
 
-        virtual int max_len() const
+        int max_len() const BOOST_OVERRIDE
         {
             return 2;
         }

--- a/src/posix/collate.cpp
+++ b/src/posix/collate.cpp
@@ -63,10 +63,8 @@ public:
         lc_(l)
     {
     }
-    virtual ~collator()
-    {
-    }
-    virtual int do_compare(char_type const *lb,char_type const *le,char_type const *rb,char_type const *re) const
+
+    int do_compare(char_type const *lb,char_type const *le,char_type const *rb,char_type const *re) const BOOST_OVERRIDE
     {
         string_type left(lb,le-lb);
         string_type right(rb,re-rb);
@@ -77,14 +75,14 @@ public:
             return 1;
         return 0;
     }
-    virtual long do_hash(char_type const *b,char_type const *e) const
+    long do_hash(char_type const *b,char_type const *e) const BOOST_OVERRIDE
     {
         string_type s(do_transform(b,e));
         char const *begin = reinterpret_cast<char const *>(s.c_str());
         char const *end = begin + s.size() * sizeof(char_type);
         return gnu_gettext::pj_winberger_hash_function(begin,end);
     }
-    virtual string_type do_transform(char_type const *b,char_type const *e) const
+    string_type do_transform(char_type const *b,char_type const *e) const BOOST_OVERRIDE
     {
         string_type s(b,e-b);
         std::vector<char_type> buf((e-b)*2+1);

--- a/src/posix/converter.cpp
+++ b/src/posix/converter.cpp
@@ -67,7 +67,7 @@ public:
         lc_(lc)
     {
     }
-    virtual string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int /*flags*/ = 0) const 
+    string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int /*flags*/ = 0) const BOOST_OVERRIDE
     {
         switch(how) {
         case converter_base::upper_case:
@@ -104,7 +104,7 @@ public:
         lc_(lc)
     {
     }
-    virtual std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int /*flags*/ = 0) const 
+    std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int /*flags*/ = 0) const BOOST_OVERRIDE
     {
         switch(how) {
         case upper_case:

--- a/src/posix/numeric.cpp
+++ b/src/posix/numeric.cpp
@@ -52,7 +52,7 @@ public:
     }
 protected: 
 
-    virtual iter_type do_format_currency(bool intl,iter_type out,std::ios_base &/*ios*/,char_type /*fill*/,long double val) const
+    iter_type do_format_currency(bool intl,iter_type out,std::ios_base &/*ios*/,char_type /*fill*/,long double val) const BOOST_OVERRIDE
     {
         char buf[4]={};
         char const *format = intl ? "%i" : "%n";
@@ -154,14 +154,11 @@ public:
         lc_(lc)
     {
     }
-    virtual ~time_put_posix()
-    {
-    }
     typedef typename std::time_put<CharType>::iter_type iter_type;
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
 
-    virtual iter_type do_put(iter_type out,std::ios_base &/*ios*/,CharType /*fill*/,std::tm const *tm,char format,char modifier) const
+    iter_type do_put(iter_type out,std::ios_base &/*ios*/,CharType /*fill*/,std::tm const *tm,char format,char modifier) const BOOST_OVERRIDE
     {
         char_type fmt[4] = { '%' , modifier != 0 ? modifier : format , modifier == 0 ? '\0' : format };
         string_type res = ftime_traits<char_type>::ftime(fmt,tm,*lc_);
@@ -427,24 +424,24 @@ public:
     {
         s2=conv::to_utf<wchar_t>(s1,nl_langinfo_l(CODESET,lc));
     }
-    virtual CharType do_decimal_point() const
+    CharType do_decimal_point() const BOOST_OVERRIDE
     {
         return *decimal_point_.c_str();
     }
-    virtual CharType do_thousands_sep() const
+    CharType do_thousands_sep() const BOOST_OVERRIDE
     {
         return *thousands_sep_.c_str();
     }
-    virtual std::string do_grouping() const
+    std::string do_grouping() const BOOST_OVERRIDE
     {
         return grouping_;
     }
-    virtual string_type do_truename() const
+    string_type do_truename() const BOOST_OVERRIDE
     {
         static const char t[]="true";
         return string_type(t,t+sizeof(t)-1);
     }
-    virtual string_type do_falsename() const
+    string_type do_falsename() const BOOST_OVERRIDE
     {
         static const char t[]="false";
         return string_type(t,t+sizeof(t)-1);

--- a/src/posix/posix_backend.cpp
+++ b/src/posix/posix_backend.cpp
@@ -41,12 +41,12 @@ namespace impl_posix {
             invalid_(true)
         {
         }
-        virtual posix_localization_backend *clone() const
+        posix_localization_backend *clone() const BOOST_OVERRIDE
         {
             return new posix_localization_backend(*this);
         }
 
-        void set_option(std::string const &name,std::string const &value) 
+        void set_option(std::string const &name,std::string const &value) BOOST_OVERRIDE
         {
             invalid_ = true;
             if(name=="locale")
@@ -57,7 +57,7 @@ namespace impl_posix {
                 domains_.push_back(value);
 
         }
-        void clear_options()
+        void clear_options() BOOST_OVERRIDE
         {
             invalid_ = true;
             locale_id_.clear();
@@ -104,9 +104,9 @@ namespace impl_posix {
             lc_ = boost::shared_ptr<locale_t>(tmp_p,free_locale_by_ptr);
         }
         
-        virtual std::locale install(std::locale const &base,
-                                    locale_category_type category,
-                                    character_facet_type type = nochar_facet)
+        std::locale install(std::locale const &base,
+                            locale_category_type category,
+                            character_facet_type type = nochar_facet) BOOST_OVERRIDE
         {
             prepare_data();
 

--- a/src/shared/localization_backend.cpp
+++ b/src/shared/localization_backend.cpp
@@ -181,7 +181,7 @@ namespace boost {
         }
 
 
-        #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+        #if BOOST_LOCALE_USE_AUTO_PTR
         std::auto_ptr<localization_backend> localization_backend_manager::get() const
         {
             std::auto_ptr<localization_backend> r(pimpl_->create());

--- a/src/shared/localization_backend.cpp
+++ b/src/shared/localization_backend.cpp
@@ -116,21 +116,21 @@ namespace boost {
                         backends_[i].reset(backends[i]->clone());
                     }
                 }
-                virtual actual_backend *clone() const 
+                actual_backend *clone() const BOOST_OVERRIDE
                 {
                     return new actual_backend(backends_,index_);
                 }
-                virtual void set_option(std::string const &name,std::string const &value)
+                void set_option(std::string const &name,std::string const &value) BOOST_OVERRIDE
                 {
                     for(unsigned i=0;i<backends_.size();i++)
                         backends_[i]->set_option(name,value);
                 }
-                virtual void clear_options()
+                void clear_options() BOOST_OVERRIDE
                 {
                     for(unsigned i=0;i<backends_.size();i++)
                         backends_[i]->clear_options();
                 }
-                virtual std::locale install(std::locale const &l,locale_category_type category,character_facet_type type = nochar_facet)
+                std::locale install(std::locale const &l,locale_category_type category,character_facet_type type = nochar_facet) BOOST_OVERRIDE
                 {
                     int id;
                     unsigned v;

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -500,12 +500,12 @@ namespace boost {
 
                 typedef std::pair<CharType const *,CharType const *> pair_type;
 
-                virtual char_type const *get(int domain_id,char_type const *context,char_type const *id) const
+                char_type const *get(int domain_id,char_type const *context,char_type const *id) const BOOST_OVERRIDE
                 {
                     return get_string(domain_id,context,id).first;
                 }
 
-                virtual char_type const *get(int domain_id,char_type const *context,char_type const *single_id,int n) const
+                char_type const *get(int domain_id,char_type const *context,char_type const *single_id,int n) const BOOST_OVERRIDE
                 {
                     pair_type ptr = get_string(domain_id,context,single_id);
                     if(!ptr.first)
@@ -528,7 +528,7 @@ namespace boost {
                     return p;
                 }
 
-                virtual int domain(std::string const &domain) const
+                int domain(std::string const &domain) const BOOST_OVERRIDE
                 {
                     domains_map_type::const_iterator p=domains_.find(domain);
                     if(p==domains_.end())
@@ -584,13 +584,9 @@ namespace boost {
                     }
                 }
                 
-                char_type const *convert(char_type const *msg,string_type &buffer) const 
+                char_type const *convert(char_type const *msg,string_type &buffer) const BOOST_OVERRIDE
                 {
                     return runtime_conversion<char_type>(msg,buffer,key_conversion_required_,locale_encoding_,key_encoding_);
-                }
-
-                virtual ~mo_message()
-                {
                 }
 
             private:

--- a/src/shared/mo_lambda.cpp
+++ b/src/shared/mo_lambda.cpp
@@ -16,11 +16,11 @@ namespace lambda {
 
 namespace { // anon
     struct identity : public plural {
-        virtual int operator()(int n) const 
+        int operator()(int n) const BOOST_OVERRIDE
         {
             return n;
         };
-        virtual identity *clone() const
+        identity *clone() const BOOST_OVERRIDE
         {
             return new identity();
         }
@@ -54,11 +54,11 @@ namespace { // anon
             val(v)
         {
         }
-        virtual int operator()(int /*n*/) const 
+        int operator()(int /*n*/) const BOOST_OVERRIDE
         {
             return val;
         }
-        virtual number *clone() const
+        number *clone() const BOOST_OVERRIDE
         {
             return new number(val);
         }
@@ -72,11 +72,11 @@ namespace { // anon
         name(plural_ptr op) : unary(op)             \
         {                                           \
         };                                          \
-        virtual int operator()(int n) const         \
+        int operator()(int n) const BOOST_OVERRIDE  \
         {                                           \
             return oper (*op1)(n);                  \
         }                                           \
-        virtual name *clone() const                 \
+        name *clone() const BOOST_OVERRIDE          \
         {                                           \
             plural_ptr op1_copy(op1->clone());      \
             return new name(op1_copy);              \
@@ -91,11 +91,11 @@ namespace { // anon
         {                                           \
         }                                           \
                                                     \
-        virtual int operator()(int n) const         \
+        int operator()(int n) const BOOST_OVERRIDE \
         {                                           \
             return (*op1)(n) oper (*op2)(n);        \
         }                                           \
-        virtual name *clone() const                 \
+        name *clone() const BOOST_OVERRIDE          \
         {                                           \
             plural_ptr op1_copy(op1->clone());      \
             plural_ptr op2_copy(op2->clone());      \
@@ -109,13 +109,13 @@ namespace { // anon
             binary(p1,p2)                           \
         {                                           \
         }                                           \
-        virtual int operator()(int n) const         \
+        int operator()(int n) const BOOST_OVERRIDE  \
         {                                           \
             int v1=(*op1)(n);                       \
             int v2=(*op2)(n);                       \
             return v2==0 ? 0 : v1 oper v2;          \
         }                                           \
-        virtual name *clone() const                 \
+        name *clone() const BOOST_OVERRIDE          \
         {                                           \
             plural_ptr op1_copy(op1->clone());      \
             plural_ptr op2_copy(op2->clone());      \
@@ -174,11 +174,11 @@ namespace { // anon
              op3(p3)
         {
         }
-        virtual int operator()(int n) const
+        int operator()(int n) const BOOST_OVERRIDE
         {
             return (*op1)(n) ? (*op2)(n) : (*op3)(n);
         }
-        virtual conditional *clone() const                 
+        conditional *clone() const BOOST_OVERRIDE
         {                                           
             plural_ptr op1_copy(op1->clone());      
             plural_ptr op2_copy(op2->clone());      

--- a/src/shared/mo_lambda.hpp
+++ b/src/shared/mo_lambda.hpp
@@ -19,9 +19,7 @@ namespace boost {
 
                     virtual int operator()(int n) const = 0;
                     virtual plural *clone() const = 0;
-                    virtual ~plural()
-                    {
-                    }
+                    virtual ~plural() {}
                 };
 
                 typedef boost::shared_ptr<plural> plural_ptr;

--- a/src/std/collate.cpp
+++ b/src/std/collate.cpp
@@ -24,19 +24,19 @@ public:
         base_(base)
     {
     }
-    virtual int do_compare(char const *lb,char const *le,char const *rb,char const *re) const
+    int do_compare(char const *lb,char const *le,char const *rb,char const *re) const BOOST_OVERRIDE
     {
         std::wstring l=conv::to_utf<wchar_t>(lb,le,"UTF-8");
         std::wstring r=conv::to_utf<wchar_t>(rb,re,"UTF-8");
         return std::use_facet<wfacet>(base_).compare(   l.c_str(),l.c_str()+l.size(),
                                                         r.c_str(),r.c_str()+r.size());
     }
-    virtual long do_hash(char const *b,char const *e) const
+    long do_hash(char const *b,char const *e) const BOOST_OVERRIDE
     {
         std::wstring tmp=conv::to_utf<wchar_t>(b,e,"UTF-8");
         return std::use_facet<wfacet>(base_).hash(tmp.c_str(),tmp.c_str()+tmp.size());
     }
-    virtual std::string do_transform(char const *b,char const *e) const
+    std::string do_transform(char const *b,char const *e) const BOOST_OVERRIDE
     {
         std::wstring tmp=conv::to_utf<wchar_t>(b,e,"UTF-8");
         std::wstring wkey = 

--- a/src/std/converter.cpp
+++ b/src/std/converter.cpp
@@ -40,7 +40,7 @@ public:
         base_(base)
     {
     }
-    virtual string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int /*flags*/ = 0) const 
+    string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int /*flags*/ = 0) const BOOST_OVERRIDE
     {
         switch(how) {
         case converter_base::upper_case:
@@ -75,7 +75,7 @@ public:
         base_(base)
     {
     }
-    virtual std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int /*flags*/ = 0) const 
+    std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int /*flags*/ = 0) const BOOST_OVERRIDE
     {
         switch(how) {
         case upper_case:

--- a/src/std/numeric.cpp
+++ b/src/std/numeric.cpp
@@ -32,7 +32,7 @@ public:
     }
     typedef typename std::time_put<CharType>::iter_type iter_type;
 
-    virtual iter_type do_put(iter_type out,std::ios_base &/*ios*/,CharType fill,std::tm const *tm,char format,char modifier) const
+    iter_type do_put(iter_type out,std::ios_base &/*ios*/,CharType fill,std::tm const *tm,char format,char modifier) const BOOST_OVERRIDE
     {
         std::basic_stringstream<CharType> ss;
         ss.imbue(base_);
@@ -49,7 +49,7 @@ public:
         base_(base)
     {
     }
-    virtual iter_type do_put(iter_type out,std::ios_base &/*ios*/,char fill,std::tm const *tm,char format,char modifier = 0) const
+    iter_type do_put(iter_type out,std::ios_base &/*ios*/,char fill,std::tm const *tm,char format,char modifier = 0) const BOOST_OVERRIDE
     {
         std::basic_ostringstream<wchar_t> wtmps;
         wtmps.imbue(base_);
@@ -105,23 +105,23 @@ public:
         }
     }
 
-    virtual char do_decimal_point() const
+    char do_decimal_point() const BOOST_OVERRIDE
     {
         return decimal_point_;
     }
-    virtual char do_thousands_sep() const
+    char do_thousands_sep() const BOOST_OVERRIDE
     {
         return thousands_sep_;
     }
-    virtual std::string do_grouping() const
+    std::string do_grouping() const BOOST_OVERRIDE
     {
         return grouping_;
     }
-    virtual std::string do_truename() const
+    std::string do_truename() const BOOST_OVERRIDE
     {
         return truename_;
     }
-    virtual std::string do_falsename() const
+    std::string do_falsename() const BOOST_OVERRIDE
     {
         return falsename_;
     }
@@ -178,45 +178,45 @@ public:
         }
     }
 
-    virtual char do_decimal_point() const
+    char do_decimal_point() const BOOST_OVERRIDE
     {
         return decimal_point_;
     }
 
-    virtual char do_thousands_sep() const
+    char do_thousands_sep() const BOOST_OVERRIDE
     {
         return thousands_sep_;
     }
 
-    virtual std::string do_grouping() const
+    std::string do_grouping() const BOOST_OVERRIDE
     {
         return grouping_;
     }
 
-    virtual std::string do_curr_symbol() const
+    std::string do_curr_symbol() const BOOST_OVERRIDE
     {
         return curr_symbol_;
     }
-    virtual std::string do_positive_sign () const
+    std::string do_positive_sign () const BOOST_OVERRIDE
     {
         return positive_sign_;
     }
-    virtual std::string do_negative_sign() const
+    std::string do_negative_sign() const BOOST_OVERRIDE
     {
         return negative_sign_;
     }
 
-    virtual int do_frac_digits() const
+    int do_frac_digits() const BOOST_OVERRIDE
     {
         return frac_digits_;
     }
 
-    virtual std::money_base::pattern do_pos_format() const
+    std::money_base::pattern do_pos_format() const BOOST_OVERRIDE
     {
         return pos_format_;
     }
 
-    virtual std::money_base::pattern do_neg_format() const
+    std::money_base::pattern do_neg_format() const BOOST_OVERRIDE
     {
         return neg_format_;
     }
@@ -240,7 +240,7 @@ public:
         std::numpunct_byname<char>(name,refs)
     {
     }
-    virtual char do_thousands_sep() const
+    char do_thousands_sep() const BOOST_OVERRIDE
     {
         unsigned char bs = base_type::do_thousands_sep();
         if(bs > 127)
@@ -251,7 +251,7 @@ public:
         else
             return bs;
     }
-    virtual std::string do_grouping() const
+    std::string do_grouping() const BOOST_OVERRIDE
     {
         unsigned char bs = base_type::do_thousands_sep();
         if(bs > 127 && bs != 0xA0)
@@ -268,7 +268,7 @@ public:
         std::moneypunct_byname<char,Intl>(name,refs)
     {
     }
-    virtual char do_thousands_sep() const
+    char do_thousands_sep() const BOOST_OVERRIDE
     {
         unsigned char bs = base_type::do_thousands_sep();
         if(bs > 127)
@@ -279,7 +279,7 @@ public:
         else
             return bs;
     }
-    virtual std::string do_grouping() const
+    std::string do_grouping() const BOOST_OVERRIDE
     {
         unsigned char bs = base_type::do_thousands_sep();
         if(bs > 127 && bs != 0xA0)

--- a/src/std/std_backend.cpp
+++ b/src/std/std_backend.cpp
@@ -46,12 +46,12 @@ namespace impl_std {
             use_ansi_encoding_(other.use_ansi_encoding_)
         {
         }
-        virtual std_localization_backend *clone() const
+        std_localization_backend *clone() const BOOST_OVERRIDE
         {
             return new std_localization_backend(*this);
         }
 
-        void set_option(std::string const &name,std::string const &value) 
+        void set_option(std::string const &name,std::string const &value) BOOST_OVERRIDE
         {
             invalid_ = true;
             if(name=="locale")
@@ -64,7 +64,7 @@ namespace impl_std {
                 use_ansi_encoding_ = value == "true";
 
         }
-        void clear_options()
+        void clear_options() BOOST_OVERRIDE
         {
             invalid_ = true;
             use_ansi_encoding_ = false;
@@ -157,9 +157,9 @@ namespace impl_std {
             }
         }
         
-        virtual std::locale install(std::locale const &base,
+        std::locale install(std::locale const &base,
                                     locale_category_type category,
-                                    character_facet_type type = nochar_facet)
+                                    character_facet_type type = nochar_facet) BOOST_OVERRIDE
         {
             prepare_data();
 

--- a/src/util/codecvt_converter.cpp
+++ b/src/util/codecvt_converter.cpp
@@ -37,22 +37,22 @@ namespace util {
     
     class utf8_converter  : public base_converter {
     public:
-        virtual int max_len() const
+        int max_len() const BOOST_OVERRIDE
         {
             return 4;
         }
 
-        virtual utf8_converter *clone() const
+        utf8_converter *clone() const BOOST_OVERRIDE
         {
             return new utf8_converter();
         }
 
-        bool is_thread_safe() const
+        bool is_thread_safe() const BOOST_OVERRIDE
         {
             return true;
         }
 
-        virtual uint32_t to_unicode(char const *&begin,char const *end)
+        uint32_t to_unicode(char const *&begin,char const *end) BOOST_OVERRIDE
         {
             char const *p=begin;
                         
@@ -68,7 +68,7 @@ namespace util {
             return c;
         }
 
-        virtual uint32_t from_unicode(uint32_t u,char *begin,char const *end) 
+        uint32_t from_unicode(uint32_t u,char *begin,char const *end) BOOST_OVERRIDE
         {
             if(!utf::is_valid_codepoint(u))
                 return illegal;
@@ -151,34 +151,30 @@ namespace util {
     class simple_converter : public base_converter {
     public:
 
-        virtual ~simple_converter() 
-        {
-        }
-
         simple_converter(std::string const &encoding) : 
             cvt_(encoding)
         {
         }
 
-        virtual int max_len() const 
+        int max_len() const BOOST_OVERRIDE
         {
             return 1;
         }
 
-        virtual bool is_thread_safe() const 
+        bool is_thread_safe() const BOOST_OVERRIDE
         {
             return true;
         }
-        virtual base_converter *clone() const 
+        base_converter *clone() const BOOST_OVERRIDE
         {
            return new simple_converter(*this); 
         }
 
-        virtual uint32_t to_unicode(char const *&begin,char const *end)
+        uint32_t to_unicode(char const *&begin,char const *end) BOOST_OVERRIDE
         {
             return cvt_.to_unicode(begin,end);
         }
-        virtual uint32_t from_unicode(uint32_t u,char *begin,char const *end)
+        uint32_t from_unicode(uint32_t u,char *begin,char const *end) BOOST_OVERRIDE
         {
             return cvt_.from_unicode(u,begin,end);
         }

--- a/src/util/codecvt_converter.cpp
+++ b/src/util/codecvt_converter.cpp
@@ -271,7 +271,7 @@ namespace util {
         return 0;
     }
     
-    #if !defined(BOOST_LOCALE_HIDE_AUTO_PTR) && !defined(BOOST_NO_AUTO_PTR)
+    #if BOOST_LOCALE_USE_AUTO_PTR
     std::auto_ptr<base_converter> create_utf8_converter()
     {
         std::auto_ptr<base_converter> res(create_utf8_converter_new_ptr());

--- a/src/util/gregorian.cpp
+++ b/src/util/gregorian.cpp
@@ -156,7 +156,7 @@ namespace util {
             ///
             /// Make a polymorphic copy of the calendar
             ///
-            virtual gregorian_calendar *clone() const
+            gregorian_calendar *clone() const BOOST_OVERRIDE
             {
                 return new gregorian_calendar(*this);
             }
@@ -164,7 +164,7 @@ namespace util {
             ///
             /// Set specific \a value for period \a p, note not all values are settable.
             ///
-            virtual void set_value(period::marks::period_mark p,int value) 
+            void set_value(period::marks::period_mark p,int value) BOOST_OVERRIDE
             {
                 using namespace period::marks;
                 switch(p) {
@@ -226,12 +226,12 @@ namespace util {
                 normalized_ = false;
             }
 
-            void normalize()
+            void normalize() BOOST_OVERRIDE
             {
                 if(!normalized_) {
                     std::tm val = tm_updated_;
                     val.tm_isdst = -1;
-                    val.tm_wday = -1; // indecator of error
+                    val.tm_wday = -1; // indicator of error
                     std::time_t point = -1;
                     if(is_local_) {
                         point = std::mktime(&val);
@@ -300,7 +300,7 @@ namespace util {
             ///
             /// Get specific value for period \a p according to a value_type \a v
             ///
-            virtual int get_value(period::marks::period_mark p,value_type v) const 
+            int get_value(period::marks::period_mark p,value_type v) const BOOST_OVERRIDE
             {
                 using namespace period::marks;
                 switch(p) {
@@ -560,11 +560,11 @@ namespace util {
             ///
             /// Set current time point
             ///
-            virtual void set_time(posix_time const &p)
+            void set_time(posix_time const &p) BOOST_OVERRIDE
             {
                 from_time(static_cast<std::time_t>(p.seconds));
             }
-            virtual posix_time get_time() const  
+            posix_time get_time() const BOOST_OVERRIDE
             {
                 posix_time pt = { time_, 0};
                 return pt;
@@ -573,7 +573,7 @@ namespace util {
             ///
             /// Set option for calendar, for future use
             ///
-            virtual void set_option(calendar_option_type opt,int /*v*/)
+            void set_option(calendar_option_type opt,int /*v*/) BOOST_OVERRIDE
             {
                 switch(opt) {
                 case is_gregorian:
@@ -587,7 +587,7 @@ namespace util {
             ///
             /// Get option for calendar, currently only check if it is Gregorian calendar
             ///
-            virtual int get_option(calendar_option_type opt) const 
+            int get_option(calendar_option_type opt) const BOOST_OVERRIDE
             {
                 switch(opt) {
                 case is_gregorian:
@@ -603,7 +603,7 @@ namespace util {
             /// Adjust period's \a p value by \a difference items using a update_type \a u.
             /// Note: not all values are adjustable
             ///
-            virtual void adjust_value(period::marks::period_mark p,update_type u,int difference)
+            void adjust_value(period::marks::period_mark p,update_type u,int difference) BOOST_OVERRIDE
             {
                 switch(u) {
                 case move:
@@ -691,7 +691,7 @@ namespace util {
             ///
             /// Calculate the difference between this calendar  and \a other in \a p units
             ///
-            virtual int difference(abstract_calendar const *other_cal,period::marks::period_mark p) const 
+            int difference(abstract_calendar const *other_cal,period::marks::period_mark p) const BOOST_OVERRIDE
             {
                 hold_ptr<gregorian_calendar> keeper;
                 gregorian_calendar const *other = dynamic_cast<gregorian_calendar const *>(other_cal);
@@ -753,7 +753,7 @@ namespace util {
             ///
             /// Set time zone, empty - use system
             ///
-            virtual void set_timezone(std::string const &tz)
+            void set_timezone(std::string const &tz) BOOST_OVERRIDE
             {
                 if(tz.empty()) {
                     is_local_ = true;
@@ -766,12 +766,12 @@ namespace util {
                 from_time(time_);
                 time_zone_name_ = tz;
             }
-            virtual std::string get_timezone() const
+            std::string get_timezone() const BOOST_OVERRIDE
             {
                 return time_zone_name_;
             }
 
-            virtual bool same(abstract_calendar const *other) const 
+            bool same(abstract_calendar const *other) const BOOST_OVERRIDE
             {
                 gregorian_calendar const *gcal = dynamic_cast<gregorian_calendar const *>(other);
                 if(!gcal)
@@ -780,10 +780,6 @@ namespace util {
                     gcal->tzoff_ == tzoff_ 
                     && gcal->is_local_ == is_local_
                     && gcal->first_day_of_week_  == first_day_of_week_;
-            }
-
-            virtual ~gregorian_calendar()
-            {
             }
 
     private:
@@ -830,7 +826,7 @@ namespace util {
             terr_(terr)
         {
         }
-        virtual abstract_calendar *create_calendar() const 
+        abstract_calendar *create_calendar() const BOOST_OVERRIDE
         {
             return create_gregorian_calendar(terr_);
         }

--- a/src/util/info.cpp
+++ b/src/util/info.cpp
@@ -29,7 +29,7 @@ namespace util {
         {
             d.parse(name);
         }
-        virtual std::string get_string_property(string_propery v) const
+        std::string get_string_property(string_propery v) const BOOST_OVERRIDE
         {
             switch(v) {
             case language_property:
@@ -47,7 +47,7 @@ namespace util {
             };
         }
 
-        virtual int get_integer_property(integer_property v) const
+        int get_integer_property(integer_property v) const BOOST_OVERRIDE
         {
             switch(v) {
             case utf8_property:

--- a/src/util/numeric.hpp
+++ b/src/util/numeric.hpp
@@ -76,29 +76,29 @@ public:
 protected: 
     
 
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, double val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, double val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long double val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long double val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
     
     #ifndef BOOST_NO_LONG_LONG 
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
-    virtual iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long long val) const
+    iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, unsigned long long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
     }
@@ -268,48 +268,48 @@ protected:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned short &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned short &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned int &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned int &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,float &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,float &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,double &val) const
+    iter_type do_get(iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,double &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long double &val) const
+    iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long double &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
     #ifndef BOOST_NO_LONG_LONG 
-    virtual iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long long &val) const
+    iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }
 
-    virtual iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long long &val) const
+    iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,unsigned long long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
     }

--- a/src/win32/collate.cpp
+++ b/src/win32/collate.cpp
@@ -25,18 +25,18 @@ public:
         lc_(lc)
     {
     }
-    virtual int do_compare(collator_base::level_type level,char const *lb,char const *le,char const *rb,char const *re) const
+    int do_compare(collator_base::level_type level,char const *lb,char const *le,char const *rb,char const *re) const BOOST_OVERRIDE
     {
         std::wstring l=conv::to_utf<wchar_t>(lb,le,"UTF-8");
         std::wstring r=conv::to_utf<wchar_t>(rb,re,"UTF-8");
         return wcscoll_l(level,l.c_str(),l.c_str()+l.size(),r.c_str(),r.c_str()+r.size(),lc_);
     }
-    virtual long do_hash(collator_base::level_type level,char const *b,char const *e) const
+    long do_hash(collator_base::level_type level,char const *b,char const *e) const BOOST_OVERRIDE
     {
         std::string key = do_transform(level,b,e);
         return gnu_gettext::pj_winberger_hash_function(key.c_str(),key.c_str() + key.size());
     }
-    virtual std::string do_transform(collator_base::level_type level,char const *b,char const *e) const
+    std::string do_transform(collator_base::level_type level,char const *b,char const *e) const BOOST_OVERRIDE
     {
         std::wstring tmp=conv::to_utf<wchar_t>(b,e,"UTF-8");
         std::wstring wkey = wcsxfrm_l(level,tmp.c_str(),tmp.c_str()+tmp.size(),lc_);
@@ -74,18 +74,18 @@ public:
         lc_(lc)
     {
     }
-    virtual int do_compare(collator_base::level_type level,wchar_t const *lb,wchar_t const *le,wchar_t const *rb,wchar_t const *re) const
+    int do_compare(collator_base::level_type level,wchar_t const *lb,wchar_t const *le,wchar_t const *rb,wchar_t const *re) const BOOST_OVERRIDE
     {
         return wcscoll_l(level,lb,le,rb,re,lc_);
     }
-    virtual long do_hash(collator_base::level_type level,wchar_t const *b,wchar_t const *e) const
+    long do_hash(collator_base::level_type level,wchar_t const *b,wchar_t const *e) const BOOST_OVERRIDE
     {
         std::wstring key = do_transform(level,b,e);
         char const *begin = reinterpret_cast<char const *>(key.c_str());
         char const *end = begin + key.size()*sizeof(wchar_t);
         return gnu_gettext::pj_winberger_hash_function(begin,end);
     }
-    virtual std::wstring do_transform(collator_base::level_type level,wchar_t const *b,wchar_t const *e) const
+    std::wstring do_transform(collator_base::level_type level,wchar_t const *b,wchar_t const *e) const BOOST_OVERRIDE
     {
         return wcsxfrm_l(level,b,e,lc_);
     }

--- a/src/win32/converter.cpp
+++ b/src/win32/converter.cpp
@@ -29,7 +29,7 @@ public:
         lc_(lc)
     {
     }
-    virtual std::wstring convert(converter_base::conversion_type how,wchar_t const *begin,wchar_t const *end,int flags = 0) const 
+    std::wstring convert(converter_base::conversion_type how,wchar_t const *begin,wchar_t const *end,int flags = 0) const BOOST_OVERRIDE
     {
         switch(how) {
         case converter_base::upper_case:
@@ -55,7 +55,7 @@ public:
         lc_(lc)
     {
     }
-    virtual std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const 
+    std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const BOOST_OVERRIDE
     {
         std::wstring tmp = conv::to_utf<wchar_t>(begin,end,"UTF-8");
         wchar_t const *wb=tmp.c_str();

--- a/src/win32/numeric.cpp
+++ b/src/win32/numeric.cpp
@@ -61,8 +61,7 @@ public:
     }
 private:
 
-    virtual 
-    iter_type do_format_currency(bool /*intl*/,iter_type out,std::ios_base &ios,char_type fill,long double val) const
+    iter_type do_format_currency(bool /*intl*/,iter_type out,std::ios_base &ios,char_type fill,long double val) const BOOST_OVERRIDE
     {
         if(lc_.is_c()) {
             std::locale loc = ios.getloc();
@@ -96,19 +95,17 @@ public:
         lc_(lc)
     {
     }
-    virtual ~time_put_win()
-    {
-    }
+
     typedef typename std::time_put<CharType>::iter_type iter_type;
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
 
-    virtual iter_type do_put(   iter_type out,
-                                std::ios_base &/*ios*/,
-                                CharType /*fill*/,
-                                std::tm const *tm,
-                                char format,
-                                char /*modifier*/) const
+    iter_type do_put( iter_type out,
+                      std::ios_base &/*ios*/,
+                      CharType /*fill*/,
+                      std::tm const *tm,
+                      char format,
+                      char /*modifier*/) const BOOST_OVERRIDE
     {
         return write_it(out,wcsftime_l(format,tm,lc_));
     }
@@ -147,24 +144,24 @@ public:
     {
         s2=conv::from_utf(s1,"UTF-8");
     }
-    virtual CharType do_decimal_point() const
+    CharType do_decimal_point() const BOOST_OVERRIDE
     {
         return *decimal_point_.c_str();
     }
-    virtual CharType do_thousands_sep() const
+    CharType do_thousands_sep() const BOOST_OVERRIDE
     {
         return *thousands_sep_.c_str();
     }
-    virtual std::string do_grouping() const
+    std::string do_grouping() const BOOST_OVERRIDE
     {
         return grouping_;
     }
-    virtual string_type do_truename() const
+    string_type do_truename() const BOOST_OVERRIDE
     {
         static const char t[]="true";
         return string_type(t,t+sizeof(t)-1);
     }
-    virtual string_type do_falsename() const
+    string_type do_falsename() const BOOST_OVERRIDE
     {
         static const char t[]="false";
         return string_type(t,t+sizeof(t)-1);

--- a/src/win32/win_backend.cpp
+++ b/src/win32/win_backend.cpp
@@ -36,7 +36,7 @@ namespace impl_win {
             invalid_(true)
         {
         }
-        virtual winapi_localization_backend *clone() const
+        winapi_localization_backend *clone() const BOOST_OVERRIDE
         {
             return new winapi_localization_backend(*this);
         }
@@ -81,9 +81,9 @@ namespace impl_win {
             }
         }
         
-        virtual std::locale install(std::locale const &base,
+        std::locale install(std::locale const &base,
                                     locale_category_type category,
-                                    character_facet_type type = nochar_facet)
+                                    character_facet_type type = nochar_facet) BOOST_OVERRIDE
         {
             prepare_data();
 

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -14,6 +14,9 @@
 #if defined(BOOST_LOCALE_WITH_ICONV) && !defined(BOOST_LOCALE_NO_POSIX_BACKEND)
 #include "../src/posix/codecvt.hpp"
 #endif
+#if defined(BOOST_NO_CXX11_SMART_PTR) && !BOOST_LOCALE_USE_AUTO_PTR
+#include <boost/locale/hold_ptr.hpp>
+#endif
 
 #include <string.h>
 
@@ -115,20 +118,16 @@ int main()
     try {
         using namespace boost::locale::util;
 
-        #ifndef BOOST_NO_CXX11_SMART_PTR
-        std::unique_ptr<base_converter> cvt;
-        #else
-        std::auto_ptr<base_converter> cvt;
-        #endif
-
         std::cout << "Test UTF-8" << std::endl;
         std::cout << "- From UTF-8" << std::endl;
 
 
         #ifndef BOOST_NO_CXX11_SMART_PTR
-        cvt = std::move(create_utf8_converter_unique_ptr());
+        std::unique_ptr<base_converter> cvt = create_utf8_converter_unique_ptr();
+        #elif BOOST_LOCALE_USE_AUTO_PTR
+        std::auto_ptr<base_converter> cvt = create_utf8_converter();
         #else
-        cvt = create_utf8_converter();
+        boost::locale::hold_ptr<base_converter> cvt(create_utf8_converter_new_ptr());
         #endif
 
         TEST(cvt.get());
@@ -262,9 +261,11 @@ int main()
         std::cout << "Test windows-1255" << std::endl;
 
         #ifndef BOOST_NO_CXX11_SMART_PTR
-        cvt = std::move(create_simple_converter_unique_ptr("windows-1255"));
-        #else
+        cvt = create_simple_converter_unique_ptr("windows-1255");
+        #elif BOOST_LOCALE_USE_AUTO_PTR
         cvt = create_simple_converter("windows-1255");
+        #else
+        cvt.reset(create_simple_converter_new_ptr("windows-1255"));
         #endif
 
         TEST(cvt.get());


### PR DESCRIPTION
This adds support for C++11 to C++20.

- C++11: `override` can be used on overridden member functions to detect mistakes in the function signature, the `virtual` is superflous in any case
- C++17: `std::auto_ptr` was removed (deprecated in C++11) -> Unify the 2 defines `BOOST_LOCALE_HIDE_AUTO_PTR` & `BOOST_NO_AUTO_PTR` to a new `BOOST_LOCALE_USE_AUTO_PTR` then use this consistently, especially in `test_codepage_converter.cpp` which failed to compile on C++17 and up
- C++20: The `<=>`-operator creates conflicts with the (wrongly defined) `==`- & `!=`-operators: They miss the `const`

Additionally `std::move` was used unnecessarily in a test causing a "pessimizing move"-warning. Fix that