### PR TITLE
Fix compilation on MinGW platforms

### DIFF
--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -7,6 +7,16 @@
 //
 #define BOOST_LOCALE_SOURCE
 #define BOOST_DETAIL_NO_CONTAINER_FWD
+
+// Need _wfopen which is an extension on MinGW but not on MinGW-w64
+// So remove the strict-mode define on (only) MinGW before including anything
+#if defined(__MINGW32__) && defined(__STRICT_ANSI__)
+#include <_mingw.h>
+#ifndef __MINGW64_VERSION_MAJOR
+#undef __STRICT_ANSI__
+#endif
+#endif
+
 #include <boost/config.hpp>
 #include <boost/version.hpp>
 #include <boost/locale/message.hpp>


### PR DESCRIPTION
Compiling with a specific C++ standard w/o GNU extensions, e.g. --std=c++11, removes the required _wfopen function.
So disable the strict-mode on MinGW but be careful not to do so on MinGW-w64 where this would be an error.

Requires:
- [x] #82