### PR TITLE
Add CI test using clang-win and BOOST_USE_WINDOWS_H

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,6 +83,13 @@ environment:
       B2_CXXSTD: 11,14,17
       B2_TOOLSET: clang-win
 
+    - FLAVOR: clang-cl using windows.h
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 17
+      B2_TOOLSET: clang-win
+      B2_DEFINES: BOOST_USE_WINDOWS_H
+
     - FLAVOR: Visual Studio 2015, 2013
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_TOOLSET: msvc-12.0,msvc-14.0

--- a/src/win32/numeric.cpp
+++ b/src/win32/numeric.cpp
@@ -6,23 +6,21 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 #define BOOST_LOCALE_SOURCE
-#include <locale>
-#include <string>
-#include <ios>
-#include <boost/locale/formatting.hpp>
-#include <boost/locale/generator.hpp>
-#include <boost/locale/encoding.hpp>
-#include <boost/shared_ptr.hpp>
-#include <sstream>
-#include <stdlib.h>
-#include <time.h>
-#include <string.h>
-#include <wctype.h>
-#include <ctype.h>
-
 #include "all_generator.hpp"
 #include "api.hpp"
 #include "../util/numeric.hpp"
+#include <boost/locale/encoding.hpp>
+#include <boost/locale/formatting.hpp>
+#include <boost/locale/generator.hpp>
+#include <ctype.h>
+#include <ios>
+#include <locale>
+#include <sstream>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <time.h>
+#include <wctype.h>
 
 namespace boost {
 namespace locale {


### PR DESCRIPTION
Then cleanup includes in numeric.cpp

Especially removing boost/shared_ptr.hpp fixes the min/max macro error.
Closes https://github.com/boostorg/locale/pull/14