### PR TITLE
Refactor and fix Utf test

### DIFF
--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -117,18 +117,26 @@ void test_to_utf(CharType const *str,unsigned codepoint)
     TEST(memcmp(str,buf,sizeof(CharType) * (end-str))==0);
 }
 
+template<typename CharType>
+void test_valid_utf(CharType const* str, unsigned codepoint)
+{
+    test_from_utf(str, codepoint);
+    test_to_utf(str, codepoint);
+}
+
 void test_utf8()
 {
-    std::cout << "- From UTF-8" << std::endl;
+    std::cout << "- Test UTF-8" << std::endl;
 
     std::cout << "-- Correct" << std::endl;
-    test_from_utf("\x7f", 0x7f);
-    test_from_utf("\xc2\x80", 0x80);
-    test_from_utf("\xdf\xbf", 0x7ff);
-    test_from_utf("\xe0\xa0\x80", 0x800);
-    test_from_utf("\xef\xbf\xbf", 0xffff);
-    test_from_utf("\xf0\x90\x80\x80", 0x10000);
-    test_from_utf("\xf4\x8f\xbf\xbf", 0x10ffff);
+    test_valid_utf("\x7f", 0x7f);
+    test_valid_utf("\xc2\x80", 0x80);
+    test_valid_utf("\xdf\xbf", 0x7ff);
+    test_valid_utf("\xe0\xa0\x80", 0x800);
+    test_valid_utf("\xef\xbf\xbf", 0xffff);
+    test_valid_utf("\xf0\x90\x80\x80", 0x10000);
+    test_valid_utf("\xf4\x8f\xbf\xbf", 0x10ffff);
+
     /// test that this actually works
     test_from_utf(make2(0x80), 0x80);
     test_from_utf(make2(0x7ff), 0x7ff);
@@ -198,26 +206,17 @@ void test_utf8()
     test_from_utf("\xf4\x8f\xbf", incomplete);
     test_from_utf("\xf4\x8f", incomplete);
     test_from_utf("\xf4", incomplete);
-
-    std::cout << "- To UTF-8" << std::endl;
-    test_to_utf("\x7f", 0x7f);
-    test_to_utf("\xc2\x80", 0x80);
-    test_to_utf("\xdf\xbf", 0x7ff);
-    test_to_utf("\xe0\xa0\x80", 0x800);
-    test_to_utf("\xef\xbf\xbf", 0xffff);
-    test_to_utf("\xf0\x90\x80\x80", 0x10000);
-    test_to_utf("\xf4\x8f\xbf\xbf", 0x10ffff);
 }
 
 void test_utf16()
 {
-    std::cout << "- From UTF-16" << std::endl;
+    std::cout << "- Test UTF-16" << std::endl;
 
     std::cout << "-- Correct" << std::endl;
-    test_from_utf(u16_seq(0x10), 0x10);
-    test_from_utf(u16_seq(0xffff), 0xffff);
-    test_from_utf(u16_seq(0xD800, 0xDC00), 0x10000);
-    test_from_utf(u16_seq(0xDBFF, 0xDFFF), 0x10FFFF);
+    test_valid_utf(u16_seq(0x10), 0x10);
+    test_valid_utf(u16_seq(0xffff), 0xffff);
+    test_valid_utf(u16_seq(0xD800, 0xDC00), 0x10000);
+    test_valid_utf(u16_seq(0xDBFF, 0xDFFF), 0x10FFFF);
 
     std::cout << "-- Invalid surrogate" << std::endl;
     test_from_utf(u16_seq(0xDFFF), illegal);
@@ -228,45 +227,31 @@ void test_utf16()
     test_from_utf(u16_seq(0xD800), incomplete);
     test_from_utf(u16_seq(0xDBFF), incomplete);
 
-    std::cout << "- To UTF-16" << std::endl;
-    test_to_utf(u16_seq(0x10), 0x10);
-    test_to_utf(u16_seq(0xffff), 0xffff);
-    test_to_utf(u16_seq(0xD800, 0xDC00), 0x10000);
-    test_to_utf(u16_seq(0xDBFF, 0xDFFF), 0x10FFFF);
-
 #ifndef BOOST_NO_CXX11_CHAR16_T
     std::cout << "-- Test char16_t" << std::endl;
-    test_from_utf(u"\u0010", 0x10);
 #if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 50000)
-    test_from_utf(u"\xffff", 0xffff);
+    test_valid_utf(u"\x0010", 0x10);
+    test_valid_utf(u"\xffff", 0xffff);
 #else
-    test_from_utf(u"\uffff", 0xffff);
+    test_valid_utf(u"\u0010", 0x10);
+    test_valid_utf(u"\uffff", 0xffff);
 #endif
-    test_from_utf(u"\U00010000", 0x10000);
-    test_from_utf(u"\U0010FFFF", 0x10FFFF);
+    test_valid_utf(u"\U00010000", 0x10000);
+    test_valid_utf(u"\U0010FFFF", 0x10FFFF);
     test_from_utf(c16_seq(0xDFFF), illegal);
     test_from_utf(c16_seq(0xDC00), illegal);
-
-    test_to_utf(u"\u0010", 0x10);
-#if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 50000)
-    test_to_utf(u"\xffff", 0xffff);
-#else
-    test_to_utf(u"\uffff", 0xffff);
-#endif
-    test_to_utf(u"\U00010000", 0x10000);
-    test_to_utf(u"\U0010FFFF", 0x10FFFF);
 #endif
 }
 
 void test_utf32()
 {
-    std::cout << "- From UTF-32" << std::endl;
+    std::cout << "- Test UTF-32" << std::endl;
 
     std::cout << "-- Correct" << std::endl;
-    test_from_utf(u32_seq(0x10), 0x10);
-    test_from_utf(u32_seq(0xffff), 0xffff);
-    test_from_utf(u32_seq(0x10000), 0x10000);
-    test_from_utf(u32_seq(0x10ffff), 0x10ffff);
+    test_valid_utf(u32_seq(0x10), 0x10);
+    test_valid_utf(u32_seq(0xffff), 0xffff);
+    test_valid_utf(u32_seq(0x10000), 0x10000);
+    test_valid_utf(u32_seq(0x10ffff), 0x10ffff);
 
     std::cout << "-- Invalid surrogate" << std::endl;
     test_from_utf(u32_seq(0xD800), illegal);
@@ -278,28 +263,21 @@ void test_utf32()
     std::cout << "-- Incomplete" << std::endl;
     test_from_utf(u32_seq(0), incomplete);
 
-    std::cout << "- To UTF-32" << std::endl;
-    test_to_utf(u32_seq(0x10), 0x10);
-    test_to_utf(u32_seq(0xffff), 0xffff);
-    test_to_utf(u32_seq(0x10000), 0x10000);
-    test_to_utf(u32_seq(0x10ffff), 0x10ffff);
-
 #ifndef BOOST_NO_CXX11_CHAR32_T
     std::cout << "-- Test char32_t" << std::endl;
-    test_from_utf(U"\U00000010", 0x10);
-    test_from_utf(U"\U0000ffff", 0xffff);
-    test_from_utf(U"\U00010000", 0x10000);
-    test_from_utf(U"\U0010ffff", 0x10ffff);
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 50000)
+    test_valid_utf(U"\x0010", 0x10);
+#else
+    test_valid_utf(U"\U00000010", 0x10);
+#endif
+    test_valid_utf(U"\U0000ffff", 0xffff);
+    test_valid_utf(U"\U00010000", 0x10000);
+    test_valid_utf(U"\U0010ffff", 0x10ffff);
     test_from_utf(c32_seq(0xD800), illegal);
     test_from_utf(c32_seq(0xDBFF), illegal);
     test_from_utf(c32_seq(0xDFFF), illegal);
     test_from_utf(c32_seq(0xDC00), illegal);
     test_from_utf(c32_seq(0x110000), illegal);
-
-    test_to_utf(U"\U00000010", 0x10);
-    test_to_utf(U"\U0000ffff", 0xffff);
-    test_to_utf(U"\U00010000", 0x10000);
-    test_to_utf(U"\U0010ffff", 0x10ffff);
 #endif
 }
 

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -57,262 +57,249 @@ char32_t const* c32_seq(boost::uint32_t a)
 }
 #endif
 
-template<typename CharType>
-void test_to(CharType const *s,unsigned codepoint)
-{
-    CharType const *begin = s;
-    CharType const *end = begin;
 
-    while(*end)
-        end++;
+// Get end of C-String, i.e. the NULL byte
+template<typename CharType>
+CharType const* str_end(CharType const *s)
+{
+    while(*s)
+        s++;
+    return s;
+}
+
+template<typename CharType>
+void test_from_utf(CharType const * const s,unsigned codepoint)
+{
+    CharType const *cur = s;
+    CharType const * const end = str_end(s);
 
     typedef utf_traits<CharType> tr;
     
     BOOST_STATIC_ASSERT(tr::max_width == 4 / sizeof(CharType));
 
-    TEST(tr::template decode<CharType const *>(begin,end) == codepoint);
+    TEST(tr::template decode<CharType const *>(cur,end) == codepoint);
 
-    if(codepoint == incomplete || codepoint != illegal)
-        TEST(end == begin);
+    if(codepoint != illegal)
+        TEST(cur == end);
 
     if(codepoint == incomplete) {
-        TEST(*s== 0 || 0 < tr::trail_length(*s));
-        TEST(tr::trail_length(*s) + 1 > end - s);
+        TEST(*s== 0 || tr::trail_length(*s) > 0);
+        TEST(tr::trail_length(*s) >= end - s);
     }
 
     if(codepoint != incomplete && codepoint != illegal) {
-        begin=s;
-        TEST(tr::is_lead(*begin));
-        TEST(!tr::is_trail(*begin));
-        begin++;
-        while(begin!=end) {
-            TEST(tr::is_trail(*begin));
-            TEST(!tr::is_lead(*begin));
-            begin++;
+        TEST(tr::is_lead(*s));
+        TEST(!tr::is_trail(*s));
+        cur = s;
+        while(++cur != end) {
+            TEST(tr::is_trail(*cur));
+            TEST(!tr::is_lead(*cur));
         }
         TEST(tr::width(codepoint)==end - s);
         TEST(tr::trail_length(*s) == tr::width(codepoint) - 1);
-        begin = s;
-        TEST(tr::decode_valid(begin) == codepoint);
-        TEST(begin == end);
+        cur = s;
+        TEST(tr::decode_valid(cur) == codepoint);
+        TEST(cur == end);
     }
 }
 
 template<typename CharType>
-void test_from(CharType const *str,unsigned codepoint)
+void test_to_utf(CharType const *str,unsigned codepoint)
 {
     CharType buf[5] = {1,1,1,1,1};
     CharType *p=buf;
     p = utf_traits<CharType>::template encode<CharType *>(codepoint,p);
-    CharType const *end = str;
-    while(*end)
-        end++;
-    TEST(end - str == p-buf );
+    CharType const * const end = str_end(str);
+    TEST(end - str == p - buf);
     TEST(*p);
     *p=0;
     TEST(memcmp(str,buf,sizeof(CharType) * (end-str))==0);
 }
 
+void test_utf8()
+{
+    std::cout << "- From UTF-8" << std::endl;
+
+    std::cout << "-- Correct" << std::endl;
+    test_from_utf("\x7f", 0x7f);
+    test_from_utf("\xc2\x80", 0x80);
+    test_from_utf("\xdf\xbf", 0x7ff);
+    test_from_utf("\xe0\xa0\x80", 0x800);
+    test_from_utf("\xef\xbf\xbf", 0xffff);
+    test_from_utf("\xf0\x90\x80\x80", 0x10000);
+    test_from_utf("\xf4\x8f\xbf\xbf", 0x10ffff);
+    /// test that this actually works
+    test_from_utf(make2(0x80), 0x80);
+    test_from_utf(make2(0x7ff), 0x7ff);
+
+    test_from_utf(make3(0x800), 0x800);
+    test_from_utf(make3(0xffff), 0xffff);
+
+    test_from_utf(make4(0x10000), 0x10000);
+    test_from_utf(make4(0x10ffff), 0x10ffff);
+
+    std::cout << "-- Too big" << std::endl;
+    test_from_utf("\xf4\x9f\x80\x80", illegal); //  11 0000
+    test_from_utf("\xfb\xbf\xbf\xbf", illegal); // 3ff ffff
+    test_from_utf("\xf8\x90\x80\x80\x80", illegal);  // 400 0000
+    test_from_utf("\xfd\xbf\xbf\xbf\xbf\xbf", illegal);  // 7fff ffff
+
+    std::cout << "-- Invalid length" << std::endl;
+
+    test_from_utf(make2(0), illegal);
+    test_from_utf(make3(0), illegal);
+    test_from_utf(make4(0), illegal);
+    test_from_utf(make2(0x7f), illegal);
+    test_from_utf(make3(0x7f), illegal);
+    test_from_utf(make4(0x7f), illegal);
+
+    test_from_utf(make3(0x80), illegal);
+    test_from_utf(make4(0x80), illegal);
+    test_from_utf(make3(0x7ff), illegal);
+    test_from_utf(make4(0x7ff), illegal);
+
+    test_from_utf(make4(0x8000), illegal);
+    test_from_utf(make4(0xffff), illegal);
+    test_from_utf(make4(0x110000), illegal);
+    test_from_utf(make4(0x1fffff), illegal);
+
+    std::cout << "-- Invalid surrogate" << std::endl;
+
+    test_from_utf(make3(0xd800), illegal);
+    test_from_utf(make3(0xdbff), illegal);
+    test_from_utf(make3(0xdc00), illegal);
+    test_from_utf(make3(0xdfff), illegal);
+
+    test_from_utf(make4(0xd800), illegal);
+    test_from_utf(make4(0xdbff), illegal);
+    test_from_utf(make4(0xdc00), illegal);
+    test_from_utf(make4(0xdfff), illegal);
+
+    std::cout << "-- Incomplete" << std::endl;
+
+    test_from_utf("", incomplete);
+
+    test_from_utf("\x80", illegal);
+    test_from_utf("\xc2", incomplete);
+
+    test_from_utf("\xdf", incomplete);
+
+    test_from_utf("\xe0", incomplete);
+    test_from_utf("\xe0\xa0", incomplete);
+
+    test_from_utf("\xef\xbf", incomplete);
+    test_from_utf("\xef", incomplete);
+
+    test_from_utf("\xf0\x90\x80", incomplete);
+    test_from_utf("\xf0\x90", incomplete);
+    test_from_utf("\xf0", incomplete);
+
+    test_from_utf("\xf4\x8f\xbf", incomplete);
+    test_from_utf("\xf4\x8f", incomplete);
+    test_from_utf("\xf4", incomplete);
+
+    std::cout << "- To UTF-8" << std::endl;
+    test_to_utf("\x7f", 0x7f);
+    test_to_utf("\xc2\x80", 0x80);
+    test_to_utf("\xdf\xbf", 0x7ff);
+    test_to_utf("\xe0\xa0\x80", 0x800);
+    test_to_utf("\xef\xbf\xbf", 0xffff);
+    test_to_utf("\xf0\x90\x80\x80", 0x10000);
+    test_to_utf("\xf4\x8f\xbf\xbf", 0x10ffff);
+}
+
+void test_utf16()
+{
+    std::cout << "- From UTF-16" << std::endl;
+
+    std::cout << "-- Correct" << std::endl;
+    test_from_utf(u16_seq(0x10), 0x10);
+    test_from_utf(u16_seq(0xffff), 0xffff);
+    test_from_utf(u16_seq(0xD800, 0xDC00), 0x10000);
+    test_from_utf(u16_seq(0xDBFF, 0xDFFF), 0x10FFFF);
+
+    std::cout << "-- Invalid surrogate" << std::endl;
+    test_from_utf(u16_seq(0xDFFF), illegal);
+    test_from_utf(u16_seq(0xDC00), illegal);
+
+    std::cout << "-- Incomplete" << std::endl;
+    test_from_utf(u16_seq(0), incomplete);
+    test_from_utf(u16_seq(0xD800), incomplete);
+    test_from_utf(u16_seq(0xDBFF), incomplete);
+
+    std::cout << "- To UTF-16" << std::endl;
+    test_to_utf(u16_seq(0x10), 0x10);
+    test_to_utf(u16_seq(0xffff), 0xffff);
+    test_to_utf(u16_seq(0xD800, 0xDC00), 0x10000);
+    test_to_utf(u16_seq(0xDBFF, 0xDFFF), 0x10FFFF);
+
+#ifndef BOOST_NO_CXX11_CHAR16_T
+    std::cout << "-- Test char16_t" << std::endl;
+    test_from_utf(u"\u0010", 0x10);
+    test_from_utf(u"\uffff", 0xffff);
+    test_from_utf(u"\U00010000", 0x10000);
+    test_from_utf(u"\U0010FFFF", 0x10FFFF);
+    test_from_utf(c16_seq(0xDFFF), illegal);
+    test_from_utf(c16_seq(0xDC00), illegal);
+
+    test_to_utf(u"\u0010", 0x10);
+    test_to_utf(u"\uffff", 0xffff);
+    test_to_utf(u"\U00010000", 0x10000);
+    test_to_utf(u"\U0010FFFF", 0x10FFFF);
+#endif
+}
+
+void test_utf32()
+{
+    std::cout << "- From UTF-32" << std::endl;
+
+    std::cout << "-- Correct" << std::endl;
+    test_from_utf(u32_seq(0x10), 0x10);
+    test_from_utf(u32_seq(0xffff), 0xffff);
+    test_from_utf(u32_seq(0x10000), 0x10000);
+    test_from_utf(u32_seq(0x10ffff), 0x10ffff);
+
+    std::cout << "-- Invalid surrogate" << std::endl;
+    test_from_utf(u32_seq(0xD800), illegal);
+    test_from_utf(u32_seq(0xDBFF), illegal);
+    test_from_utf(u32_seq(0xDFFF), illegal);
+    test_from_utf(u32_seq(0xDC00), illegal);
+    test_from_utf(u32_seq(0x110000), illegal);
+
+    std::cout << "-- Incomplete" << std::endl;
+    test_from_utf(u32_seq(0), incomplete);
+
+    std::cout << "- To UTF-32" << std::endl;
+    test_to_utf(u32_seq(0x10), 0x10);
+    test_to_utf(u32_seq(0xffff), 0xffff);
+    test_to_utf(u32_seq(0x10000), 0x10000);
+    test_to_utf(u32_seq(0x10ffff), 0x10ffff);
+
+#ifndef BOOST_NO_CXX11_CHAR32_T
+    std::cout << "-- Test char32_t" << std::endl;
+    test_from_utf(U"\U00000010", 0x10);
+    test_from_utf(U"\U0000ffff", 0xffff);
+    test_from_utf(U"\U00010000", 0x10000);
+    test_from_utf(U"\U0010ffff", 0x10ffff);
+    test_from_utf(c32_seq(0xD800), illegal);
+    test_from_utf(c32_seq(0xDBFF), illegal);
+    test_from_utf(c32_seq(0xDFFF), illegal);
+    test_from_utf(c32_seq(0xDC00), illegal);
+    test_from_utf(c32_seq(0x110000), illegal);
+
+    test_to_utf(U"\U00000010", 0x10);
+    test_to_utf(U"\U0000ffff", 0xffff);
+    test_to_utf(U"\U00010000", 0x10000);
+    test_to_utf(U"\U0010ffff", 0x10ffff);
+#endif
+}
 
 int main()
 {
     try {
-
-        std::cout << "Test UTF-8" << std::endl;
-        std::cout << "- From UTF-8" << std::endl;
-
-
-        std::cout << "-- Correct" << std::endl;
-
-        test_to("\x7f",0x7f);
-        test_to("\xc2\x80",0x80);
-        test_to("\xdf\xbf",0x7ff);
-        test_to("\xe0\xa0\x80",0x800);
-        test_to("\xef\xbf\xbf",0xffff);
-        test_to("\xf0\x90\x80\x80",0x10000);
-        test_to("\xf4\x8f\xbf\xbf",0x10ffff);
-
-        std::cout << "-- Too big" << std::endl;
-        test_to("\xf4\x9f\x80\x80",illegal); //  11 0000
-        test_to("\xfb\xbf\xbf\xbf",illegal); // 3ff ffff
-        test_to("\xf8\x90\x80\x80\x80",illegal);  // 400 0000
-        test_to("\xfd\xbf\xbf\xbf\xbf\xbf",illegal);  // 7fff ffff
-
-        std::cout << "-- Invalid length" << std::endl;
-
-        /// test that this actually works
-        test_to(make2(0x80),0x80);
-        test_to(make2(0x7ff),0x7ff);
-
-        test_to(make3(0x800),0x800);
-        test_to(make3(0xffff),0xffff);
-
-        test_to(make4(0x10000),0x10000);
-        test_to(make4(0x10ffff),0x10ffff);
-
-        test_to(make4(0x110000),illegal);
-        test_to(make4(0x1fffff),illegal);
-        
-        test_to(make2(0),illegal);
-        test_to(make3(0),illegal);
-        test_to(make4(0),illegal);
-        test_to(make2(0x7f),illegal);
-        test_to(make3(0x7f),illegal);
-        test_to(make4(0x7f),illegal);
-
-        test_to(make3(0x80),illegal);
-        test_to(make4(0x80),illegal);
-        test_to(make3(0x7ff),illegal);
-        test_to(make4(0x7ff),illegal);
-
-        test_to(make4(0x8000),illegal);
-        test_to(make4(0xffff),illegal);
-        
-        std::cout << "-- Invalid surrogate" << std::endl;
-        
-        test_to(make3(0xd800),illegal);
-        test_to(make3(0xdbff),illegal);
-        test_to(make3(0xdc00),illegal);
-        test_to(make3(0xdfff),illegal);
-
-        test_to(make4(0xd800),illegal);
-        test_to(make4(0xdbff),illegal);
-        test_to(make4(0xdc00),illegal);
-        test_to(make4(0xdfff),illegal);
-
-        std::cout <<"-- Incomplete" << std::endl;
-
-        test_to("",incomplete);
-
-        test_to("\x80",illegal);
-        test_to("\xc2",incomplete);
-        
-        test_to("\xdf",incomplete);
-
-        test_to("\xe0",incomplete);
-        test_to("\xe0\xa0",incomplete);
-
-        test_to("\xef\xbf",incomplete);
-        test_to("\xef",incomplete);
-
-        test_to("\xf0\x90\x80",incomplete);
-        test_to("\xf0\x90",incomplete);
-        test_to("\xf0",incomplete);
-
-        test_to("\xf4\x8f\xbf",incomplete);
-        test_to("\xf4\x8f",incomplete);
-        test_to("\xf4",incomplete);
-
-        std::cout << "- To UTF-8" << std::endl;
-
-        std::cout << "-- Test correct" << std::endl;
-
-        test_from("\x7f",0x7f);
-        test_from("\xc2\x80",0x80);
-        test_from("\xdf\xbf",0x7ff);
-        test_from("\xe0\xa0\x80",0x800);
-        test_from("\xef\xbf\xbf",0xffff);
-        test_from("\xf0\x90\x80\x80",0x10000);
-        test_from("\xf4\x8f\xbf\xbf",0x10ffff);
-
-        std::cout << "Test UTF-16" << std::endl;
-        std::cout << "- From UTF-16" << std::endl;
-
-
-        std::cout << "-- Correct" << std::endl;
-
-        test_to(u16_seq(0x10),0x10);
-        test_to(u16_seq(0xffff),0xffff);
-        test_to(u16_seq(0xD800,0xDC00),0x10000);
-        test_to(u16_seq(0xDBFF,0xDFFF),0x10FFFF);
-
-
-        std::cout << "-- Invalid surrogate" << std::endl;
-        
-        test_to(u16_seq(0xDFFF),illegal);
-        test_to(u16_seq(0xDC00),illegal);
-
-        std::cout <<"-- Incomplete" << std::endl;
-
-        test_to(u16_seq(0),incomplete);
-        test_to(u16_seq(0xD800),incomplete);
-        test_to(u16_seq(0xDBFF),incomplete);
-
-        std::cout << "- To UTF-16" << std::endl;
-
-        std::cout << "-- Test correct" << std::endl;
-
-        test_to(u16_seq(0x10),0x10);
-        test_to(u16_seq(0xffff),0xffff);
-        test_to(u16_seq(0xD800,0xDC00),0x10000);
-        test_to(u16_seq(0xDBFF,0xDFFF),0x10FFFF);
-
-
-        std::cout << "Test UTF-32" << std::endl;
-        std::cout << "- From UTF-32" << std::endl;
-
-
-        std::cout << "-- Correct" << std::endl;
-
-        test_to(u32_seq(0x10),0x10);
-        test_to(u32_seq(0xffff),0xffff);
-        test_to(u32_seq(0x10000),0x10000);
-        test_to(u32_seq(0x10ffff),0x10ffff);
-
-
-
-        std::cout << "-- Invalid surrogate" << std::endl;
-        
-        test_to(u32_seq(0xD800),illegal);
-        test_to(u32_seq(0xDBFF),illegal);
-        test_to(u32_seq(0xDFFF),illegal);
-        test_to(u32_seq(0xDC00),illegal);
-        test_to(u32_seq(0x110000),illegal);
-
-        std::cout <<"-- Incomplete" << std::endl;
-
-        test_to(u32_seq(0),incomplete);
-
-        std::cout << "- To UTF-32" << std::endl;
-
-        std::cout << "-- Test correct" << std::endl;
-
-        test_to(u32_seq(0x10),0x10);
-        test_to(u32_seq(0xffff),0xffff);
-        test_to(u32_seq(0x10ffff),0x10ffff);
-
-#ifndef BOOST_NO_CXX11_CHAR16_T
-        std::cout << "-- Test char16_t" << std::endl;
-        test_to(u"\u0010", 0x10);
-        test_to(u"\uffff", 0xffff);
-        test_to(u"\U00010000", 0x10000);
-        test_to(u"\U0010FFFF", 0x10FFFF);
-        test_to(c16_seq(0xDFFF), illegal);
-        test_to(c16_seq(0xDC00), illegal);
-
-        test_from(u"\u0010", 0x10);
-        test_from(u"\uffff", 0xffff);
-        test_from(u"\U00010000", 0x10000);
-        test_from(u"\U0010FFFF", 0x10FFFF);
-#endif
-#ifndef BOOST_NO_CXX11_CHAR32_T
-        std::cout << "-- Test char32_t" << std::endl;
-        test_to(U"\U00000010", 0x10);
-        test_to(U"\U0000ffff", 0xffff);
-        test_to(U"\U00010000", 0x10000);
-        test_to(U"\U0010ffff", 0x10ffff);
-        test_to(c32_seq(0xD800), illegal);
-        test_to(c32_seq(0xDBFF), illegal);
-        test_to(c32_seq(0xDFFF), illegal);
-        test_to(c32_seq(0xDC00), illegal);
-        test_to(c32_seq(0x110000), illegal);
-
-        test_from(U"\U00000010", 0x10);
-        test_from(U"\U0000ffff", 0xffff);
-        test_from(U"\U00010000", 0x10000);
-        test_from(U"\U0010ffff", 0x10ffff);
-#endif
-
+        test_utf8();
+        test_utf16();
+        test_utf32();
     }
     catch(std::exception const &e) {
         std::cerr << "Failed " << e.what() << std::endl;

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -6,6 +6,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/locale/utf.hpp>
+#include <boost/detail/workaround.hpp>
 #include <boost/static_assert.hpp>
 #include <cstring>
 #include "test_locale.hpp"
@@ -236,14 +237,22 @@ void test_utf16()
 #ifndef BOOST_NO_CXX11_CHAR16_T
     std::cout << "-- Test char16_t" << std::endl;
     test_from_utf(u"\u0010", 0x10);
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 50000)
+    test_from_utf(u"\xffff", 0xffff);
+#else
     test_from_utf(u"\uffff", 0xffff);
+#endif
     test_from_utf(u"\U00010000", 0x10000);
     test_from_utf(u"\U0010FFFF", 0x10FFFF);
     test_from_utf(c16_seq(0xDFFF), illegal);
     test_from_utf(c16_seq(0xDC00), illegal);
 
     test_to_utf(u"\u0010", 0x10);
+#if BOOST_WORKAROUND(BOOST_GCC_VERSION, < 50000)
+    test_to_utf(u"\xffff", 0xffff);
+#else
     test_to_utf(u"\uffff", 0xffff);
+#endif
     test_to_utf(u"\U00010000", 0x10000);
     test_to_utf(u"\U0010FFFF", 0x10FFFF);
 #endif

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -38,6 +38,25 @@ boost::uint16_t const *u16_seq(boost::uint16_t a,boost::uint16_t b)
     return buf;
 }
 
+#ifndef BOOST_NO_CXX11_CHAR16_T
+char16_t const* c16_seq(boost::uint16_t a)
+{
+    static char16_t buf[2];
+    buf[0] = static_cast<char16_t>(a);
+    buf[1] = 0;
+    return buf;
+}
+#endif
+#ifndef BOOST_NO_CXX11_CHAR32_T
+char32_t const* c32_seq(boost::uint32_t a)
+{
+    static char32_t buf[2];
+    buf[0] = static_cast<char32_t>(a);
+    buf[1] = 0;
+    return buf;
+}
+#endif
+
 template<typename CharType>
 void test_to(CharType const *s,unsigned codepoint)
 {
@@ -262,7 +281,37 @@ int main()
         test_to(u32_seq(0xffff),0xffff);
         test_to(u32_seq(0x10ffff),0x10ffff);
 
+#ifndef BOOST_NO_CXX11_CHAR16_T
+        std::cout << "-- Test char16_t" << std::endl;
+        test_to(u"\u0010", 0x10);
+        test_to(u"\uffff", 0xffff);
+        test_to(u"\U00010000", 0x10000);
+        test_to(u"\U0010FFFF", 0x10FFFF);
+        test_to(c16_seq(0xDFFF), illegal);
+        test_to(c16_seq(0xDC00), illegal);
 
+        test_from(u"\u0010", 0x10);
+        test_from(u"\uffff", 0xffff);
+        test_from(u"\U00010000", 0x10000);
+        test_from(u"\U0010FFFF", 0x10FFFF);
+#endif
+#ifndef BOOST_NO_CXX11_CHAR32_T
+        std::cout << "-- Test char32_t" << std::endl;
+        test_to(U"\U00000010", 0x10);
+        test_to(U"\U0000ffff", 0xffff);
+        test_to(U"\U00010000", 0x10000);
+        test_to(U"\U0010ffff", 0x10ffff);
+        test_to(c32_seq(0xD800), illegal);
+        test_to(c32_seq(0xDBFF), illegal);
+        test_to(c32_seq(0xDFFF), illegal);
+        test_to(c32_seq(0xDC00), illegal);
+        test_to(c32_seq(0x110000), illegal);
+
+        test_from(U"\U00000010", 0x10);
+        test_from(U"\U0000ffff", 0xffff);
+        test_from(U"\U00010000", 0x10000);
+        test_from(U"\U0010ffff", 0x10ffff);
+#endif
 
     }
     catch(std::exception const &e) {


### PR DESCRIPTION
- Add tests using char16_t/char32_t when available
- Rename test_from/test_to to make C&P issue obvious and fix that.
- Introduce functions for the tests to better group the subtests

Contains the bugfix from #48 and hence closes #48