### PR TITLE
Use Boost.Predef to detect Linux and remove trailing spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(boost_locale
   PRIVATE
     Boost::thread
     Boost::unordered
+    Boost::predef
 )
 
 target_compile_definitions(boost_locale

--- a/build/has_icu_test.cpp
+++ b/build/has_icu_test.cpp
@@ -3,8 +3,8 @@
  * Copyright (c) 2010
  * John Maddock
  *
- * Use, modification and distribution are subject to the 
- * Boost Software License, Version 1.0. (See accompanying file 
+ * Use, modification and distribution are subject to the
+ * Boost Software License, Version 1.0. (See accompanying file
  * LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  *
  */

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -128,7 +128,7 @@ FULL_PATH_NAMES        = YES
 # If left blank the directory from which doxygen is run is used as the
 # path to strip.
 
-STRIP_FROM_PATH        = ../../.. ../include 
+STRIP_FROM_PATH        = ../../.. ../include
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of
 # the path mentioned in the documentation of a class, which tells
@@ -137,7 +137,7 @@ STRIP_FROM_PATH        = ../../.. ../include
 # definition is used. Otherwise one should specify the include paths that
 # are normally passed to the compiler using the -I flag.
 
-STRIP_FROM_INC_PATH    = ../../.. ../include 
+STRIP_FROM_INC_PATH    = ../../.. ../include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter
 # (but less readable) file names. This can be useful if your file system

--- a/doc/appendix.txt
+++ b/doc/appendix.txt
@@ -10,13 +10,13 @@
 /*!
 \page appendix Appendix
 
-\section appendix_toc Table of Contents 
+\section appendix_toc Table of Contents
 
 - \subpage rationale
 - \subpage faq
 - \subpage default_encoding_under_windows
-- \subpage running_examples_under_windows 
-- \subpage gettext_for_windows 
+- \subpage running_examples_under_windows
+- \subpage gettext_for_windows
 - \subpage glossary
 - \subpage tested_compilers_and_platforms
 - \subpage status_of_cpp0x_characters_support

--- a/doc/boundary_analysys.txt
+++ b/doc/boundary_analysys.txt
@@ -25,11 +25,11 @@
 \section boundary_analysys_basics Basics
 
 Boost.Locale provides a boundary analysis tool, allowing you to split text into characters,
-words, or sentences, and find appropriate places for line breaks. 
+words, or sentences, and find appropriate places for line breaks.
 
 \note This task is not a trivial task.
 \par
-A Unicode code point and a character are not equivalent, for example: 
+A Unicode code point and a character are not equivalent, for example:
 Hebrew word Shalom - "שָלוֹם" that consists of 4 characters and 6 code points (4 base letters and 2 diacritical marks)
 \par
 Words may not be separated by space characters in some languages like in Japanese or Chinese.
@@ -41,7 +41,7 @@ Boost.Locale provides 2 major classes for boundary analysis:
 -   \ref boost::locale::boundary::boundary_point_index - an object that holds an index of boundary points in the text.
     It allows to iterate over the \ref boost::locale::boundary::boundary_point "boundary_point" objects.
 
-Each of the classes above use an iterator type as template parameter. 
+Each of the classes above use an iterator type as template parameter.
 Both of these classes accept in their constructor:
 
 - A flag that defines boundary analysis \ref boost::locale::boundary::boundary_type "boundary_type".
@@ -85,7 +85,7 @@ using namespace boost::locale::boundary;
 boost::locale::generator gen;
 std::string text="To be or not to be, that is the question."
 // Create mapping of text for token iterator using global locale.
-ssegment_index map(word,text.begin(),text.end(),gen("en_US.UTF-8")); 
+ssegment_index map(word,text.begin(),text.end(),gen("en_US.UTF-8"));
 // Print all "words" -- chunks of word boundary
 for(ssegment_index::iterator it=map.begin(),e=map.end();it!=e;++it)
     std::cout <<"\""<< * it << "\", ";
@@ -102,12 +102,12 @@ This sentence "生きるか死ぬか、それが問題だ。" (<a href="http://t
 would be split into following segments in \c ja_JP.UTF-8 (Japanese) locale:
 
 \verbatim
-"生", "きるか", "死", "ぬか", "、", "それが", "問題", "だ", "。", 
+"生", "きるか", "死", "ぬか", "、", "それが", "問題", "だ", "。",
 \endverbatim
 
 The boundary analysis that is done by Boost.Locale
 is much more complicated then just splitting the text according
-to white space characters, even thou it is not perfect. 
+to white space characters, even thou it is not perfect.
 
 
 \section boundary_analysys_segments_rules Using Rules
@@ -116,7 +116,7 @@ The segments selection can be customized using \ref boost::locale::boundary::seg
 \ref boost::locale::boundary::segment_index::full_select(bool) "full_select()" member functions.
 
 By default segment_index's iterator return each text segment defined by two boundary points regardless
-the way they were selected. Thus in the example above we could see text segments like "." or " " 
+the way they were selected. Thus in the example above we could see text segments like "." or " "
 that were selected as words.
 
 Using a \c rule() member function we can specify a binary mask of rules we want to use for selection of
@@ -138,7 +138,7 @@ So the code:
 using namespace boost::locale::boundary;
 std::string text="To be or not to be, that is the question."
 // Create mapping of text for token iterator using global locale.
-ssegment_index map(word,text.begin(),text.end()); 
+ssegment_index map(word,text.begin(),text.end());
 // Define a rule
 map.rule(word_any);
 // Print all "words" -- chunks of word boundary
@@ -168,7 +168,7 @@ For example:
 boost::locale::generator gen;
 using namespace boost::locale::boundary;
 std::string text="生きるか死ぬか、それが問題だ。";
-ssegment_index map(word,text.begin(),text.end(),gen("ja_JP.UTF-8")); 
+ssegment_index map(word,text.begin(),text.end(),gen("ja_JP.UTF-8"));
 for(ssegment_index::iterator it=map.begin(),e=map.end();it!=e;++it) {
     std::cout << "Segment " << *it << " contains: ";
     if(it->rule() & word_none)
@@ -185,14 +185,14 @@ Would print
 
 \verbatim
 Segment 生 contains: ideographic characters
-Segment きるか contains: kana characters 
+Segment きるか contains: kana characters
 Segment 死 contains: ideographic characters
-Segment ぬか contains: kana characters 
-Segment 、 contains: white space or punctuation marks 
-Segment それが contains: kana characters 
+Segment ぬか contains: kana characters
+Segment 、 contains: white space or punctuation marks
+Segment それが contains: kana characters
 Segment 問題 contains: ideographic characters
-Segment だ contains: kana characters 
-Segment 。 contains: white space or punctuation marks 
+Segment だ contains: kana characters
+Segment 。 contains: white space or punctuation marks
 \endverbatim
 
 One important things that should be noted that each segment is defined
@@ -223,9 +223,9 @@ boost::locale::generator gen;
 using namespace boost::locale::boundary;
 std::string text=   "Hello! How\n"
                     "are you?\n";
-ssegment_index map(sentence,text.begin(),text.end(),gen("en_US.UTF-8")); 
+ssegment_index map(sentence,text.begin(),text.end(),gen("en_US.UTF-8"));
 map.rule(sentence_term);
-for(ssegment_index::iterator it=map.begin(),e=map.end();it!=e;++it) 
+for(ssegment_index::iterator it=map.begin(),e=map.end();it!=e;++it)
     std::cout << "Sentence [" << *it << "]" << std::endl;
 \endcode
 
@@ -264,8 +264,8 @@ Sometimes it is useful to find a segment that some specific iterator is pointing
 For example a user had clicked at specific point, we want to select a word on this
 location.
 
-\ref boost::locale::boundary::segment_index "segment_index" provides 
-\ref boost::locale::boundary::segment_index::find() "find(base_iterator p)" 
+\ref boost::locale::boundary::segment_index "segment_index" provides
+\ref boost::locale::boundary::segment_index::find() "find(base_iterator p)"
 member function for this purpose.
 
 This function returns the iterator to the segmet such that \a p points to.
@@ -287,7 +287,7 @@ Would print:
 be
 \endverbatim
 
-\note 
+\note
 
 if the iterator lays inside the segment this segment returned. If the segment does
 not fit the selection rules, then the segment following requested position
@@ -304,12 +304,12 @@ For example: For \ref boost::locale::boundary::word "word" boundary analysis wit
 \section boundary_analysys_break Iterating Over Boundary Points
 \section boundary_analysys_break_basics Basic Iteration
 
-The \ref boost::locale::boundary::boundary_point_index "boundary_point_index" is similar  to 
+The \ref boost::locale::boundary::boundary_point_index "boundary_point_index" is similar  to
 \ref boost::locale::boundary::segment_index "segment_index" in its interface but as a different role.
 Instead of returning text chunks (\ref boost::locale::boundary::segment "segment"s), it returns
 \ref boost::locale::boundary::boundary_point "boundary_point" object that
-represents a position in text - a base iterator used that is used for 
-iteration of the source text C++ characters. 
+represents a position in text - a base iterator used that is used for
+iteration of the source text C++ characters.
 The \ref boost::locale::boundary::boundary_point "boundary_point" object
 also provides a \ref boost::locale::boundary::boundary_point::rule() "rule()" member
 function that defines a rule this boundary was selected according to.
@@ -325,7 +325,7 @@ boost::locale::generator gen;
 
 // our text sample
 std::string const text="First sentence. Second sentence! Third one?";
-// Create an index 
+// Create an index
 sboundary_point_index map(sentence,text.begin(),text.end(),gen("en_US.UTF-8"));
 
 // Count two boundary points
@@ -337,8 +337,8 @@ while(p!=e && count < 2) {
 }
 
 if(p!=e) {
-    std::cout   << "First two sentences are: " 
-                << std::string(text.begin(),p->iterator()) 
+    std::cout   << "First two sentences are: "
+                << std::string(text.begin(),p->iterator())
                 << std::endl;
 }
 else {
@@ -354,7 +354,7 @@ First two sentences are: First sentence. Second sentence!
 
 \section boundary_analysys_break_rules Using Rules
 
-Similarly to the \ref boost::locale::boundary::segment_index "segment_index" the 
+Similarly to the \ref boost::locale::boundary::segment_index "segment_index" the
 \ref boost::locale::boundary::boundary_point_index "boundary_point_index" provides
 a \ref boost::locale::boundary::boundary_point_index::rule(rule_type r) "rule(rule_type mask)"
 member function to filter boundary points that interest us.
@@ -379,7 +379,7 @@ Which is not something that we really expected. As the "Second\n"
 is considered an independent sentence that was separated by
 a line separator "Line Feed".
 
-However, we can set set a rule \ref boost::locale::boundary::sentence_term "sentence_term" 
+However, we can set set a rule \ref boost::locale::boundary::sentence_term "sentence_term"
 and the iterator would use only boundary points that are created
 by a sentence terminators like ".!?".
 
@@ -392,7 +392,7 @@ Right after the generation of the index we would get the desired output:
 
 \verbatim
 First two sentences are: First sentence. Second
-sentence! 
+sentence!
 \endverbatim
 
 You can also use \ref boost::locale::boundary::boundary_point::rule() "boundary_point::rule()" member
@@ -415,8 +415,8 @@ for(sboundary_point_index::iterator p = map.begin(),e=map.end();p!=e;++p) {
     else if(p->rule() & sentence_sep)
         std::cout << "There is a sentence separator: ";
     if(p->rule()!=0) // print if some rule exists
-        std::cout   << "[" << std::string(text.begin(),p->iterator()) 
-                    << "|" << std::string(p->iterator(),text.end()) 
+        std::cout   << "[" << std::string(text.begin(),p->iterator())
+                    << "|" << std::string(p->iterator(),text.end())
                     << "]\n";
 }
 \endcode
@@ -467,13 +467,13 @@ map.rule(word_any);
 std::string::const_iterator pos = text.begin() + 12; // "no|t";
 
 // Get the search range
-sboundary_point_index::iterator 
+sboundary_point_index::iterator
     begin =map.begin(),
     end = map.end(),
     it = map.find(pos); // find a boundary
 
 // go 3 words backward
-for(int count = 0;count <3 && it!=begin; count ++) 
+for(int count = 0;count <3 && it!=begin; count ++)
     --it;
 
 // Save the start

--- a/doc/building_boost_locale.txt
+++ b/doc/building_boost_locale.txt
@@ -131,7 +131,7 @@ You can run unit tests by invoking \c bjam with \c libs/locale/test project para
 
 Boost.Locale is built with binary compatibility in mind. Switching localization back ends on or off,
 or using iconv or not, does not affect binary compatibility. So if a dynamic library was built
-with all possible backends, other dynamic libraries compiled with, for example, only the \c std, \c posix 
+with all possible backends, other dynamic libraries compiled with, for example, only the \c std, \c posix
 or \c winapi backends would still be binary-compatible with it.
 
 However this definitely has an effect on some features. For example, if you

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -10,7 +10,7 @@
 /*!
 \page changelog Changelog
 
-- 1.67.0 
+- 1.67.0
     - Added support of unique_ptr interface in addition to C++2003 auto_ptr - in order to support C++2017, now you can use BOOST_LOCALE_HIDE_AUTO_PTR definiton to remove auto_ptr from the interfaces and prevent deprecated watnings
     - Fixed test problem with ICU >60.1
     - Fix of solaris build
@@ -21,22 +21,22 @@
     - Fixed build agains Boost.Thread v4
     - Fixed Year of week instead of year ICU backend formatting
     - Fixed formatting test for ICU 56.1 and above
-- 1.60.0 
+- 1.60.0
     - Implemented generic codecvt facet and add general purpose utf8_codecvt facet
     - Added posix locale support for FreeBSD 10.0 and above
     - Fixed issues 10017 (sun redefinition on SunOS), 11163 (set_default_messages_domain incorrect behavior), 11673 - build issues
-    - Some warning cleanup 
+    - Some warning cleanup
     - Fixed tests for latest ICU versions
     - Added workaround for `libc++` issues
     - Added new defines `BOOST_LOCALE_ENABLE_CHAR16_T` and `BOOST_LOCALE_ENABLE_CHAR32_T` to enable C++11 `char16_t` and `char32_t` instead of deprecated ones
 - 1.53.0 - Bug fixes: 7743, 7386, 7734, 7701, 7368, 7762:
-    -  7743 - security related bug fix, some invalid UTF-8 sequences where accepted as valid 
+    -  7743 - security related bug fix, some invalid UTF-8 sequences where accepted as valid
     -  7386 - invalid Windows codepage names used
     -  7734 - fixed missing documentation, caused by a error in Doxygen formatting
     -  7701 - fixed missing \c std:: in some places
     -  7368, 7762 - Spelling, grammar, typos
 - 1.49.0
-   - Fixed incorrect use of MultiByteToWideChar in detection of invalid input sequences 
+   - Fixed incorrect use of MultiByteToWideChar in detection of invalid input sequences
 - 1.48.0 - First Release
 
 

--- a/doc/charset_handling.txt
+++ b/doc/charset_handling.txt
@@ -12,8 +12,8 @@
 
 \section codecvt Convenience Interface
 
-Boost.Locale provides \ref boost::locale::conv::to_utf() "to_utf", \ref boost::locale::conv::from_utf() "from_utf" and 
-\ref boost::locale::conv::utf_to_utf() "utf_to_utf" functions in 
+Boost.Locale provides \ref boost::locale::conv::to_utf() "to_utf", \ref boost::locale::conv::from_utf() "from_utf" and
+\ref boost::locale::conv::utf_to_utf() "utf_to_utf" functions in
 the \c boost::locale::conv namespace. They are simple and
 convenient functions to convert a string to and from
 UTF-8/16/32 strings and strings using other encodings.
@@ -33,16 +33,16 @@ or use std::locale as a parameter to fetch this information from it.
 It also receives a policy parameter that tells it how to behave if the
 conversion can't be performed (i.e. an illegal or unsupported character is found).
 By default this function skips all illegal characters and tries to do the best it
-can, however, it is possible ask it to throw 
-a \ref boost::locale::conv::conversion_error "conversion_error" exception 
+can, however, it is possible ask it to throw
+a \ref boost::locale::conv::conversion_error "conversion_error" exception
 by passing the \c stop flag to it:
 
 \code
-std::wstring s=to_utf<wchar_t>("\xFF\xFF","UTF-8",stop); 
+std::wstring s=to_utf<wchar_t>("\xFF\xFF","UTF-8",stop);
 // Throws because this string is illegal in UTF-8
 \endcode
 
-\section codecvt_codecvt std::codecvt facet 
+\section codecvt_codecvt std::codecvt facet
 
 Boost.Locale provides stream codepage conversion facets based on the \c std::codecvt facet.
 This allows conversion between wide-character encodings and 8-bit encodings like UTF-8, ISO-8859 or Shift-JIS.
@@ -53,7 +53,7 @@ Most of compilers provide such facets, but:
 -   Under Linux the encodings are supported only if the required locales are generated. For example
     it may be impossible to create a \c he_IL.CP1255  locale even when the \c he_IL  locale is available.
 
-Thus Boost.Locale provides an option to generate code-page conversion facets for use with 
+Thus Boost.Locale provides an option to generate code-page conversion facets for use with
 Boost.Iostreams filters or \c std::wfstream. For example:
 
 \code
@@ -79,7 +79,7 @@ stream:
 
 \code
 #include <boost/iostreams/stream.hpp>
-#include <boost/iostreams/categories.hpp> 
+#include <boost/iostreams/categories.hpp>
 #include <boost/iostreams/code_converter.hpp>
 
 #include <boost/locale.hpp>
@@ -102,7 +102,7 @@ public:
 
 
 int main()
-{ 
+{
     // the device that converts wide characters
     // to narrow
     typedef io::code_converter<consumer> converter_device;
@@ -112,7 +112,7 @@ int main()
 
     consumer cons;
     // setup out converter to work
-    // with he_IL.UTF-8 locale 
+    // with he_IL.UTF-8 locale
     converter_device dev;
     boost::locale::generator gen;
     dev.imbue(gen("he_IL.UTF-8"));
@@ -121,7 +121,7 @@ int main()
     stream.open(dev);
     // Now wide characters that are written
     // to the stream would be given to
-    // our consumer as narrow characters 
+    // our consumer as narrow characters
     // in UTF-8 encoding
     stream << L"שלום" << std::flush;
 }
@@ -139,7 +139,7 @@ ISO-8859, and Shift-JIS, but not with stateful encodings like UTF-7 or SCSU.
 
 \b Recommendation: Prefer the Unicode UTF-8 encoding for \c char based strings and files in your application.
 
-\note 
+\note
 
 The implementation of codecvt for single byte encodings like ISO-8859-X and for UTF-8 is very efficient
 and would allow fast conversion of the content, however its performance may be sub-optimal for

--- a/doc/collation.txt
+++ b/doc/collation.txt
@@ -9,7 +9,7 @@
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 filetype=cpp.doxygen
 /*!
-\page collation Collation 
+\page collation Collation
 
 Boost.Locale provides a \ref boost::locale::collator "collator" class, derived from \c std::collate, that adds support for
 primary, secondary, tertiary, quaternary and identical comparison levels. They can be approximately defined as:

--- a/doc/conversions.txt
+++ b/doc/conversions.txt
@@ -10,7 +10,7 @@
 /*!
 \page conversions Text Conversions
 
-There is a set of functions that perform basic string conversion operations: 
+There is a set of functions that perform basic string conversion operations:
 upper, lower and \ref term_title_case "title case" conversions, \ref term_case_folding "case folding"
 and Unicode \ref term_normalization "normalization". These are \ref boost::locale::to_upper "to_upper" , \ref boost::locale::to_lower "to_lower", \ref boost::locale::to_title "to_title", \ref boost::locale::fold_case "fold_case" and \ref boost::locale::normalize "normalize".
 
@@ -56,8 +56,8 @@ GRÜßEN GRÜSSEN
 
 Where a letter "ß" was not converted correctly to double-S in first case because of a limitation of \c std::ctype facet.
 
-This is even more problematic in case of UTF-8 encodings where non US-ASCII are not converted at all. 
-For example, this code 
+This is even more problematic in case of UTF-8 encodings where non US-ASCII are not converted at all.
+For example, this code
 
 \code
     std::string grussen = "grüßen";

--- a/doc/dates_times_timezones.txt
+++ b/doc/dates_times_timezones.txt
@@ -11,7 +11,7 @@
 \page dates_times_timezones Working with dates, times, timezones and calendars.
 
 \section dates_times_timezones_intro Introduction
- 
+
 There are several important flaws in the standard C, C++ and Boost libraries that handle dates and time:
 
 -#  The biggest flaw of most libraries that provide operations over dates is the fact that they only support
@@ -23,7 +23,7 @@ There are several important flaws in the standard C, C++ and Boost libraries tha
     user the information about the first day of week. This information is locale dependent.
     It is Monday in France and it is Sunday in United States.
 
-Boost.Locale provides generic \ref boost::locale::date_time "date_time", and \ref boost::locale::calendar "calendar" classes 
+Boost.Locale provides generic \ref boost::locale::date_time "date_time", and \ref boost::locale::calendar "calendar" classes
 that allow you to perform operations on dates and times for non-Gregorian calendars such as Hebrew, Islamic, Japanese and others.
 
 \ref using_localization_backends "Non-ICU based backends" support the Gregorian calendar only.
@@ -49,7 +49,7 @@ For example:
     cout << "Let's meet tomorrow at " << as::date << tomorrow << endl;
     date_time some_point = period::year(1995) + period::january() + period::day(1);
     // Set some_point's date to 1995-Jan-1.
-    cout << "The "<< as::date << some_point << " is the " 
+    cout << "The "<< as::date << some_point << " is the "
         << as::ordinal << some_point / period::day_of_week_local() << " day of the week"  << endl;
 \endcode
 
@@ -61,7 +61,7 @@ You can calculate the difference between dates by dividing the difference by a p
             "between " << as::date << now << " and " << now + 2*period::month() << endl;
 \endcode
 
-You can also use different syntax (less operator overloading) 
+You can also use different syntax (less operator overloading)
 
 \code
     date_time now;
@@ -95,7 +95,7 @@ For example:
     // Create locales with Hebrew and Gregorian (default) calendars.
     std::locale l_hebrew=gen("en_US.UTF-8@calendar=hebrew");
     std::locale l_gregorian=gen("en_US.UTF-8");
-    
+
     // Create a Gregorian date from fields
     date_time greg(year(2010) + february() + day(5),l_gregorian);
     // Assign a time point taken from the Gregorian date to date_time with
@@ -105,12 +105,12 @@ For example:
     std::cout << "Hebrew year is " << heb / year << std::endl;
 \endcode
 
-\note 
+\note
 
 Non-ICU based backends support the same date-time range as \c mktime and \c localtime C library functions.
 
 - Unix 32 bit: dates between 1901 and 2038
-- Unix 64 bit: dates from 1 BC 
+- Unix 64 bit: dates from 1 BC
 - Windows: dates from 1970. If the \c time_t is 32 bits wide (mingw), then the upper limit is year 2038
 
 \section dates_times_timezones_tz Time Zone
@@ -129,7 +129,7 @@ several different levels:
 
 \ref using_localization_backends "Non-ICU based backends" support only two kinds of time zones:
 
--#  The current OS time zone, as it is handled by \c localtime and \c mktime the standard 
+-#  The current OS time zone, as it is handled by \c localtime and \c mktime the standard
     library functions - the default time zone
 -#  Simple time zone in format "GMT+HH:MM" - the time zone represented using fixed shift from
     the UTC without support of daylight saving time.
@@ -140,7 +140,7 @@ several different levels:
 Writing a \ref boost::locale::date_time "date_time" is equivalent
 to:
 
--   Applying \ref boost::locale::as::datetime "as::datetime" manipulator on the stream 
+-   Applying \ref boost::locale::as::datetime "as::datetime" manipulator on the stream
 -   Writing POSIX time as number that is fetched by calling \ref boost::locale::date_time::time()
     "date_time::time()" function.
 -   Reverting the manipulator effect back.
@@ -180,7 +180,7 @@ Would print something like:
 This is important to remember that \c date_time object is always rendered and parsed in the context
 of the \c iostream's locale and time zone and not in the context of specific \c date_time object.
 
-\section dates_times_timezones_qna Questions and Answers 
+\section dates_times_timezones_qna Questions and Answers
 
 
 <b>Why should I use Boost.Locale over Boost.DateTime when I need Gregorian calendar only?</b>
@@ -201,7 +201,7 @@ a simple table of rules where daylight saving depend only on certain n'th day of
 The daylight savings time may vary by year, political issues and many other things.
 
 Most of the modern operating systems (Linux, *BSD, Mac OS X, OpenVMS) and many important software packages
-(ICU, Java, Python) use so called Olson database in order to handle daylight saving time 
+(ICU, Java, Python) use so called Olson database in order to handle daylight saving time
 correctly.
 
 If you need full time zone database support, then you should use ICU library.

--- a/doc/default_encoding_under_windows.txt
+++ b/doc/default_encoding_under_windows.txt
@@ -44,7 +44,7 @@ int main()
     // Make boost.filesystem use it
     boost::filesystem::path::imbue(std::locale());
     // Now Works perfectly fine with UTF-8!
-    boost::filesystem::ofstream hello("שלום.txt"); 
+    boost::filesystem::ofstream hello("שלום.txt");
 }
 
 \endcode

--- a/doc/formatting_and_parsing.txt
+++ b/doc/formatting_and_parsing.txt
@@ -117,7 +117,7 @@ There is a list of supported \c strftime flags by ICU backend:
 -   \c \%c  -- Locale date-time format. \b Note: prefer using \c as::datetime
 -   \c \%d  -- Day of Month [01,31]
 -   \c \%e  -- Day of Month [1,31]
--   \c \%h  -- Same as \c \%b 
+-   \c \%h  -- Same as \c \%b
 -   \c \%H  -- 24 clock hour [00,23]
 -   \c \%I  -- 12 clock hour [01,12]
 -   \c \%j  -- Day of year [1,366]
@@ -125,11 +125,11 @@ There is a list of supported \c strftime flags by ICU backend:
 -   \c \%M  -- Minute [00,59]
 -   \c \%n  -- New Line
 -   \c \%p  -- AM/PM in locale representation
--   \c \%r  -- Time with AM/PM, same as \c \%I:\%M:\%S \%p 
--   \c \%R  -- Same as \c \%H:\%M 
+-   \c \%r  -- Time with AM/PM, same as \c \%I:\%M:\%S \%p
+-   \c \%R  -- Same as \c \%H:\%M
 -   \c \%S  -- Second [00,61]
 -   \c \%t  -- Tab character
--   \c \%T  -- Same as \c \%H:\%M:\%S 
+-   \c \%T  -- Same as \c \%H:\%M:\%S
 -   \c \%x  -- Local date representation. **Note:** prefer using \c as::date
 -   \c \%X  -- Local time representation. **Note:** prefer using \c as::time
 -   \c \%y  -- Year [00,99]

--- a/doc/gendoc.sh
+++ b/doc/gendoc.sh
@@ -8,4 +8,4 @@
 #
 
 
-rm html/* && doxygen 
+rm html/* && doxygen

--- a/doc/gettext_for_windows.txt
+++ b/doc/gettext_for_windows.txt
@@ -23,7 +23,7 @@ basically several options:
 
 Boost.Locale was developed for needs of <a href="http://cppcms.sourceforge.net">CppCMS</a> project
 and thus CppCMS hosts a convince package for Windows users of pre-build, statically liked \c gettext
-runtime utilities like \c xgettext, \c msgfmt, etc. 
+runtime utilities like \c xgettext, \c msgfmt, etc.
 
 So you can download a zip file \c gettext-tools-static-XXX.zip from a CppCMS downloads page
 under <a href="https://sourceforge.net/projects/cppcms/files/boost_locale/gettext_for_windows/">boost_locale/gettext_for_windows</a>.
@@ -37,7 +37,7 @@ Thus you can always install full MinGW distribution including gettext tools. How
 a want minimalistic runtime version that allows you to extract messages and create catalogs
 you need to download several packages manually.
 
-In order to install Gettext via MinGW distributing you need to download, a GCC's runtime, 
+In order to install Gettext via MinGW distributing you need to download, a GCC's runtime,
 iconv library and gettext itself.
 
 So visit a <a href="https://sourceforge.net/projects/mingw/files/">downloads page</a> of MinGW project
@@ -61,9 +61,9 @@ For example, at June 23, 2011 it was:
 After you download the packages, extract all the files to the same directory using tools like
 \c 7zip and you'll get all the executables and \c dll's you need under \c bin subdirectory.
 
-\note the version on MinGW site is slightly outdated (0.17.1) while gettext provides currently 0.18.1. 
+\note the version on MinGW site is slightly outdated (0.17.1) while gettext provides currently 0.18.1.
 
-\section gettext_for_windows_build Building latest version on your own. 
+\section gettext_for_windows_build Building latest version on your own.
 
 You can build your own version of GNU Gettext using MinGW environment, you'll need to have up-to-date gcc compiler
 and the shell, you'll need to install iconv first and then build a gettext with it.

--- a/doc/glossary.txt
+++ b/doc/glossary.txt
@@ -10,7 +10,7 @@
 /*!
 \page glossary Glossary
 
--   \anchor term_bmp <b>Basic Multilingual Plane (BMP)</b> -- a part of 
+-   \anchor term_bmp <b>Basic Multilingual Plane (BMP)</b> -- a part of
     the <i>Universal Character Set</i> with code points in the range U-0000--U-FFFF.
     The most commonly used UCS characters lay in this plane, including all Western, Cyrillic, Hebrew, Thai, Arabic and CJK characters.
     However there are many characters that lay outside the BMP and they are absolutely required for correct support of East Asian languages.
@@ -31,7 +31,7 @@
 -   \b Formatting - representation of various values according to locale preferences. For example, a number 1234.5 (C representation)
     should be displayed as 1,234.5 in the US locale and 1.234,5 in the Russian locale. The date November 1st, 2005 would be represented as
     11/01/2005 in the United States, and 01.11.2005 in Russia. This is an important part of localization.
-    \n 
+    \n
     For example: does "You have to bring 134,230 kg of rice on 04/01/2010" means "134 tons of rice on the first of April" or "134 kg 230 g
     of rice on January 4th"? That is quite different.
 -   \b Gettext - The GNU localization library used for message formatting. Today it is the de-facto standard localization library in the
@@ -52,7 +52,7 @@
     library.
 -   \b UCS-2 - a fixed-width Unicode encoding, capable of representing only code points in the <i>Basic Multilingual Plane (BMP)</i>.
     It is a legacy encoding and is not recommended for use.
--   \b Unicode -- the industry standard that defines the representation and manipulation of text suitable for most languages and countries. 
+-   \b Unicode -- the industry standard that defines the representation and manipulation of text suitable for most languages and countries.
     It should not be confused with the <i>Universal Character Set</i>, it is a much larger standard that also defines algorithms like
     bidirectional display order, Arabic shaping, etc.
 -   <b>Universal Character Set (UCS)</b> - an international standard that defines a set of characters for many scripts and their

--- a/doc/locale_gen.txt
+++ b/doc/locale_gen.txt
@@ -18,20 +18,20 @@ and variant is additional options for specializing the locale, like \c euro or \
 
 Note that each locale should include the encoding in order to handle \c char based strings correctly.
 
-\section locale_gen_basics Basics 
+\section locale_gen_basics Basics
 
 The class \ref boost::locale::generator "generator" provides tools to generate the locales we need. The simplest way to use
 \c generator is to create a locale and set it as the global one:
 
 \code
     #include <boost/locale.hpp>
-    
+
     using namespace boost::locale;
     int main()
     {
         generator gen;
-        // Create locale generator 
-        std::locale::global(gen("")); 
+        // Create locale generator
+        std::locale::global(gen(""));
         // "" - the system default locale, set
         // it globally
     }
@@ -40,7 +40,7 @@ The class \ref boost::locale::generator "generator" provides tools to generate t
 Of course we can also specify the locale manually
 
 \code
-    std::locale loc = gen("en_US.UTF-8"); 
+    std::locale loc = gen("en_US.UTF-8");
     // Use English, United States locale
 \endcode
 
@@ -64,7 +64,7 @@ member functions of the \ref boost::locale::generator "generator" class.
 
 For example:
 
-\code    
+\code
     generator gen;
     gen.characters(wchar_t_facet);
     gen.categories(collation_facet | formatting_facet);
@@ -75,10 +75,10 @@ For example:
 
 The variant part of the locale (the part that comes after \@ symbol) is localization \ref using_localization_backends "back-end" dependent.
 
-\subsection locale_gen_variant_non_icu Non ICU Backends 
+\subsection locale_gen_variant_non_icu Non ICU Backends
 
-\ref posix_backend "POSIX" and \ref std_backend "std" back-ends use their own OS specific naming conventions and 
-depend on the current OS configuration. For example typical Linux distribution provides \c euro for currency selection, 
+\ref posix_backend "POSIX" and \ref std_backend "std" back-ends use their own OS specific naming conventions and
+depend on the current OS configuration. For example typical Linux distribution provides \c euro for currency selection,
 \c cyrillic and \c latin for specification of language script.
 
 \ref winapi_backend "winapi" back-end does not support any variants.
@@ -93,7 +93,7 @@ However in general it is represented as set of key=value pairs separated with a 
 
 Currently ICU supports following keys:
 
--   \c calendar - the calendar used for the current locale. For example: \c gregorian, \c japanese, 
+-   \c calendar - the calendar used for the current locale. For example: \c gregorian, \c japanese,
     \c buddhist, \c islamic, \c hebrew,  \c chinese, \c islamic-civil.
 -   \c collation - the collation order used for this locales, for example \c phonebook, \c pinyin, \c traditional,
     \c stroke, \c direct, \c posix.

--- a/doc/localized_text_formatting.txt
+++ b/doc/localized_text_formatting.txt
@@ -51,7 +51,7 @@ The syntax is described by following grammar:
     parameters: parameter | parameter ',' parameters;
     parameter : key ["=" value] ;
     key : [0-9a-zA-Z<>]+ ;
-    value : ascii-string-excluding-"}"-and="," | local-string ; 
+    value : ascii-string-excluding-"}"-and="," | local-string ;
     local-string : quoted-text | quoted-text local-string;
     quoted-text : '[^']*' ;
 \endverbatim

--- a/doc/main.txt
+++ b/doc/main.txt
@@ -47,7 +47,7 @@ Boost.Locale enhances and unifies the standard library's API
 the way it becomes useful and convenient for development
 of cross platform and "cross-culture" software.
 
-In order to achieve this goal Boost.Locale uses 
+In order to achieve this goal Boost.Locale uses
 the-state-of-the-art Unicode and Localization
 library: <a href="http://icu-project.org/">ICU</a> - International Components for Unicode.
 
@@ -70,7 +70,7 @@ and use library.
     - \ref conversions
     - \ref formatting_and_parsing
     - \ref messages_formatting
-    - \ref charset_handling 
+    - \ref charset_handling
     - \ref boundary_analysys
     - \ref localized_text_formatting
     - \ref dates_times_timezones
@@ -83,7 +83,7 @@ and use library.
     - \ref rationale
     - \ref faq
     - \ref default_encoding_under_windows
-    - \ref running_examples_under_windows 
+    - \ref running_examples_under_windows
     - \ref gettext_for_windows
     - \ref glossary
     - \ref tested_compilers_and_platforms

--- a/doc/messages_formatting.txt
+++ b/doc/messages_formatting.txt
@@ -14,7 +14,7 @@
 - \ref msg_loading_dictionaries
 - \ref message_translation
     - \ref indirect_message_translation
-    - \ref plural_forms 
+    - \ref plural_forms
     - \ref multiple_gettext_domain
     - \ref direct_message_translation
 - \ref extracting_messages_from_code
@@ -33,7 +33,7 @@ of GNU Gettext, as it is outside the scope of this document.
 
 The model is following:
 
--   First, our application \c foo is prepared for localization by calling the \ref boost::locale::translate() "translate" function 
+-   First, our application \c foo is prepared for localization by calling the \ref boost::locale::translate() "translate" function
     for each message used in user interface.
     \n
     For example:
@@ -128,7 +128,7 @@ There are two ways to translate messages:
 
 -   using \ref boost_locale_translate_family "boost::locale::translate()" family of functions:
     \n
-    These functions create a special proxy object \ref boost::locale::basic_message "basic_message" 
+    These functions create a special proxy object \ref boost::locale::basic_message "basic_message"
     that can be converted to string according to given locale or written to \c std::ostream
     formatting the message in the \c std::ostream's locale.
     \n
@@ -147,7 +147,7 @@ The basic function that allows us to translate a message is \ref boost_locale_tr
 
 These functions use a character type \c CharType as template parameter and receive either <tt>CharType const *</tt> or <tt>std::basic_string<CharType></tt> as input.
 
-These functions receive an original message and return a special proxy 
+These functions receive an original message and return a special proxy
 object - \ref boost::locale::basic_message "basic_message<CharType>".
 This object holds all the required information for the message formatting.
 
@@ -196,8 +196,8 @@ int main()
 
 \note
 
--   \ref boost::locale::basic_message "basic_message" can be implicitly converted 
-    to an apopriate std::basic_string using 
+-   \ref boost::locale::basic_message "basic_message" can be implicitly converted
+    to an apopriate std::basic_string using
     the global locale:
     \n
     \code
@@ -267,7 +267,7 @@ For more detailed information please refer to GNU Gettext: <a href="http://www.g
 \subsection adding_context_information Adding Context Information
 
 In many cases it is not sufficient to provide only the original English string to get the correct translation.
-You sometimes need to provide some context information. In German, for example, a button labeled "open" is translated to 
+You sometimes need to provide some context information. In German, for example, a button labeled "open" is translated to
 "öffnen" in the context of "opening a file", or to "aufbauen" in the context of opening an internet connection.
 
 In these cases you must add some context information to the original string, by adding a comment.
@@ -282,7 +282,7 @@ function in both singular and plural forms. The translator would see this contex
 
 For example, this is how the \c po file would look:
 
-\code    
+\code
 msgctxt "File"
 msgid "open"
 msgstr "öffnen"
@@ -300,7 +300,7 @@ formatting message catalogs.
 
 In some cases it is useful to work with multiple message domains.
 
-For example, if an application consists of several independent modules, it may 
+For example, if an application consists of several independent modules, it may
 have several domains - a separate domain for each module.
 
 For example, developing a FooBar office suite we might have:
@@ -341,7 +341,7 @@ The GNU Gettext like functions prototypes can be found \ref boost_locale_gettext
 
 All of these functions can have different prefixes for different forms:
 
--  \c d - translation in specific domain 
+-  \c d - translation in specific domain
 -  \c n - plural form translation
 -  \c p - translation in specific context
 
@@ -360,7 +360,7 @@ For example, we have a source file called \c dir.cpp that prints:
 
 \code
     cout << format(translate("Listing of catalog {1}:")) % file_name << endl;
-    cout << format(translate("Catalog {1} contains 1 file","Catalog {1} contains {2,num} files",files_no)) 
+    cout << format(translate("Catalog {1} contains 1 file","Catalog {1} contains {2,num} files",files_no))
             % file_name % files_no << endl;
 \endcode
 
@@ -386,13 +386,13 @@ msgstr[1] ""
 
 This file can be given to translators to adapt it to specific languages.
 
-We used the \c --keyword  parameter of \c xgettext to make it suitable for extracting messages from 
+We used the \c --keyword  parameter of \c xgettext to make it suitable for extracting messages from
 source code localized with Boost.Locale, searching for <tt>translate()</tt> function calls instead of the default <tt>gettext()</tt>
 and <tt>ngettext()</tt> ones.
 The first parameter <tt>--keyword=translate:1,1t</tt> provides the template for basic messages: a \c translate function that is
 called with 1 argument (1t) and the first message is taken as the key. The second one <tt>--keyword=translate:1,2,3t</tt> is used
 for plural forms.
-It tells \c xgettext to use a <tt>translate()</tt> function call with 3 parameters (3t) and take the 1st and 2nd parameter as keys. An 
+It tells \c xgettext to use a <tt>translate()</tt> function call with 3 parameters (3t) and take the 1st and 2nd parameter as keys. An
 additional marker \c Nc can be used to mark context information.
 
 The full set of xgettext parameters suitable for Boost.Locale is:
@@ -411,11 +411,11 @@ may ignore some of these parameters.
 \subsection custom_file_system_support Custom Filesystem Support
 
 When the access to actual file system is limited like in ActiveX controls or
-when the developer wants to ship all-in-one executable file, 
-it is useful to be able to load \c gettext  catalogs from a custom location - 
+when the developer wants to ship all-in-one executable file,
+it is useful to be able to load \c gettext  catalogs from a custom location -
 a custom file system.
 
-Boost.Locale provides an option to install boost::locale::message_format facet 
+Boost.Locale provides an option to install boost::locale::message_format facet
 with customized options provided in boost::locale::gnu_gettext::messages_info structure.
 
 This structure contains \c boost::function based
@@ -509,7 +509,7 @@ int main()
     // Generate locales and imbue them to iostream
     locale::global(gen(""));
     cout.imbue(locale());
-    
+
     // In Windows 1255 (C) symbol is encoded as 0xA9
     cout << translate("© 2001 All Rights Reserved") << endl;
 }
@@ -534,7 +534,7 @@ key is missing in the dictionary.
     -#  A tool for extracting strings from source code, and managing them: GNU Gettext provides good tools, but other
         implementations are available as well.
     -#  A good translation program like <a href="http://userbase.kde.org/Lokalize">Lokalize</a>, <a href="http://www.poedit.net/">Pedit</a> or <a href="http://projects.gnome.org/gtranslator/">GTranslator</a>.
-    
+
 -   Why doesn't Boost.Locale provide tools for extracting and management of message catalogs. Why should
     I use GPL-ed software? Are my programs or message catalogs affected by its license?
     \n
@@ -546,7 +546,7 @@ key is missing in the dictionary.
         do a very fine job, especially as they are freely available for download and support almost any platform.
     All Linux distributions, BSD Flavors, Mac OS X and other Unix like operating systems provide GNU Gettext tools
     as a standard package.\n
-    Windows users can get GNU Gettext utilities via MinGW project. See \ref gettext_for_windows. 
+    Windows users can get GNU Gettext utilities via MinGW project. See \ref gettext_for_windows.
 
 
 -   Is there any reason to prefer the Boost.Locale implementation to the original GNU Gettext runtime library?
@@ -555,7 +555,7 @@ key is missing in the dictionary.
     There are two important differences between the GNU Gettext runtime library and the Boost.Locale implementation:
     \n
     -#  The GNU Gettext runtime supports only one locale per process. It is not thread-safe to use multiple locales
-        and encodings in the same process. This is perfectly fine for applications that interact directly with 
+        and encodings in the same process. This is perfectly fine for applications that interact directly with
         a single user like most GUI applications, but is problematic for services and servers.
     -#  The GNU Gettext API supports only 8-bit encodings, making it irrelevant in environments that natively use
         wide strings.

--- a/doc/rationale.txt
+++ b/doc/rationale.txt
@@ -9,13 +9,13 @@
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 filetype=cpp.doxygen
 /*!
 
-\page rationale Design Rationale 
+\page rationale Design Rationale
 
 - \ref rationale_why
 - \ref why_icu
-- \ref why_icu_wrapper 
+- \ref why_icu_wrapper
 - \ref why_icu_api_is_hidden
-- \ref why_gnu_gettext 
+- \ref why_gnu_gettext
 - \ref why_posix_names
 - \ref why_linear_chunks
 - \ref why_abstract_api
@@ -56,7 +56,7 @@ Almost every(!) facet has design flaws:
     for the UTF-8 encoding where only Unicode 0-0x7F range can be represented as a single character. As a result, localized numbers can't be
     represented correctly under locales that use the Unicode "EN SPACE" character for the thousands separator, such as Russian.
     \n
-    This actually causes real problems under GCC and SunStudio compilers, where formatting numbers under a Russian locale creates invalid 
+    This actually causes real problems under GCC and SunStudio compilers, where formatting numbers under a Russian locale creates invalid
     UTF-8 sequences.
 -   \c std::time_put and \c std::time_get have several flaws:
     -# They assume that the calendar is always Gregorian, by using \c std::tm for time representation, ignoring the fact that in many
@@ -148,7 +148,7 @@ There are several reasons:
 -#  A Gregorian Date by definition can't be used to represent locale-independent dates, because not all
     calendars are Gregorian.
 -#  \c ptime -- definitely could be used, but it has several problems:
-    \n   
+    \n
     -   It is created in GMT or Local time clock, when `time()` gives a representation that is independent of time zones
         (usually GMT time), and only later should it be represented in a time zone that the user requests.
         \n
@@ -159,7 +159,7 @@ There are several reasons:
         The major formatting and parsing functions are not virtual. This makes it impossible to reimplement the formatting and
         parsing functions of \c ptime unless the developers of the Boost.DateTime library decide to change them.
         \n
-        Also, the facets of \c ptime are not "correctly" designed in terms of division of formatting information and 
+        Also, the facets of \c ptime are not "correctly" designed in terms of division of formatting information and
         locale information. Formatting information should be stored within \c std::ios_base and information about
         locale-specific formatting should be stored in the facet itself.
         \n
@@ -186,7 +186,7 @@ There are two reasons:
 - Boost.Locale relies heavily on the third-party APIs like ICU, POSIX or Win32 API, all of them
   work only on linear chunks of text, so providing non-linear API would just hide the
   real situation and would not bring real performance advantage.
-- In fact, all known libraries that work with Unicode: ICU, Qt, Glib, Win32 API, POSIX API 
+- In fact, all known libraries that work with Unicode: ICU, Qt, Glib, Win32 API, POSIX API
   and others accept an input as single linear chunk of text and there is a good reason for this:
   \n
   -#  Most of supported operations on text like collation, case handling usually work on small
@@ -221,11 +221,11 @@ There are several reasons:
 
 - C++0x defines \c char16_t and \c char32_t as distinct types, so substituting is with something like \c uint16_t or \c uint32_t
   would not work as for example writing \c uint16_t to \c uint32_t stream would write a number to stream.
-- The C++ locales system would work only if standard facets like \c std::num_put are installed into the 
+- The C++ locales system would work only if standard facets like \c std::num_put are installed into the
   existing instance of \c std::locale, however in the many standard C++ libraries these facets are specialized for each
   specific character that the standard library supports, so an attempt to create a new facet would
   fail as it is not specialized.
-  
+
 These are exactly the reasons why Boost.Locale fails with current limited C++0x characters support on GCC-4.5 (the second reason)
 and MSVC-2010 (the first reason)
 

--- a/doc/recommendations_and_myths.txt
+++ b/doc/recommendations_and_myths.txt
@@ -16,10 +16,10 @@
     supported Unicode characters and is more convenient for general use than encodings like Latin1.
 -   Remember, there are many different cultures. You can assume very little about the user's language. His calendar
     may not have "January". It may be not possible to convert strings to integers using \c atoi because
-    they may not use the "ordinary" digits 0..9 at all. You can't assume that "space" characters are frequent 
+    they may not use the "ordinary" digits 0..9 at all. You can't assume that "space" characters are frequent
     because in Chinese the space character does not separate words. The text may be written from Right-to-Left or
     from Up-to-Down, and so on.
--   Using message formatting, try to provide as much context information as you can. Prefer translating entire 
+-   Using message formatting, try to provide as much context information as you can. Prefer translating entire
     sentences over single words. When translating words, \b always add some context information.
 
 

--- a/doc/running_examples_under_windows.txt
+++ b/doc/running_examples_under_windows.txt
@@ -13,7 +13,7 @@
 All of the examples that come with Boost.Locale are designed for UTF-8 and it is
 the default encoding used by Boost.Locale.
 
-However, the default narrow encoding under Microsoft Windows is not UTF-8 and 
+However, the default narrow encoding under Microsoft Windows is not UTF-8 and
 the output of the applications would not be displayed correctly in the console.
 
 So in order to use UTF-8 encoding under the Windows console and see the output correctly, do the following:

--- a/doc/special_thanks.txt
+++ b/doc/special_thanks.txt
@@ -8,11 +8,11 @@
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 filetype=cpp.doxygen
 /*!
-\page special_thanks Special Thanks 
+\page special_thanks Special Thanks
 
 (in alphabetical order)
 
--   Chad Nelson - for volunteering to manage the formal review and for the great language corrections 
+-   Chad Nelson - for volunteering to manage the formal review and for the great language corrections
     for this tutorial.
 -   Vladimir Prus - for development of Boost.Build support for Boost.Locale.
 

--- a/doc/std_locales.txt
+++ b/doc/std_locales.txt
@@ -12,7 +12,7 @@
 
 \section std_locales_basics Getting familiar with standard C++ Locales
 
-The C++ standard library offers a simple and powerful way to provide locale-specific information. It is done via the \c 
+The C++ standard library offers a simple and powerful way to provide locale-specific information. It is done via the \c
 std::locale class, the container that holds all the required information about a specific culture, such as number formatting
 patterns, date and time formatting, currency, case conversion etc.
 
@@ -49,7 +49,7 @@ You can also create your own facets and install them into existing locale object
     class measure : public std::locale::facet {
     public:
         typedef enum { inches, ... } measure_type;
-        measure(measure_type m,size_t refs=0) 
+        measure(measure_type m,size_t refs=0)
         double from_metric(double value) const;
         std::string name() const;
         ...
@@ -89,14 +89,14 @@ additional issues:
     \code
         int main()
         {
-            std::locale::global(std::locale("")); 
+            std::locale::global(std::locale(""));
             // Set system's default locale as global
             std::ofstream csv("test.csv");
             csv << 1.1 << ","  << 1.3 << std::endl;
         }
     \endcode
     \n
-    What would be the content of \c test.csv ? It may be "1.1,1.3" or it may be "1,1,1,3" 
+    What would be the content of \c test.csv ? It may be "1.1,1.3" or it may be "1,1,1,3"
     rather than what you had expected.
     \n
     More than that it affects even \c printf and libraries like \c boost::lexical_cast giving
@@ -113,12 +113,12 @@ additional issues:
     in \c ru_RU.UTF-8 locale number 1024 should be displayed as "1 024" where the space
     is a Unicode character with codepoint u00A0. Unfortunately many libraries don't handle
     this correctly, for example GCC and SunStudio display a "\xC2" character instead of
-    the first character in the UTF-8 sequence "\xC2\xA0" that represents this code point, and 
+    the first character in the UTF-8 sequence "\xC2\xA0" that represents this code point, and
     actually generate invalid UTF-8.
     \n
 -   Locale names are not standardized. For example, under MSVC you need to provide the name
-    \c en-US or \c English_USA.1252 , when on POSIX platforms it would be \c en_US.UTF-8 
-    or \c en_US.ISO-8859-1 
+    \c en-US or \c English_USA.1252 , when on POSIX platforms it would be \c en_US.UTF-8
+    or \c en_US.ISO-8859-1
     \n
     More than that, MSVC does not support UTF-8 locales at all.
     \n

--- a/doc/using_boost_locale.txt
+++ b/doc/using_boost_locale.txt
@@ -25,7 +25,7 @@ supported by other localization backends.
 - \subpage localized_text_formatting
 - \subpage dates_times_timezones
 - \subpage locale_information
-- \subpage working_with_multiple_locales 
+- \subpage working_with_multiple_locales
 
 */
 

--- a/doc/using_localization_backends.txt
+++ b/doc/using_localization_backends.txt
@@ -17,7 +17,7 @@ libraries, and ICU is by no means a small library.
 
 Boost.Locale provides an option to use non-ICU based localization
 backends. Although usually less powerful, these often provide all you need:
-message formatting, currency, date, time, number formatting, basic collation and 
+message formatting, currency, date, time, number formatting, basic collation and
 case manipulation. They are implemented using the standard OS API or a C or C++ library.
 
 \section when_to_use_non_icu_backends When to use non-ICU backends
@@ -83,7 +83,7 @@ problems with this.
 \note
 
 - If you using GCC compiler under Windows you need GCC-4.x series to use it, GCC-3.4 is not supported
-- Only UTF-8 as narrow locale encoding and UTF-16 as wide encoding are supported. 
+- Only UTF-8 as narrow locale encoding and UTF-16 as wide encoding are supported.
 
 \section supported_features_by_backends Supported Features
 
@@ -161,13 +161,13 @@ via the boost::locale::localization_backend_manager::global static member functi
 For example:
 
 \code
-    localization_backend_manager my = localization_backend_manager::global(); 
+    localization_backend_manager my = localization_backend_manager::global();
     // Get global backend
 
-    my.select("std"); 
+    my.select("std");
     // select std backend as default
 
-    generator gen(my); 
+    generator gen(my);
     // create a generator that uses this backend.
 
     localization_backend_manager::global(my);
@@ -182,12 +182,12 @@ for example \c icu for one kind of operation and \c std
 for all others:
 
 \code
-    localization_backend_manager my = localization_backend_manager::global(); 
+    localization_backend_manager my = localization_backend_manager::global();
     // Get global backend
 
-    my.select("std"); 
+    my.select("std");
     // select std backend as default for all categories
-    my.select("icu",boundary_facet); 
+    my.select("icu",boundary_facet);
     // select icu backend for boundary analysis (since it is not supported by \c std)
 \endcode
 

--- a/doc/working_with_multiple_locales.txt
+++ b/doc/working_with_multiple_locales.txt
@@ -31,7 +31,7 @@ For example:
     gen("ja_JP.UTF-8");
     // Create all locales
 
-    std::locale en=gen("en_US.UTF-8"); 
+    std::locale en=gen("en_US.UTF-8");
     // Fetch an existing locale from the cache
     std::locale ar=gen("ar_EG.UTF-8");
     // Because ar_EG not in the cache, a new locale is generated (and cached)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ function(boost_locale_add_example name)
     set(ARG_SRC ${name}.cpp)
   endif()
   set(name ${PROJECT_NAME}-expl_${name})
-  
+
   add_executable(${name} ${ARG_SRC})
   add_dependencies(tests ${name})
   target_link_libraries(${name} PRIVATE

--- a/examples/boundary.cpp
+++ b/examples/boundary.cpp
@@ -24,9 +24,9 @@ int main()
         cout << "boundary detection not implemented in this environment" << endl;
         return 0;
     }
-    locale::global(loc); 
+    locale::global(loc);
     cout.imbue(loc);
-    
+
 
     string text="Hello World! あにま! Linux2.6 and Windows7 is word and number. שָלוֹם עוֹלָם!";
 
@@ -70,7 +70,7 @@ int main()
         cout<<"|" <<*p ;
     }
     cout<<"|\n\n";
-    
+
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/examples/calendar.cpp
+++ b/examples/calendar.cpp
@@ -39,11 +39,11 @@ int main()
     for(now=start; period::year(now) == current_year;) {
 
         // Print heading of month
-        if(calendar().is_gregorian()) 
+        if(calendar().is_gregorian())
             std::cout << format("{1,ftime='%B'}") % now <<std::endl;
         else
             std::cout << format("{1,ftime='%B'} ({1,ftime='%Y-%m-%d',locale=en} - {2,locale=en,ftime='%Y-%m-%d'})")
-                % now 
+                % now
                 % date_time(now,now.maximum(period::day())*period::day()) << std::endl;
 
         int first = calendar().first_day_of_week();
@@ -60,7 +60,7 @@ int main()
         for(int i=0;i<skip*9;i++)
             std::cout << ' ';
         for(;now / period::month() == current_month ;now += period::day()) {
-            std::cout << format("{1,w=8,ftime='%e'} ") % now;     
+            std::cout << format("{1,w=8,ftime='%e'} ") % now;
             if(now / period::day_of_week_local() == 7)
                 std::cout << std::endl;
         }

--- a/examples/conversions.cpp
+++ b/examples/conversions.cpp
@@ -19,11 +19,11 @@ int main()
     using namespace std;
     // Create system default locale
     generator gen;
-    locale loc=gen(""); 
-    locale::global(loc); 
+    locale loc=gen("");
+    locale::global(loc);
     cout.imbue(loc);
 
-    
+
     cout<<"Correct case conversion can't be done by simple, character by character conversion"<<endl;
     cout<<"because case conversion is context sensitive and not 1-to-1 conversion"<<endl;
     cout<<"For example:"<<endl;
@@ -36,7 +36,7 @@ int main()
     cout<<"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is "<<endl;
     cout<<"not even applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct "<<endl;
     cout<<"behavior to unicode subset BMP or ASCII only"<<endl;
-   
+
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -15,27 +15,27 @@ int main()
     using namespace boost::locale;
     using namespace std;
     generator gen;
-    locale loc=gen(""); 
+    locale loc=gen("");
     // Create system default locale
 
-    locale::global(loc); 
+    locale::global(loc);
     // Make it system global
-    
+
     cout.imbue(loc);
     // Set as default locale for output
-    
-    cout <<format("Today {1,date} at {1,time} we had run our first localization example") % time(0) 
+
+    cout <<format("Today {1,date} at {1,time} we had run our first localization example") % time(0)
           <<endl;
-   
-    cout<<"This is how we show numbers in this locale "<<as::number << 103.34 <<endl; 
-    cout<<"This is how we show currency in this locale "<<as::currency << 103.34 <<endl; 
+
+    cout<<"This is how we show numbers in this locale "<<as::number << 103.34 <<endl;
+    cout<<"This is how we show currency in this locale "<<as::currency << 103.34 <<endl;
     cout<<"This is typical date in the locale "<<as::date << std::time(0) <<endl;
     cout<<"This is typical time in the locale "<<as::time << std::time(0) <<endl;
     cout<<"This is upper case "<<to_upper("Hello World!")<<endl;
     cout<<"This is lower case "<<to_lower("Hello World!")<<endl;
     cout<<"This is title case "<<to_title("Hello World!")<<endl;
     cout<<"This is fold case "<<fold_case("Hello World!")<<endl;
-   
+
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/examples/performance/perf_convert.cpp
+++ b/examples/performance/perf_convert.cpp
@@ -46,8 +46,8 @@ int main(int argc,char **argv)
                 boost::locale::to_upper(all[j]);
                 boost::locale::to_lower(all[j]);
                 if(i==0) {
-                    std::cout << boost::locale::to_upper(all[j]) << std::endl; 
-                    std::cout << boost::locale::to_lower(all[j]) << std::endl; 
+                    std::cout << boost::locale::to_upper(all[j]) << std::endl;
+                    std::cout << boost::locale::to_lower(all[j]) << std::endl;
                 }
             }
         }

--- a/examples/wboundary.cpp
+++ b/examples/wboundary.cpp
@@ -19,7 +19,7 @@
 // So, before you compile "wide" examples with MSVC, please convert them to text
 // files with BOM. There are two very simple ways to do it:
 //
-// 1. Open file with Notepad and save it from there. It would convert 
+// 1. Open file with Notepad and save it from there. It would convert
 //    it to file with BOM.
 // 2. In Visual Studio go File->Advances Save Options... and select
 //    Unicode (UTF-8  with signature) Codepage 65001
@@ -51,9 +51,9 @@ int main()
     }
     locale::global(loc);
     wcout.imbue(loc);
-    
+
     // This is needed to prevent C library to
-    // convert strings to narrow 
+    // convert strings to narrow
     // instead of C++ on some platforms
     std::ios_base::sync_with_stdio(false);
 
@@ -100,7 +100,7 @@ int main()
         wcout<<L"|" <<*p ;
     }
     wcout<<"|\n\n";
-    
+
 }
 
 

--- a/examples/wconversions.cpp
+++ b/examples/wconversions.cpp
@@ -19,7 +19,7 @@
 // So, before you compile "wide" examples with MSVC, please convert them to text
 // files with BOM. There are two very simple ways to do it:
 //
-// 1. Open file with Notepad and save it from there. It would convert 
+// 1. Open file with Notepad and save it from there. It would convert
 //    it to file with BOM.
 // 2. In Visual Studio go File->Advances Save Options... and select
 //    Unicode (UTF-8  with signature) Codepage 65001
@@ -43,16 +43,16 @@ int main()
     using namespace std;
     // Create system default locale
     generator gen;
-    locale loc=gen(""); 
+    locale loc=gen("");
     locale::global(loc);
     wcout.imbue(loc);
 
     // This is needed to prevent C library to
-    // convert strings to narrow 
+    // convert strings to narrow
     // instead of C++ on some platforms
     std::ios_base::sync_with_stdio(false);
 
-    
+
     wcout<<L"Correct case conversion can't be done by simple, character by character conversion"<<endl;
     wcout<<L"because case conversion is context sensitive and not 1-to-1 conversion"<<endl;
     wcout<<L"For example:"<<endl;
@@ -65,7 +65,7 @@ int main()
     wcout<<L"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is "<<endl;
     wcout<<L"not fully applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct "<<endl;
     wcout<<L"behavoir to BMP or ASCII only"<<endl;
-   
+
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/examples/whello.cpp
+++ b/examples/whello.cpp
@@ -14,31 +14,31 @@ int main()
 {
     using namespace boost::locale;
     using namespace std;
-    
+
     // Create system default locale
     generator gen;
-    locale loc=gen(""); 
+    locale loc=gen("");
     locale::global(loc);
     wcout.imbue(loc);
-    
+
     // This is needed to prevent C library to
-    // convert strings to narrow 
+    // convert strings to narrow
     // instead of C++ on some platforms
     std::ios_base::sync_with_stdio(false);
 
-    
-    wcout <<wformat(L"Today {1,date} at {1,time} we had run our first localization example") % time(0) 
+
+    wcout <<wformat(L"Today {1,date} at {1,time} we had run our first localization example") % time(0)
           <<endl;
-   
-    wcout<<L"This is how we show numbers in this locale "<<as::number << 103.34 <<endl; 
-    wcout<<L"This is how we show currency in this locale "<<as::currency << 103.34 <<endl; 
+
+    wcout<<L"This is how we show numbers in this locale "<<as::number << 103.34 <<endl;
+    wcout<<L"This is how we show currency in this locale "<<as::currency << 103.34 <<endl;
     wcout<<L"This is typical date in the locale "<<as::date << std::time(0) <<endl;
     wcout<<L"This is typical time in the locale "<<as::time << std::time(0) <<endl;
     wcout<<L"This is upper case "<<to_upper(L"Hello World!")<<endl;
     wcout<<L"This is lower case "<<to_lower(L"Hello World!")<<endl;
     wcout<<L"This is title case "<<to_title(L"Hello World!")<<endl;
     wcout<<L"This is fold case "<<fold_case(L"Hello World!")<<endl;
-   
+
 }
 
 

--- a/include/boost/locale/boundary/boundary_point.hpp
+++ b/include/boost/locale/boundary/boundary_point.hpp
@@ -19,13 +19,13 @@ namespace boundary {
     /// @{
 
     ///
-    /// \brief This class represents a boundary point in the text. 
+    /// \brief This class represents a boundary point in the text.
     ///
-    /// It represents a pair - an iterator and a rule that defines this 
+    /// It represents a pair - an iterator and a rule that defines this
     /// point.
     ///
     /// This type of object is dereference by the iterators of boundary_point_index. Using a rule()
-    /// member function you can get the reason why this specific boundary point was selected. 
+    /// member function you can get the reason why this specific boundary point was selected.
     ///
     /// For example, When you use a sentence boundary analysis, the (rule() & \ref sentence_term) != 0 means
     /// that this boundary point was selected because a sentence terminator (like .?!) was spotted
@@ -56,7 +56,7 @@ namespace boundary {
         /// Empty default constructor
         ///
         boundary_point() : rule_(0) {}
-        
+
         ///
         /// Create a new boundary_point using iterator \p and a rule \a r
         ///
@@ -82,7 +82,7 @@ namespace boundary {
         ///
         /// Fetch an iterator
         ///
-        iterator_type iterator() const 
+        iterator_type iterator() const
         {
             return iterator_;
         }
@@ -133,7 +133,7 @@ namespace boundary {
     private:
         iterator_type iterator_;
         rule_type rule_;
-       
+
     };
     ///
     /// Check if the boundary point \a r points to same location as an iterator \a l
@@ -153,7 +153,7 @@ namespace boundary {
     }
 
     /// @}
-    
+
     typedef boundary_point<std::string::const_iterator> sboundary_point;      ///< convenience typedef
     typedef boundary_point<std::wstring::const_iterator> wsboundary_point;    ///< convenience typedef
     #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -162,7 +162,7 @@ namespace boundary {
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     typedef boundary_point<std::u32string::const_iterator> u32sboundary_point;///< convenience typedef
     #endif
-   
+
     typedef boundary_point<char const *> cboundary_point;                     ///< convenience typedef
     typedef boundary_point<wchar_t const *> wcboundary_point;                 ///< convenience typedef
     #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -171,7 +171,7 @@ namespace boundary {
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     typedef boundary_point<char32_t const *> u32cboundary_point;              ///< convenience typedef
     #endif
-    
+
 
 } // boundary
 } // locale

--- a/include/boost/locale/boundary/facets.hpp
+++ b/include/boost/locale/boundary/facets.hpp
@@ -20,7 +20,7 @@
 namespace boost {
 
     namespace locale {
-        
+
         ///
         /// \brief This namespace contains all operations required for boundary analysis of text
         ///
@@ -31,7 +31,7 @@ namespace boost {
             /// @{
             ///
 
-            
+
             ///
             /// \brief This structure is used for representing boundary point
             /// that follows the offset.
@@ -41,7 +41,7 @@ namespace boost {
                 ///
                 /// Create empty break point at beginning
                 ///
-                break_info() : 
+                break_info() :
                     offset(0),
                     rule(0)
                 {
@@ -61,11 +61,11 @@ namespace boost {
                 ///
                 size_t offset;
                 ///
-                /// The identification of this break point according to 
+                /// The identification of this break point according to
                 /// various break types
                 ///
                 rule_type rule;
-               
+
                 ///
                 /// Compare two break points' offset. Allows to search with
                 /// standard algorithms over the index.
@@ -75,7 +75,7 @@ namespace boost {
                     return offset < other.offset;
                 }
             };
-            
+
             ///
             /// This type holds the analysis of the text - all its break points
             /// with marks
@@ -114,7 +114,7 @@ namespace boost {
                 /// Identification of this facet
                 ///
                 static std::locale::id id;
-                
+
                 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
                 std::locale::id& __get_id (void) const { return id; }
                 #endif
@@ -135,7 +135,7 @@ namespace boost {
                 std::locale::id& __get_id (void) const { return id; }
                 #endif
             };
-            
+
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<wchar_t> : public std::locale::facet {
             public:
@@ -150,7 +150,7 @@ namespace boost {
                 std::locale::id& __get_id (void) const { return id; }
                 #endif
             };
-            
+
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<char16_t> : public std::locale::facet {
@@ -166,7 +166,7 @@ namespace boost {
                 #endif
             };
             #endif
-            
+
             #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<char32_t> : public std::locale::facet {

--- a/include/boost/locale/boundary/index.hpp
+++ b/include/boost/locale/boundary/index.hpp
@@ -33,7 +33,7 @@
 namespace boost {
 
     namespace locale {
-        
+
         namespace boundary {
             ///
             /// \defgroup boundary Boundary Analysis
@@ -87,7 +87,7 @@ namespace boost {
                         //
                         // C++0x requires that string is continious in memory and all known
                         // string implementations
-                        // do this because of c_str() support. 
+                        // do this because of c_str() support.
                         //
 
                         if(linear_iterator_traits<char_type,IteratorType>::is_linear && b!=e)
@@ -116,8 +116,8 @@ namespace boost {
                     mapping(boundary_type type,
                             base_iterator begin,
                             base_iterator end,
-                            std::locale const &loc) 
-                        :   
+                            std::locale const &loc)
+                        :
                             index_(new index_type()),
                             begin_(begin),
                             end_(end)
@@ -151,7 +151,7 @@ namespace boost {
                 };
 
                 template<typename BaseIterator>
-                class segment_index_iterator : 
+                class segment_index_iterator :
                     public boost::iterator_facade<
                         segment_index_iterator<BaseIterator>,
                         segment<BaseIterator>,
@@ -163,7 +163,7 @@ namespace boost {
                     typedef BaseIterator base_iterator;
                     typedef mapping<base_iterator> mapping_type;
                     typedef segment<base_iterator> segment_type;
-                    
+
                     segment_index_iterator() : current_(0,0),map_(0)
                     {
                     }
@@ -266,13 +266,13 @@ namespace boost {
                     {
                         size_t dist=std::distance(map_->begin(),p);
                         index_type::const_iterator b=map_->index().begin(),e=map_->index().end();
-                        index_type::const_iterator 
+                        index_type::const_iterator
                             boundary_point=std::upper_bound(b,e,break_info(dist));
                         while(boundary_point != e && (boundary_point->rule & mask_)==0)
                             boundary_point++;
 
                         current_.first = current_.second = boundary_point - b;
-                        
+
                         if(full_select_) {
                             while(current_.first > 0) {
                                 current_.first --;
@@ -317,31 +317,31 @@ namespace boost {
 
                     bool valid_offset(size_t offset) const
                     {
-                        return  offset == 0 
+                        return  offset == 0
                                 || offset == size() // make sure we not acess index[size]
                                 || (index()[offset].rule & mask_)!=0;
                     }
-                    
+
                     size_t size() const
                     {
                         return index().size();
                     }
-                    
+
                     index_type const &index() const
                     {
                         return map_->index();
                     }
-                
-                    
+
+
                     segment_type value_;
                     std::pair<size_t,size_t> current_;
                     mapping_type const *map_;
                     rule_type mask_;
                     bool full_select_;
                 };
-                            
+
                 template<typename BaseIterator>
-                class boundary_point_index_iterator : 
+                class boundary_point_index_iterator :
                     public boost::iterator_facade<
                         boundary_point_index_iterator<BaseIterator>,
                         boundary_point<BaseIterator>,
@@ -353,7 +353,7 @@ namespace boost {
                     typedef BaseIterator base_iterator;
                     typedef mapping<base_iterator> mapping_type;
                     typedef boundary_point<base_iterator> boundary_point_type;
-                    
+
                     boundary_point_index_iterator() : current_(0),map_(0)
                     {
                     }
@@ -465,22 +465,22 @@ namespace boost {
 
                     bool valid_offset(size_t offset) const
                     {
-                        return  offset == 0 
+                        return  offset == 0
                                 || offset + 1 >= size() // last and first are always valid regardless of mark
                                 || (index()[offset].rule & mask_)!=0;
                     }
-                    
+
                     size_t size() const
                     {
                         return index().size();
                     }
-                    
+
                     index_type const &index() const
                     {
                         return map_->index();
                     }
-                
-                    
+
+
                     boundary_point_type value_;
                     size_t current_;
                     mapping_type const *map_;
@@ -497,10 +497,10 @@ namespace boost {
 
             template<typename BaseIterator>
             class boundary_point_index;
-            
+
 
             ///
-            /// \brief This class holds an index of segments in the text range and allows to iterate over them 
+            /// \brief This class holds an index of segments in the text range and allows to iterate over them
             ///
             /// This class is provides \ref begin() and \ref end() member functions that return bidirectional iterators
             /// to the \ref segment objects.
@@ -511,7 +511,7 @@ namespace boost {
             ///     various masks %as \ref word_any.
             ///     \n
             ///     The default is to select any types of boundaries.
-            ///     \n 
+            ///     \n
             ///     For example: using word %boundary analysis, when the provided mask is \ref word_kana then the iterators
             ///     would iterate only over the words containing Kana letters and \ref word_any would select all types of
             ///     words excluding ranges that consist of white space and punctuation marks. So iterating over the text
@@ -532,7 +532,7 @@ namespace boost {
             ///     terminator "!" or "?". But changing \ref full_select() to true, the selected segment would include
             ///     all the text up to previous valid %boundary point and would return two expected sentences:
             ///     "Hello!" and "How\nare you?".
-            ///     
+            ///
             /// This class allows to find a segment according to the given iterator in range using \ref find() member
             /// function.
             ///
@@ -554,7 +554,7 @@ namespace boost {
             template<typename BaseIterator>
             class segment_index {
             public:
-                
+
                 ///
                 /// The type of the iterator used to iterate over the original text
                 ///
@@ -590,7 +590,7 @@ namespace boost {
                 typedef segment<base_iterator> value_type;
 
                 ///
-                /// Default constructor. 
+                /// Default constructor.
                 ///
                 /// \note
                 ///
@@ -609,7 +609,7 @@ namespace boost {
                             base_iterator begin,
                             base_iterator end,
                             rule_type mask,
-                            std::locale const &loc=std::locale()) 
+                            std::locale const &loc=std::locale())
                     :
                         map_(type,begin,end,loc),
                         mask_(mask),
@@ -623,7 +623,7 @@ namespace boost {
                 segment_index(boundary_type type,
                             base_iterator begin,
                             base_iterator end,
-                            std::locale const &loc=std::locale()) 
+                            std::locale const &loc=std::locale())
                     :
                         map_(type,begin,end,loc),
                         mask_(0xFFFFFFFFu),
@@ -654,7 +654,7 @@ namespace boost {
                 ///
                 segment_index const &operator = (boundary_point_index<base_iterator> const &);
 
-                
+
                 ///
                 /// Create a new index for %boundary analysis \ref boundary_type "type" of the text
                 /// in range [begin,end) for locale \a loc.
@@ -693,7 +693,7 @@ namespace boost {
                 }
 
                 ///
-                /// Find a first valid segment following a position \a p. 
+                /// Find a first valid segment following a position \a p.
                 ///
                 /// If \a p is inside a valid segment this segment is selected:
                 ///
@@ -703,7 +703,7 @@ namespace boost {
                 /// - "t|o be or ", would point to "to",
                 /// - "to be or| ", would point to end.
                 ///
-                ///                 
+                ///
                 /// Preconditions: the segment_index should have a mapping and \a p should be valid iterator
                 /// to the text in the mapped range.
                 ///
@@ -713,17 +713,17 @@ namespace boost {
                 {
                     return iterator(p,&map_,mask_,full_select_);
                 }
-               
+
                 ///
                 /// Get the mask of rules that are used
-                /// 
+                ///
                 rule_type rule() const
                 {
                     return mask_;
                 }
                 ///
                 /// Set the mask of rules that are used
-                /// 
+                ///
                 void rule(rule_type v)
                 {
                     mask_ = v;
@@ -742,7 +742,7 @@ namespace boost {
                 /// following part "are you?"
                 ///
 
-                bool full_select()  const 
+                bool full_select()  const
                 {
                     return full_select_;
                 }
@@ -760,11 +760,11 @@ namespace boost {
                 /// following part "are you?"
                 ///
 
-                void full_select(bool v) 
+                void full_select(bool v)
                 {
                     full_select_ = v;
                 }
-                
+
             private:
                 friend class boundary_point_index<base_iterator>;
                 typedef details::mapping<base_iterator> mapping_type;
@@ -792,14 +792,14 @@ namespace boost {
             /// - "Hello! How\n|are you?"
             /// - "Hello! How\nare you?|"
             ///
-            /// However if \ref rule() is set to \ref sentence_term then the selected %boundary points would be: 
+            /// However if \ref rule() is set to \ref sentence_term then the selected %boundary points would be:
             ///
             /// - "|Hello! How\nare you?"
             /// - "Hello! |How\nare you?"
             /// - "Hello! How\nare you?|"
-            /// 
+            ///
             /// Such that a %boundary point defined by a line feed character would be ignored.
-            ///     
+            ///
             /// This class allows to find a boundary_point according to the given iterator in range using \ref find() member
             /// function.
             ///
@@ -857,9 +857,9 @@ namespace boost {
                 /// an object that represents the selected \ref boundary_point "boundary point".
                 ///
                 typedef boundary_point<base_iterator> value_type;
-                
+
                 ///
-                /// Default constructor. 
+                /// Default constructor.
                 ///
                 /// \note
                 ///
@@ -870,7 +870,7 @@ namespace boost {
                 boundary_point_index() : mask_(0xFFFFFFFFu)
                 {
                 }
-                
+
                 ///
                 /// Create a segment_index for %boundary analysis \ref boundary_type "type" of the text
                 /// in range [begin,end) using a rule \a mask for locale \a loc.
@@ -879,7 +879,7 @@ namespace boost {
                             base_iterator begin,
                             base_iterator end,
                             rule_type mask,
-                            std::locale const &loc=std::locale()) 
+                            std::locale const &loc=std::locale())
                     :
                         map_(type,begin,end,loc),
                         mask_(mask)
@@ -892,7 +892,7 @@ namespace boost {
                 boundary_point_index(boundary_type type,
                             base_iterator begin,
                             base_iterator end,
-                            std::locale const &loc=std::locale()) 
+                            std::locale const &loc=std::locale())
                     :
                         map_(type,begin,end,loc),
                         mask_(0xFFFFFFFFu)
@@ -968,7 +968,7 @@ namespace boost {
                 ///
                 /// - "|to be", would return %boundary point at "|to be",
                 /// - "t|o be", would point to "to| be"
-                ///                 
+                ///
                 /// Preconditions: the boundary_point_index should have a mapping and \a p should be valid iterator
                 /// to the text in the mapped range.
                 ///
@@ -978,17 +978,17 @@ namespace boost {
                 {
                     return iterator(p,&map_,mask_);
                 }
-                
+
                 ///
                 /// Get the mask of rules that are used
-                /// 
+                ///
                 rule_type rule() const
                 {
                     return mask_;
                 }
                 ///
                 /// Set the mask of rules that are used
-                /// 
+                ///
                 void rule(rule_type v)
                 {
                     mask_ = v;
@@ -1001,8 +1001,8 @@ namespace boost {
                 mapping_type  map_;
                 rule_type mask_;
             };
-           
-            /// \cond INTERNAL  
+
+            /// \cond INTERNAL
             template<typename BaseIterator>
             segment_index<BaseIterator>::segment_index(boundary_point_index<BaseIterator> const &other) :
                 map_(other.map_),
@@ -1010,7 +1010,7 @@ namespace boost {
                 full_select_(false)
             {
             }
-            
+
             template<typename BaseIterator>
             boundary_point_index<BaseIterator>::boundary_point_index(segment_index<BaseIterator> const &other) :
                 map_(other.map_),
@@ -1024,7 +1024,7 @@ namespace boost {
                 map_ = other.map_;
                 return *this;
             }
-            
+
             template<typename BaseIterator>
             boundary_point_index<BaseIterator> const &boundary_point_index<BaseIterator>::operator=(segment_index<BaseIterator> const &other)
             {
@@ -1032,7 +1032,7 @@ namespace boost {
                 return *this;
             }
             /// \endcond
-          
+
             typedef segment_index<std::string::const_iterator> ssegment_index;      ///< convenience typedef
             typedef segment_index<std::wstring::const_iterator> wssegment_index;    ///< convenience typedef
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -1041,7 +1041,7 @@ namespace boost {
             #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             typedef segment_index<std::u32string::const_iterator> u32ssegment_index;///< convenience typedef
             #endif
-           
+
             typedef segment_index<char const *> csegment_index;                     ///< convenience typedef
             typedef segment_index<wchar_t const *> wcsegment_index;                 ///< convenience typedef
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -1059,7 +1059,7 @@ namespace boost {
             #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             typedef boundary_point_index<std::u32string::const_iterator> u32sboundary_point_index;///< convenience typedef
             #endif
-           
+
             typedef boundary_point_index<char const *> cboundary_point_index;       ///< convenience typedef
             typedef boundary_point_index<wchar_t const *> wcboundary_point_index;   ///< convenience typedef
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T

--- a/include/boost/locale/boundary/segment.hpp
+++ b/include/boost/locale/boundary/segment.hpp
@@ -54,7 +54,7 @@ namespace boundary {
         {
             return compare_text(l.begin(),l.end(),r.begin(),r.end());
         }
-        
+
         template<typename Left,typename Char>
         int compare_string(Left const &l,Char const *begin)
         {
@@ -96,14 +96,14 @@ namespace boundary {
     /// \see
     ///
     /// - \ref segment_index
-    /// - \ref boundary_point 
-    /// - \ref boundary_point_index 
+    /// - \ref boundary_point
+    /// - \ref boundary_point_index
     ///
     template<typename IteratorType>
     class segment : public std::pair<IteratorType,IteratorType> {
     public:
         ///
-        /// The type of the underlying character 
+        /// The type of the underlying character
         ///
         typedef typename std::iterator_traits<IteratorType>::value_type char_type;
         ///
@@ -157,7 +157,7 @@ namespace boundary {
         ///
         /// Get the start of the range
         ///
-        IteratorType begin() const 
+        IteratorType begin() const
         {
             return this->first;
         }
@@ -177,7 +177,7 @@ namespace boundary {
         {
             return std::basic_string<char_type, T, A>(this->first, this->second);
         }
-        
+
         ///
         /// Create a string from the range explicitly
         ///
@@ -234,122 +234,122 @@ namespace boundary {
 
     private:
         rule_type rule_;
-       
+
     };
 
-   
+
     /// Compare two segments
     template<typename IteratorL,typename IteratorR>
     bool operator==(segment<IteratorL> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) == 0; 
+        return details::compare_text(l,r) == 0;
     }
     /// Compare two segments
     template<typename IteratorL,typename IteratorR>
     bool operator!=(segment<IteratorL> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) != 0; 
+        return details::compare_text(l,r) != 0;
     }
 
     /// Compare two segments
     template<typename IteratorL,typename IteratorR>
     bool operator<(segment<IteratorL> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) < 0; 
+        return details::compare_text(l,r) < 0;
     }
     /// Compare two segments
     template<typename IteratorL,typename IteratorR>
     bool operator<=(segment<IteratorL> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) <= 0; 
+        return details::compare_text(l,r) <= 0;
     }
     /// Compare two segments
     template<typename IteratorL,typename IteratorR>
     bool operator>(segment<IteratorL> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) > 0; 
+        return details::compare_text(l,r) > 0;
     }
     /// Compare two segments
     template<typename IteratorL,typename IteratorR>
     bool operator>=(segment<IteratorL> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) >= 0; 
+        return details::compare_text(l,r) >= 0;
     }
 
     /// Compare string and segment
     template<typename CharType,typename Traits,typename Alloc,typename IteratorR>
     bool operator==(std::basic_string<CharType,Traits,Alloc> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) == 0; 
+        return details::compare_text(l,r) == 0;
     }
     /// Compare string and segment
     template<typename CharType,typename Traits,typename Alloc,typename IteratorR>
     bool operator!=(std::basic_string<CharType,Traits,Alloc> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) != 0; 
+        return details::compare_text(l,r) != 0;
     }
 
     /// Compare string and segment
     template<typename CharType,typename Traits,typename Alloc,typename IteratorR>
     bool operator<(std::basic_string<CharType,Traits,Alloc> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) < 0; 
+        return details::compare_text(l,r) < 0;
     }
     /// Compare string and segment
     template<typename CharType,typename Traits,typename Alloc,typename IteratorR>
     bool operator<=(std::basic_string<CharType,Traits,Alloc> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) <= 0; 
+        return details::compare_text(l,r) <= 0;
     }
     /// Compare string and segment
     template<typename CharType,typename Traits,typename Alloc,typename IteratorR>
     bool operator>(std::basic_string<CharType,Traits,Alloc> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) > 0; 
+        return details::compare_text(l,r) > 0;
     }
     /// Compare string and segment
     template<typename CharType,typename Traits,typename Alloc,typename IteratorR>
     bool operator>=(std::basic_string<CharType,Traits,Alloc> const &l,segment<IteratorR> const &r)
     {
-        return details::compare_text(l,r) >= 0; 
+        return details::compare_text(l,r) >= 0;
     }
 
     /// Compare string and segment
     template<typename Iterator,typename CharType,typename Traits,typename Alloc>
     bool operator==(segment<Iterator> const &l,std::basic_string<CharType,Traits,Alloc> const &r)
     {
-        return details::compare_text(l,r) == 0; 
+        return details::compare_text(l,r) == 0;
     }
     /// Compare string and segment
     template<typename Iterator,typename CharType,typename Traits,typename Alloc>
     bool operator!=(segment<Iterator> const &l,std::basic_string<CharType,Traits,Alloc> const &r)
     {
-        return details::compare_text(l,r) != 0; 
+        return details::compare_text(l,r) != 0;
     }
 
     /// Compare string and segment
     template<typename Iterator,typename CharType,typename Traits,typename Alloc>
     bool operator<(segment<Iterator> const &l,std::basic_string<CharType,Traits,Alloc> const &r)
     {
-        return details::compare_text(l,r) < 0; 
+        return details::compare_text(l,r) < 0;
     }
     /// Compare string and segment
     template<typename Iterator,typename CharType,typename Traits,typename Alloc>
     bool operator<=(segment<Iterator> const &l,std::basic_string<CharType,Traits,Alloc> const &r)
     {
-        return details::compare_text(l,r) <= 0; 
+        return details::compare_text(l,r) <= 0;
     }
     /// Compare string and segment
     template<typename Iterator,typename CharType,typename Traits,typename Alloc>
     bool operator>(segment<Iterator> const &l,std::basic_string<CharType,Traits,Alloc> const &r)
     {
-        return details::compare_text(l,r) > 0; 
+        return details::compare_text(l,r) > 0;
     }
     /// Compare string and segment
     template<typename Iterator,typename CharType,typename Traits,typename Alloc>
     bool operator>=(segment<Iterator> const &l,std::basic_string<CharType,Traits,Alloc> const &r)
     {
-        return details::compare_text(l,r) >= 0; 
+        return details::compare_text(l,r) >= 0;
     }
 
 
@@ -357,76 +357,76 @@ namespace boundary {
     template<typename CharType,typename IteratorR>
     bool operator==(CharType const *l,segment<IteratorR> const &r)
     {
-        return details::compare_string(l,r) == 0; 
+        return details::compare_string(l,r) == 0;
     }
     /// Compare C string and segment
     template<typename CharType,typename IteratorR>
     bool operator!=(CharType const *l,segment<IteratorR> const &r)
     {
-        return details::compare_string(l,r) != 0; 
+        return details::compare_string(l,r) != 0;
     }
 
     /// Compare C string and segment
     template<typename CharType,typename IteratorR>
     bool operator<(CharType const *l,segment<IteratorR> const &r)
     {
-        return details::compare_string(l,r) < 0; 
+        return details::compare_string(l,r) < 0;
     }
     /// Compare C string and segment
     template<typename CharType,typename IteratorR>
     bool operator<=(CharType const *l,segment<IteratorR> const &r)
     {
-        return details::compare_string(l,r) <= 0; 
+        return details::compare_string(l,r) <= 0;
     }
     /// Compare C string and segment
     template<typename CharType,typename IteratorR>
     bool operator>(CharType const *l,segment<IteratorR> const &r)
     {
-        return details::compare_string(l,r) > 0; 
+        return details::compare_string(l,r) > 0;
     }
     /// Compare C string and segment
     template<typename CharType,typename IteratorR>
     bool operator>=(CharType const *l,segment<IteratorR> const &r)
     {
-        return details::compare_string(l,r) >= 0; 
+        return details::compare_string(l,r) >= 0;
     }
 
     /// Compare C string and segment
     template<typename Iterator,typename CharType>
     bool operator==(segment<Iterator> const &l,CharType const *r)
     {
-        return details::compare_string(l,r) == 0; 
+        return details::compare_string(l,r) == 0;
     }
     /// Compare C string and segment
     template<typename Iterator,typename CharType>
     bool operator!=(segment<Iterator> const &l,CharType const *r)
     {
-        return details::compare_string(l,r) != 0; 
+        return details::compare_string(l,r) != 0;
     }
 
     /// Compare C string and segment
     template<typename Iterator,typename CharType>
     bool operator<(segment<Iterator> const &l,CharType const *r)
     {
-        return details::compare_string(l,r) < 0; 
+        return details::compare_string(l,r) < 0;
     }
     /// Compare C string and segment
     template<typename Iterator,typename CharType>
     bool operator<=(segment<Iterator> const &l,CharType const *r)
     {
-        return details::compare_string(l,r) <= 0; 
+        return details::compare_string(l,r) <= 0;
     }
     /// Compare C string and segment
     template<typename Iterator,typename CharType>
     bool operator>(segment<Iterator> const &l,CharType const *r)
     {
-        return details::compare_string(l,r) > 0; 
+        return details::compare_string(l,r) > 0;
     }
     /// Compare C string and segment
     template<typename Iterator,typename CharType>
     bool operator>=(segment<Iterator> const &l,CharType const *r)
     {
-        return details::compare_string(l,r) >= 0; 
+        return details::compare_string(l,r) >= 0;
     }
 
 
@@ -442,7 +442,7 @@ namespace boundary {
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     typedef segment<std::u32string::const_iterator> u32ssegment;///< convenience typedef
     #endif
-   
+
     typedef segment<char const *> csegment;                     ///< convenience typedef
     typedef segment<wchar_t const *> wcsegment;                 ///< convenience typedef
     #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -454,8 +454,8 @@ namespace boundary {
 
 
 
- 
-    
+
+
     ///
     /// Write the segment to the stream character by character
     ///

--- a/include/boost/locale/boundary/types.hpp
+++ b/include/boost/locale/boundary/types.hpp
@@ -20,7 +20,7 @@
 namespace boost {
 
     namespace locale {
-        
+
         ///
         /// \brief This namespase contains all operations required for boundary analysis of text
         ///
@@ -51,13 +51,13 @@ namespace boost {
             typedef uint32_t rule_type;
 
             ///
-            /// \anchor bl_boundary_word_rules 
+            /// \anchor bl_boundary_word_rules
             /// \name Flags that describe a type of word selected
             /// @{
             static const rule_type
                 word_none       =  0x0000F,   ///< Not a word, like white space or punctuation mark
                 word_number     =  0x000F0,   ///< Word that appear to be a number
-                word_letter     =  0x00F00,   ///< Word that contains letters, excluding kana and ideographic characters 
+                word_letter     =  0x00F00,   ///< Word that contains letters, excluding kana and ideographic characters
                 word_kana       =  0x0F000,   ///< Word that contains kana characters
                 word_ideo       =  0xF0000,   ///< Word that contains ideographic characters
                 word_any        =  0xFFFF0,   ///< Any word including numbers, 0 is special flag, equivalent to 15
@@ -67,24 +67,24 @@ namespace boost {
             /// @}
 
             ///
-            /// \anchor bl_boundary_line_rules 
+            /// \anchor bl_boundary_line_rules
             /// \name Flags that describe a type of line break
             /// @{
-            static const rule_type 
+            static const rule_type
                 line_soft       =  0x0F,   ///< Soft line break: optional but not required
                 line_hard       =  0xF0,   ///< Hard line break: like break is required (as per CR/LF)
                 line_any        =  0xFF,   ///< Soft or Hard line break
                 line_mask       =  0xFF;   ///< Select all types of line breaks
-            
+
             /// @}
-            
+
             ///
-            /// \anchor bl_boundary_sentence_rules 
+            /// \anchor bl_boundary_sentence_rules
             /// \name Flags that describe a type of sentence break
             ///
             /// @{
             static const rule_type
-                sentence_term   =  0x0F,    ///< \brief The sentence was terminated with a sentence terminator 
+                sentence_term   =  0x0F,    ///< \brief The sentence was terminated with a sentence terminator
                                             ///  like ".", "!" possible followed by hard separator like CR, LF, PS
                 sentence_sep    =  0xF0,    ///< \brief The sentence does not contain terminator like ".", "!" but ended with hard separator
                                             ///  like CR, LF, PS or end of input.
@@ -126,7 +126,7 @@ namespace boost {
         } // boundary
     } // locale
 } // boost
-            
+
 
 #ifdef BOOST_MSVC
 #pragma warning(pop)

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -22,7 +22,7 @@ namespace locale {
     class info;
 
     ///
-    /// \defgroup collation Collation 
+    /// \defgroup collation Collation
     ///
     /// This module introduces collation related classes
     ///
@@ -45,15 +45,15 @@ namespace locale {
             identical   = 4  ///< identical collation level: include code-point comparison
         } level_type;
     };
-    
+
     ///
-    /// \brief Collation facet. 
+    /// \brief Collation facet.
     ///
     /// It reimplements standard C++ std::collate,
     /// allowing usage of std::locale for direct string comparison
     ///
     template<typename CharType>
-    class collator : 
+    class collator :
         public std::collate<CharType>,
         public collator_base
     {
@@ -66,7 +66,7 @@ namespace locale {
         /// Type of string used with this facet
         ///
         typedef std::basic_string<CharType> string_type;
-        
+
 
         ///
         /// Compare two strings in rage [b1,e1),  [b2,e2) according using a collation level \a level. Calls do_compare
@@ -143,16 +143,16 @@ namespace locale {
         {
             return do_transform(level,s.data(),s.data()+s.size());
         }
-        
+
     protected:
 
         ///
         /// constructor of the collator object
         ///
-        collator(size_t refs = 0) : std::collate<CharType>(refs) 
+        collator(size_t refs = 0) : std::collate<CharType>(refs)
         {
         }
-        
+
         ///
         /// This function is used to override default collation function that does not take in account collation level.
         /// Uses primary level
@@ -180,17 +180,17 @@ namespace locale {
         }
 
         ///
-        /// Actual function that performs comparison between the strings. For details see compare member function. Can be overridden. 
+        /// Actual function that performs comparison between the strings. For details see compare member function. Can be overridden.
         ///
         virtual int do_compare( level_type level,
                                 char_type const *b1,char_type const *e1,
                                 char_type const *b2,char_type const *e2) const = 0;
         ///
-        /// Actual function that performs transformation. For details see transform member function. Can be overridden. 
+        /// Actual function that performs transformation. For details see transform member function. Can be overridden.
         ///
         virtual string_type do_transform(level_type level,char_type const *b,char_type const *e) const = 0;
         ///
-        /// Actual function that calculates hash. For details see hash member function. Can be overridden. 
+        /// Actual function that calculates hash. For details see hash member function. Can be overridden.
         ///
         virtual long do_hash(level_type level,char_type const *b,char_type const *e) const = 0;
 
@@ -206,7 +206,7 @@ namespace locale {
     /// \code
     ///  std::map<std::string,std::string,comparator<char,collator_base::secondary> > data;
     /// \endcode
-    /// 
+    ///
     /// Would create a map the keys of which are sorted using secondary collation level
     ///
     template<typename CharType,collator_base::level_type default_level = collator_base::identical>
@@ -217,8 +217,8 @@ namespace locale {
         /// Create a comparator class for locale \a l and with collation leval \a level
         ///
         /// \note throws std::bad_cast if l does not have \ref collator facet installed
-        /// 
-        comparator(std::locale const &l=std::locale(),collator_base::level_type level=default_level) : 
+        ///
+        comparator(std::locale const &l=std::locale(),collator_base::level_type level=default_level) :
             locale_(l),
             level_(level)
         {

--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -21,8 +21,8 @@
 #endif // BOOST_LOCALE_DYN_LINK
 
 //
-// Automatically link to the correct build variant where possible. 
-// 
+// Automatically link to the correct build variant where possible.
+//
 #if !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_LOCALE_NO_LIB) && !defined(BOOST_LOCALE_SOURCE)
 //
 // Set the name of our library, this will get undef'ed by auto_link.hpp

--- a/include/boost/locale/conversion.hpp
+++ b/include/boost/locale/conversion.hpp
@@ -18,15 +18,15 @@
 
 namespace boost {
     namespace locale {
-        
+
         ///
-        /// \defgroup convert Text Conversions 
+        /// \defgroup convert Text Conversions
         ///
         ///  This module provides various function for string manipulation like Unicode normalization, case conversion etc.
         /// @{
         ///
 
-        
+
         ///
         /// \brief This class provides base flags for text manipulation. It is used as base for converter facet.
         ///
@@ -113,7 +113,7 @@ namespace boost {
             {
             }
             ~converter();
-            virtual std::u16string convert(conversion_type how,char16_t const *begin,char16_t const *end,int flags = 0) const = 0; 
+            virtual std::u16string convert(conversion_type how,char16_t const *begin,char16_t const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
             std::locale::id& __get_id (void) const { return id; }
 #endif
@@ -149,16 +149,16 @@ namespace boost {
             norm_nfkc,  ///< Compatibility decomposition followed by canonical composition.
             norm_default = norm_nfc, ///< Default normalization - canonical decomposition followed by canonical composition
         } norm_type;
-       
+
         ///
         /// Normalize Unicode string \a str according to \ref norm_type "normalization form" \a n
         ///
         /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
-        /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside 
+        /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
         /// of a Unicode character set.
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> normalize(std::basic_string<CharType> const &str,norm_type n=norm_default,std::locale const &loc=std::locale())
         {
@@ -169,11 +169,11 @@ namespace boost {
         /// Normalize NUL terminated Unicode string \a str according to \ref norm_type "normalization form" \a n
         ///
         /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
-        /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside 
+        /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
         /// of a Unicode character set.
-        /// 
+        ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> normalize(CharType const *str,norm_type n=norm_default,std::locale const &loc=std::locale())
         {
@@ -182,16 +182,16 @@ namespace boost {
                 end++;
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::normalization,str,end,n);
         }
-        
+
         ///
         /// Normalize Unicode string in range [begin,end) according to \ref norm_type "normalization form" \a n
         ///
         /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
-        /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside 
+        /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
         /// of a Unicode character set.
-        /// 
+        ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> normalize(  CharType const *begin,
                                                 CharType const *end,
@@ -202,24 +202,24 @@ namespace boost {
         }
 
         ///////////////////////////////////////////////////
-        
+
         ///
         /// Convert a string \a str to upper case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
 
         template<typename CharType>
         std::basic_string<CharType> to_upper(std::basic_string<CharType> const &str,std::locale const &loc=std::locale())
         {
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::upper_case,str.data(),str.data()+str.size());
         }
-        
+
         ///
         /// Convert a NUL terminated string \a str to upper case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> to_upper(CharType const *str,std::locale const &loc=std::locale())
         {
@@ -228,12 +228,12 @@ namespace boost {
                 end++;
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::upper_case,str,end);
         }
-        
+
         ///
         /// Convert a string in range [begin,end) to upper case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> to_upper(CharType const *begin,CharType const *end,std::locale const &loc=std::locale())
         {
@@ -241,24 +241,24 @@ namespace boost {
         }
 
         ///////////////////////////////////////////////////
-        
+
         ///
         /// Convert a string \a str to lower case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
 
         template<typename CharType>
         std::basic_string<CharType> to_lower(std::basic_string<CharType> const &str,std::locale const &loc=std::locale())
         {
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::lower_case,str.data(),str.data()+str.size());
         }
-        
+
         ///
         /// Convert a NUL terminated string \a str to lower case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> to_lower(CharType const *str,std::locale const &loc=std::locale())
         {
@@ -267,36 +267,36 @@ namespace boost {
                 end++;
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::lower_case,str,end);
         }
-        
+
         ///
         /// Convert a string in range [begin,end) to lower case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> to_lower(CharType const *begin,CharType const *end,std::locale const &loc=std::locale())
         {
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::lower_case,begin,end);
         }
         ///////////////////////////////////////////////////
-        
+
         ///
         /// Convert a string \a str to title case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
 
         template<typename CharType>
         std::basic_string<CharType> to_title(std::basic_string<CharType> const &str,std::locale const &loc=std::locale())
         {
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::title_case,str.data(),str.data()+str.size());
         }
-        
+
         ///
         /// Convert a NUL terminated string \a str to title case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> to_title(CharType const *str,std::locale const &loc=std::locale())
         {
@@ -305,12 +305,12 @@ namespace boost {
                 end++;
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::title_case,str,end);
         }
-        
+
         ///
         /// Convert a string in range [begin,end) to title case according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> to_title(CharType const *begin,CharType const *end,std::locale const &loc=std::locale())
         {
@@ -318,24 +318,24 @@ namespace boost {
         }
 
         ///////////////////////////////////////////////////
-        
+
         ///
         /// Fold case of a string \a str according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
 
         template<typename CharType>
         std::basic_string<CharType> fold_case(std::basic_string<CharType> const &str,std::locale const &loc=std::locale())
         {
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::case_folding,str.data(),str.data()+str.size());
         }
-        
+
         ///
         /// Fold case of a NUL terminated string \a str according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> fold_case(CharType const *str,std::locale const &loc=std::locale())
         {
@@ -344,12 +344,12 @@ namespace boost {
                 end++;
             return std::use_facet<converter<CharType> >(loc).convert(converter_base::case_folding,str,end);
         }
-        
+
         ///
         /// Fold case of a string in range [begin,end) according to locale \a loc
         ///
         /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-        /// 
+        ///
         template<typename CharType>
         std::basic_string<CharType> fold_case(CharType const *begin,CharType const *end,std::locale const &loc=std::locale())
         {

--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -24,7 +24,7 @@
 namespace boost {
     namespace locale {
         ///
-        /// \defgroup date_time Date, Time, Timezone and Calendar manipulations 
+        /// \defgroup date_time Date, Time, Timezone and Calendar manipulations
         ///
         /// This module provides various calendar, timezone and date time services
         ///
@@ -38,7 +38,7 @@ namespace boost {
         public:
             ///
             /// Constructor of date_time_error class
-            /// 
+            ///
             date_time_error(std::string const &e) : std::runtime_error(e) {}
         };
 
@@ -50,8 +50,8 @@ namespace boost {
         /// Usually obtained as product of period_type and integer or
         /// my calling a representative functions
         /// For example day()*3 == date_time_period(day(),3) == day(3)
-        /// 
-        struct date_time_period 
+        ///
+        struct date_time_period
         {
             period::period_type type;   ///< The type of period, i.e. era, year, day etc.
             int value;                  ///< The value the actual number of \a periods
@@ -63,7 +63,7 @@ namespace boost {
             /// Operator -, switches the sign of period
             ///
             date_time_period operator-() const { return date_time_period(type,-value); }
-            
+
             ///
             /// Constructor that creates date_time_period from period_type \a f and a value \a v -- default 1.
             ///
@@ -109,7 +109,7 @@ namespace boost {
             ///
             inline period_type day_of_week(){ return period_type(marks::day_of_week); }
             ///
-            ///  Get period_type for: Original number of the day of the week in month. For example 1st Sunday, 
+            ///  Get period_type for: Original number of the day of the week in month. For example 1st Sunday,
             /// 2nd Sunday, etc. in Gregorian [1..5]
             ///
             inline period_type day_of_week_in_month(){ return period_type(marks::day_of_week_in_month); }
@@ -153,27 +153,27 @@ namespace boost {
             ///
             ///  Get date_time_period for: Era i.e. AC, BC in Gregorian and Julian calendar, range [0,1]
             ///
-            inline date_time_period era(int v) { return date_time_period(era(),v); } 
+            inline date_time_period era(int v) { return date_time_period(era(),v); }
             ///
             ///  Get date_time_period for: Year, it is calendar specific, for example 2011 in Gregorian calendar.
             ///
-            inline date_time_period year(int v) { return date_time_period(year(),v); } 
+            inline date_time_period year(int v) { return date_time_period(year(),v); }
             ///
             ///  Get date_time_period for: Extended year for Gregorian/Julian calendars, where 1 BC == 0, 2 BC == -1.
             ///
-            inline date_time_period extended_year(int v) { return date_time_period(extended_year(),v); } 
+            inline date_time_period extended_year(int v) { return date_time_period(extended_year(),v); }
             ///
             ///  Get date_time_period for: The month of year, calendar specific, in Gregorian [0..11]
             ///
-            inline date_time_period month(int v) { return date_time_period(month(),v); } 
+            inline date_time_period month(int v) { return date_time_period(month(),v); }
             ///
             ///  Get date_time_period for: The day of month, calendar specific, in Gregorian [1..31]
             ///
-            inline date_time_period day(int v) { return date_time_period(day(),v); } 
+            inline date_time_period day(int v) { return date_time_period(day(),v); }
             ///
             ///  Get date_time_period for: The number of day in year, starting from 1, in Gregorian  [1..366]
             ///
-            inline date_time_period day_of_year(int v) { return date_time_period(day_of_year(),v); } 
+            inline date_time_period day_of_year(int v) { return date_time_period(day_of_year(),v); }
             ///
             ///  Get date_time_period for: Day of week, Sunday=1, Monday=2,..., Saturday=7.
             ///
@@ -182,48 +182,48 @@ namespace boost {
             /// the value to Sunday (1) would forward the date by 5 days forward and not backward
             /// by two days as it could be expected if the numbers were taken as is.
             ///
-            inline date_time_period day_of_week(int v) { return date_time_period(day_of_week(),v); } 
+            inline date_time_period day_of_week(int v) { return date_time_period(day_of_week(),v); }
             ///
-            ///  Get date_time_period for: Original number of the day of the week in month. For example 1st Sunday, 
+            ///  Get date_time_period for: Original number of the day of the week in month. For example 1st Sunday,
             /// 2nd Sunday, etc. in Gregorian [1..5]
             ///
-            inline date_time_period day_of_week_in_month(int v) { return date_time_period(day_of_week_in_month(),v); } 
+            inline date_time_period day_of_week_in_month(int v) { return date_time_period(day_of_week_in_month(),v); }
             ///
             ///  Get date_time_period for: Local day of week, for example in France Monday is 1, in US Sunday is 1, [1..7]
             ///
-            inline date_time_period day_of_week_local(int v) { return date_time_period(day_of_week_local(),v); } 
+            inline date_time_period day_of_week_local(int v) { return date_time_period(day_of_week_local(),v); }
             ///
             ///  Get date_time_period for: 24 clock hour [0..23]
             ///
-            inline date_time_period hour(int v) { return date_time_period(hour(),v); } 
+            inline date_time_period hour(int v) { return date_time_period(hour(),v); }
             ///
             ///  Get date_time_period for: 12 clock hour [0..11]
             ///
-            inline date_time_period hour_12(int v) { return date_time_period(hour_12(),v); } 
+            inline date_time_period hour_12(int v) { return date_time_period(hour_12(),v); }
             ///
             ///  Get date_time_period for: am or pm marker [0..1]
             ///
-            inline date_time_period am_pm(int v) { return date_time_period(am_pm(),v); } 
+            inline date_time_period am_pm(int v) { return date_time_period(am_pm(),v); }
             ///
             ///  Get date_time_period for: minute [0..59]
             ///
-            inline date_time_period minute(int v) { return date_time_period(minute(),v); } 
+            inline date_time_period minute(int v) { return date_time_period(minute(),v); }
             ///
             ///  Get date_time_period for: second [0..59]
             ///
-            inline date_time_period second(int v) { return date_time_period(second(),v); } 
+            inline date_time_period second(int v) { return date_time_period(second(),v); }
             ///
             ///  Get date_time_period for: The week number in the year
             ///
-            inline date_time_period week_of_year(int v) { return date_time_period(week_of_year(),v); } 
+            inline date_time_period week_of_year(int v) { return date_time_period(week_of_year(),v); }
             ///
             ///  Get date_time_period for: The week number within current month
             ///
-            inline date_time_period week_of_month(int v) { return date_time_period(week_of_month(),v); } 
+            inline date_time_period week_of_month(int v) { return date_time_period(week_of_month(),v); }
             ///
             ///  Get date_time_period for: First day of week, constant, for example Sunday in US = 1, Monday in France = 2
             ///
-            inline date_time_period first_day_of_week(int v) { return date_time_period(first_day_of_week(),v); } 
+            inline date_time_period first_day_of_week(int v) { return date_time_period(first_day_of_week(),v); }
 
             ///
             /// Get predefined constant for January
@@ -262,7 +262,7 @@ namespace boost {
             ///
             inline date_time_period september() { return date_time_period(month(),8); }
             ///
-            /// Get predefined constant for October 
+            /// Get predefined constant for October
             ///
             inline date_time_period october() { return date_time_period(month(),9); }
             ///
@@ -279,7 +279,7 @@ namespace boost {
             ///
             inline date_time_period sunday() { return date_time_period(day_of_week(),1); }
             ///
-            /// Get predefined constant for Monday 
+            /// Get predefined constant for Monday
             ///
             inline date_time_period monday() { return date_time_period(day_of_week(),2); }
             ///
@@ -314,7 +314,7 @@ namespace boost {
             ///
             /// convert period_type to date_time_period(f,1)
             ///
-            inline date_time_period operator+(period::period_type f) 
+            inline date_time_period operator+(period::period_type f)
             {
                 return date_time_period(f);
             }
@@ -327,7 +327,7 @@ namespace boost {
             }
 
             ///
-            /// Create date_time_period of type \a f with value \a v. 
+            /// Create date_time_period of type \a f with value \a v.
             ///
             template<typename T>
             date_time_period operator*(period::period_type f,T v)
@@ -336,7 +336,7 @@ namespace boost {
             }
 
             ///
-            /// Create date_time_period of type \a f with value \a v. 
+            /// Create date_time_period of type \a f with value \a v.
             ///
             template<typename T>
             date_time_period operator*(T v,period::period_type f)
@@ -344,7 +344,7 @@ namespace boost {
                 return date_time_period(f,v);
             }
             ///
-            /// Create date_time_period of type \a f with value \a v. 
+            /// Create date_time_period of type \a f with value \a v.
             ///
             template<typename T>
             date_time_period operator*(T v,date_time_period f)
@@ -353,7 +353,7 @@ namespace boost {
             }
 
             ///
-            /// Create date_time_period of type \a f with value \a v. 
+            /// Create date_time_period of type \a f with value \a v.
             ///
             template<typename T>
             date_time_period operator*(date_time_period f,T v)
@@ -366,14 +366,14 @@ namespace boost {
 
 
         ///
-        /// \brief this class that represents a set of periods, 
+        /// \brief this class that represents a set of periods,
         ///
         /// It is generally created by operations on periods:
         /// 1995*year + 3*month + 1*day. Note: operations are not commutative.
         ///
         class date_time_period_set {
         public:
-            
+
             ///
             /// Default constructor - empty set
             ///
@@ -423,7 +423,7 @@ namespace boost {
             ///
             /// Get item at position \a n the set, n should be in range [0,size)
             ///
-            date_time_period const &operator[](size_t n) const 
+            date_time_period const &operator[](size_t n) const
             {
                 if(n >= size())
                     throw std::out_of_range("Invalid index to date_time_period");
@@ -437,9 +437,9 @@ namespace boost {
             std::vector<date_time_period> periods_;
         };
 
-        
+
         ///
-        /// Append two periods sets. Note this operator is not commutative 
+        /// Append two periods sets. Note this operator is not commutative
         ///
         inline date_time_period_set operator+(date_time_period_set const &a,date_time_period_set const &b)
         {
@@ -448,7 +448,7 @@ namespace boost {
                 s.add(b[i]);
             return s;
         }
-        
+
         ///
         /// Append two period sets when all periods of set \b change their sign
         ///
@@ -462,7 +462,7 @@ namespace boost {
 
 
         ///
-        /// \brief this class provides an access to general calendar information. 
+        /// \brief this class provides an access to general calendar information.
         ///
         /// This information is not connected to specific date but generic to locale, and timezone.
         /// It is used in obtaining general information about calendar and is essential for creation of
@@ -473,34 +473,34 @@ namespace boost {
 
             ///
             /// Create calendar taking locale and timezone information from ios_base instance.
-            /// 
+            ///
             /// \note throws std::bad_cast if ios does not have a locale with installed \ref calendar_facet
             /// facet installed
-            /// 
+            ///
             calendar(std::ios_base &ios);
             ///
             /// Create calendar with locale \a l and time_zone \a zone
             ///
             /// \note throws std::bad_cast if loc does not have \ref calendar_facet facet installed
-            /// 
+            ///
             calendar(std::locale const &l,std::string const &zone);
             ///
             /// Create calendar with locale \a l and default timezone
             ///
             /// \note throws std::bad_cast if loc does not have \ref calendar_facet facet installed
-            /// 
+            ///
             calendar(std::locale const &l);
             ///
             /// Create calendar with default locale and timezone \a zone
             ///
             /// \note throws std::bad_cast if global locale does not have \ref calendar_facet facet installed
-            /// 
+            ///
             calendar(std::string const &zone);
             ///
-            /// Create calendar with default locale and timezone 
+            /// Create calendar with default locale and timezone
             ///
             /// \note throws std::bad_cast if global locale does not have \ref calendar_facet facet installed
-            /// 
+            ///
             calendar();
             ~calendar();
 
@@ -584,7 +584,7 @@ namespace boost {
         /// some_time = year * 1995 that sets the year to 1995.
         ///
         ///
-        
+
         class BOOST_LOCALE_DECL date_time {
         public:
 
@@ -592,7 +592,7 @@ namespace boost {
             /// Dafault constructor, uses default calendar initialized date_time object to current time.
             ///
             /// \note throws std::bad_cast if the global locale does not have \ref calendar_facet facet installed
-            /// 
+            ///
             date_time();
             ///
             /// copy date_time
@@ -612,7 +612,7 @@ namespace boost {
             /// Create a date_time object using POSIX time \a time and default calendar
             ///
             /// \note throws std::bad_cast if the global locale does not have \ref calendar_facet facet installed
-            /// 
+            ///
             date_time(double time);
             ///
             /// Create a date_time object using POSIX time \a time and calendar \a cal
@@ -622,21 +622,21 @@ namespace boost {
             /// Create a date_time object using calendar \a cal and initializes it to current time.
             ///
             date_time(calendar const &cal);
-            
+
             ///
             /// Create a date_time object using default calendar and define values given in \a set
             ///
             /// \note throws std::bad_cast if the global locale does not have \ref calendar_facet facet installed
-            /// 
+            ///
             date_time(date_time_period_set const &set);
             ///
             /// Create a date_time object using calendar \a cal and define values given in \a set
             ///
             date_time(date_time_period_set const &set,calendar const &cal);
 
-           
+
             ///
-            /// assign values to various periods in set \a f  
+            /// assign values to various periods in set \a f
             ///
             date_time const &operator=(date_time_period_set const &f);
 
@@ -847,7 +847,7 @@ namespace boost {
             int maximum(period::period_type f) const;
 
             ///
-            /// Check if *this time point is in daylight saving time 
+            /// Check if *this time point is in daylight saving time
             ///
             bool is_in_daylight_saving_time() const;
 
@@ -867,18 +867,18 @@ namespace boost {
         /// \endcode
         ///
         /// The output may be Year:5770 Full Date:Jan 1, 2010
-        /// 
+        ///
         template<typename CharType>
         std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out,date_time const &t)
         {
             double time_point = t.time();
             uint64_t display_flags = ios_info::get(out).display_flags();
             if  (
-                    display_flags == flags::date 
-                    || display_flags == flags::time 
-                    || display_flags == flags::datetime 
+                    display_flags == flags::date
+                    || display_flags == flags::time
+                    || display_flags == flags::datetime
                     || display_flags == flags::strftime
-                ) 
+                )
             {
                 out << time_point;
             }
@@ -901,11 +901,11 @@ namespace boost {
             double v;
             uint64_t display_flags = ios_info::get(in).display_flags();
             if  (
-                    display_flags == flags::date 
-                    || display_flags == flags::time 
-                    || display_flags == flags::datetime 
+                    display_flags == flags::date
+                    || display_flags == flags::time
+                    || display_flags == flags::datetime
                     || display_flags == flags::strftime
-                ) 
+                )
             {
                 in >> v;
             }
@@ -921,7 +921,7 @@ namespace boost {
 
         ///
         /// \brief This class represents a period: a pair of two date_time objects.
-        /// 
+        ///
         /// It is generally used as syntactic sugar to calculate difference between two dates.
         ///
         /// Note: it stores references to the original objects, so it is not recommended to be used
@@ -933,13 +933,13 @@ namespace boost {
             ///
             /// Create an object were \a first represents earlier point on time line and \a second is later
             /// point.
-            /// 
+            ///
             date_time_duration(date_time const &first,date_time const &second) :
                 s_(first),
                 e_(second)
             {
             }
-            
+
             ///
             /// find a difference in terms of period_type \a f
             ///
@@ -978,32 +978,32 @@ namespace boost {
             return date_time_duration(earlier,later);
         }
 
-        
+
         namespace period {
             ///
             ///  Extract from date_time numerical value of Era i.e. AC, BC in Gregorian and Julian calendar, range [0,1]
             ///
-            inline int era(date_time const &dt) { return dt.get(era()); } 
+            inline int era(date_time const &dt) { return dt.get(era()); }
             ///
             ///  Extract from date_time numerical value of Year, it is calendar specific, for example 2011 in Gregorian calendar.
             ///
-            inline int year(date_time const &dt) { return dt.get(year()); } 
+            inline int year(date_time const &dt) { return dt.get(year()); }
             ///
             ///  Extract from date_time numerical value of Extended year for Gregorian/Julian calendars, where 1 BC == 0, 2 BC == -1.
             ///
-            inline int extended_year(date_time const &dt) { return dt.get(extended_year()); } 
+            inline int extended_year(date_time const &dt) { return dt.get(extended_year()); }
             ///
             ///  Extract from date_time numerical value of The month of year, calendar specific, in Gregorian [0..11]
             ///
-            inline int month(date_time const &dt) { return dt.get(month()); } 
+            inline int month(date_time const &dt) { return dt.get(month()); }
             ///
             ///  Extract from date_time numerical value of The day of month, calendar specific, in Gregorian [1..31]
             ///
-            inline int day(date_time const &dt) { return dt.get(day()); } 
+            inline int day(date_time const &dt) { return dt.get(day()); }
             ///
             ///  Extract from date_time numerical value of The number of day in year, starting from 1, in Gregorian  [1..366]
             ///
-            inline int day_of_year(date_time const &dt) { return dt.get(day_of_year()); } 
+            inline int day_of_year(date_time const &dt) { return dt.get(day_of_year()); }
             ///
             ///  Extract from date_time numerical value of Day of week, Sunday=1, Monday=2,..., Saturday=7.
             ///
@@ -1012,121 +1012,121 @@ namespace boost {
             /// the value to Sunday (1) would forward the date by 5 days forward and not backward
             /// by two days as it could be expected if the numbers were taken as is.
             ///
-            inline int day_of_week(date_time const &dt) { return dt.get(day_of_week()); } 
+            inline int day_of_week(date_time const &dt) { return dt.get(day_of_week()); }
             ///
-            ///  Extract from date_time numerical value of Original number of the day of the week in month. For example 1st Sunday, 
+            ///  Extract from date_time numerical value of Original number of the day of the week in month. For example 1st Sunday,
             /// 2nd Sunday, etc. in Gregorian [1..5]
             ///
-            inline int day_of_week_in_month(date_time const &dt) { return dt.get(day_of_week_in_month()); } 
+            inline int day_of_week_in_month(date_time const &dt) { return dt.get(day_of_week_in_month()); }
             ///
             ///  Extract from date_time numerical value of Local day of week, for example in France Monday is 1, in US Sunday is 1, [1..7]
             ///
-            inline int day_of_week_local(date_time const &dt) { return dt.get(day_of_week_local()); } 
+            inline int day_of_week_local(date_time const &dt) { return dt.get(day_of_week_local()); }
             ///
             ///  Extract from date_time numerical value of 24 clock hour [0..23]
             ///
-            inline int hour(date_time const &dt) { return dt.get(hour()); } 
+            inline int hour(date_time const &dt) { return dt.get(hour()); }
             ///
             ///  Extract from date_time numerical value of 12 clock hour [0..11]
             ///
-            inline int hour_12(date_time const &dt) { return dt.get(hour_12()); } 
+            inline int hour_12(date_time const &dt) { return dt.get(hour_12()); }
             ///
             ///  Extract from date_time numerical value of am or pm marker [0..1]
             ///
-            inline int am_pm(date_time const &dt) { return dt.get(am_pm()); } 
+            inline int am_pm(date_time const &dt) { return dt.get(am_pm()); }
             ///
             ///  Extract from date_time numerical value of minute [0..59]
             ///
-            inline int minute(date_time const &dt) { return dt.get(minute()); } 
+            inline int minute(date_time const &dt) { return dt.get(minute()); }
             ///
             ///  Extract from date_time numerical value of second [0..59]
             ///
-            inline int second(date_time const &dt) { return dt.get(second()); } 
+            inline int second(date_time const &dt) { return dt.get(second()); }
             ///
             ///  Extract from date_time numerical value of The week number in the year
             ///
-            inline int week_of_year(date_time const &dt) { return dt.get(week_of_year()); } 
+            inline int week_of_year(date_time const &dt) { return dt.get(week_of_year()); }
             ///
             ///  Extract from date_time numerical value of The week number within current month
             ///
-            inline int week_of_month(date_time const &dt) { return dt.get(week_of_month()); } 
+            inline int week_of_month(date_time const &dt) { return dt.get(week_of_month()); }
             ///
             ///  Extract from date_time numerical value of First day of week, constant, for example Sunday in US = 1, Monday in France = 2
             ///
-            inline int first_day_of_week(date_time const &dt) { return dt.get(first_day_of_week()); } 
-            
+            inline int first_day_of_week(date_time const &dt) { return dt.get(first_day_of_week()); }
+
             ///
             ///  Extract from date_time_duration numerical value of duration in  Era i.e. AC, BC in Gregorian and Julian calendar, range [0,1]
             ///
-            inline int era(date_time_duration const &dt) { return dt.get(era()); } 
+            inline int era(date_time_duration const &dt) { return dt.get(era()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in years
             ///
-            inline int year(date_time_duration const &dt) { return dt.get(year()); } 
+            inline int year(date_time_duration const &dt) { return dt.get(year()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in extended years (for Gregorian/Julian calendars, where 1 BC == 0, 2 BC == -1).
             ///
-            inline int extended_year(date_time_duration const &dt) { return dt.get(extended_year()); } 
+            inline int extended_year(date_time_duration const &dt) { return dt.get(extended_year()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in months
             ///
-            inline int month(date_time_duration const &dt) { return dt.get(month()); } 
+            inline int month(date_time_duration const &dt) { return dt.get(month()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in days of month
             ///
-            inline int day(date_time_duration const &dt) { return dt.get(day()); } 
+            inline int day(date_time_duration const &dt) { return dt.get(day()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in days of year
             ///
-            inline int day_of_year(date_time_duration const &dt) { return dt.get(day_of_year()); } 
+            inline int day_of_year(date_time_duration const &dt) { return dt.get(day_of_year()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in days of week
             ///
-            inline int day_of_week(date_time_duration const &dt) { return dt.get(day_of_week()); } 
+            inline int day_of_week(date_time_duration const &dt) { return dt.get(day_of_week()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in original number of the day of the week in month
             ///
-            inline int day_of_week_in_month(date_time_duration const &dt) { return dt.get(day_of_week_in_month()); } 
+            inline int day_of_week_in_month(date_time_duration const &dt) { return dt.get(day_of_week_in_month()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in local day of week
             ///
-            inline int day_of_week_local(date_time_duration const &dt) { return dt.get(day_of_week_local()); } 
+            inline int day_of_week_local(date_time_duration const &dt) { return dt.get(day_of_week_local()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in hours
             ///
-            inline int hour(date_time_duration const &dt) { return dt.get(hour()); } 
+            inline int hour(date_time_duration const &dt) { return dt.get(hour()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in  12 clock hours
             ///
-            inline int hour_12(date_time_duration const &dt) { return dt.get(hour_12()); } 
+            inline int hour_12(date_time_duration const &dt) { return dt.get(hour_12()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in  am or pm markers
             ///
-            inline int am_pm(date_time_duration const &dt) { return dt.get(am_pm()); } 
+            inline int am_pm(date_time_duration const &dt) { return dt.get(am_pm()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in  minutes
             ///
-            inline int minute(date_time_duration const &dt) { return dt.get(minute()); } 
+            inline int minute(date_time_duration const &dt) { return dt.get(minute()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in  seconds
             ///
-            inline int second(date_time_duration const &dt) { return dt.get(second()); } 
+            inline int second(date_time_duration const &dt) { return dt.get(second()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in the week number in the year
             ///
-            inline int week_of_year(date_time_duration const &dt) { return dt.get(week_of_year()); } 
+            inline int week_of_year(date_time_duration const &dt) { return dt.get(week_of_year()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in  The week number within current month
             ///
-            inline int week_of_month(date_time_duration const &dt) { return dt.get(week_of_month()); } 
+            inline int week_of_month(date_time_duration const &dt) { return dt.get(week_of_month()); }
             ///
             ///  Extract from date_time_duration numerical value of duration in the first day of week
             ///
-            inline int first_day_of_week(date_time_duration const &dt) { return dt.get(first_day_of_week()); } 
+            inline int first_day_of_week(date_time_duration const &dt) { return dt.get(first_day_of_week()); }
 
 
         }
-        
+
         /// @}
 
 

--- a/include/boost/locale/date_time_facet.hpp
+++ b/include/boost/locale/date_time_facet.hpp
@@ -41,7 +41,7 @@ namespace boost {
                                                 ///< If first day of week is Monday and the current day is Tuesday then setting
                                                 ///< the value to Sunday (1) would forward the date by 5 days forward and not backward
                                                 ///< by two days as it could be expected if the numbers were taken as is.
-                    day_of_week_in_month,       ///< Original number of the day of the week in month. For example 1st Sunday, 
+                    day_of_week_in_month,       ///< Original number of the day of the week in month. For example 1st Sunday,
                                                 ///< 2nd Sunday, etc. in Gregorian [1..5]
                     day_of_week_local,          ///< Local day of week, for example in France Monday is 1, in US Sunday is 1, [1..7]
                     hour,                       ///< 24 clock hour [0..23]
@@ -72,13 +72,13 @@ namespace boost {
                 ///
                 /// Create a period of specific type, default is invalid.
                 ///
-                period_type(marks::period_mark m = marks::invalid) : mark_(m) 
+                period_type(marks::period_mark m = marks::invalid) : mark_(m)
                 {
                 }
-               
+
                 ///
                 /// Get the value of marks::period_mark it was created with.
-                /// 
+                ///
                 marks::period_mark mark() const
                 {
                     return mark_;
@@ -233,7 +233,7 @@ namespace boost {
             ///
             /// Basic constructor
             ///
-            calendar_facet(size_t refs = 0) : std::locale::facet(refs) 
+            calendar_facet(size_t refs = 0) : std::locale::facet(refs)
             {
             }
             ///

--- a/include/boost/locale/encoding.hpp
+++ b/include/boost/locale/encoding.hpp
@@ -46,7 +46,7 @@ namespace boost {
             /// convert string to UTF string from text in range [begin,end) encoded according to locale \a loc according to policy \a how
             ///
             /// \note throws std::bad_cast if the loc does not have \ref info facet installed
-            /// 
+            ///
             template<typename CharType>
             std::basic_string<CharType> to_utf(char const *begin,char const *end,std::locale const &loc,method_type how=default_method)
             {
@@ -57,7 +57,7 @@ namespace boost {
             /// convert UTF text in range [begin,end) to a text encoded according to locale \a loc according to policy \a how
             ///
             /// \note throws std::bad_cast if the loc does not have \ref info facet installed
-            /// 
+            ///
             template<typename CharType>
             std::string from_utf(CharType const *begin,CharType const *end,std::locale const &loc,method_type how=default_method)
             {
@@ -67,7 +67,7 @@ namespace boost {
             ///
             /// convert a string \a text encoded with \a charset to UTF string
             ///
-            
+
             template<typename CharType>
             std::basic_string<CharType> to_utf(std::string const &text,std::string const &charset,method_type how=default_method)
             {
@@ -90,7 +90,7 @@ namespace boost {
             std::basic_string<CharType> to_utf(char const *text,std::string const &charset,method_type how=default_method)
             {
                 char const *text_end = text;
-                while(*text_end) 
+                while(*text_end)
                     text_end++;
                 return to_utf<CharType>(text,text_end,charset,how);
             }
@@ -102,7 +102,7 @@ namespace boost {
             std::string from_utf(CharType const *text,std::string const &charset,method_type how=default_method)
             {
                 CharType const *text_end = text;
-                while(*text_end) 
+                while(*text_end)
                     text_end++;
                 return from_utf(text,text_end,charset,how);
             }
@@ -111,7 +111,7 @@ namespace boost {
             /// Convert a \a text in locale encoding given by \a loc to UTF
             ///
             /// \note throws std::bad_cast if the loc does not have \ref info facet installed
-            /// 
+            ///
             template<typename CharType>
             std::basic_string<CharType> to_utf(std::string const &text,std::locale const &loc,method_type how=default_method)
             {
@@ -122,7 +122,7 @@ namespace boost {
             /// Convert a \a text in UTF to locale encoding given by \a loc
             ///
             /// \note throws std::bad_cast if the loc does not have \ref info facet installed
-            /// 
+            ///
             template<typename CharType>
             std::string from_utf(std::basic_string<CharType> const &text,std::locale const &loc,method_type how=default_method)
             {
@@ -133,12 +133,12 @@ namespace boost {
             /// Convert a \a text in locale encoding given by \a loc to UTF
             ///
             /// \note throws std::bad_cast if the loc does not have \ref info facet installed
-            /// 
+            ///
             template<typename CharType>
             std::basic_string<CharType> to_utf(char const *text,std::locale const &loc,method_type how=default_method)
             {
                 char const *text_end = text;
-                while(*text_end) 
+                while(*text_end)
                     text_end++;
                 return to_utf<CharType>(text,text_end,loc,how);
             }
@@ -147,12 +147,12 @@ namespace boost {
             /// Convert a \a text in UTF to locale encoding given by \a loc
             ///
             /// \note throws std::bad_cast if the loc does not have \ref info facet installed
-            /// 
+            ///
             template<typename CharType>
             std::string from_utf(CharType const *text,std::locale const &loc,method_type how=default_method)
             {
                 CharType const *text_end = text;
-                while(*text_end) 
+                while(*text_end)
                     text_end++;
                 return from_utf(text,text_end,loc,how);
             }
@@ -161,7 +161,7 @@ namespace boost {
             ///
             /// Convert a text in range [begin,end) to \a to_encoding from \a from_encoding
             ///
-            
+
             BOOST_LOCALE_DECL
             std::string between(char const *begin,
                                 char const *end,
@@ -172,7 +172,7 @@ namespace boost {
             ///
             /// Convert a \a text to \a to_encoding from \a from_encoding
             ///
-            
+
             inline
             std::string between(char const *text,
                                 std::string const &to_encoding,
@@ -196,7 +196,7 @@ namespace boost {
             {
                 return boost::locale::conv::between(text.c_str(),text.c_str()+text.size(),to_encoding,from_encoding,how);
             }
-          
+
             /// \cond INTERNAL
 
             template<>

--- a/include/boost/locale/encoding_errors.hpp
+++ b/include/boost/locale/encoding_errors.hpp
@@ -20,7 +20,7 @@ namespace boost {
     namespace locale {
         namespace conv {
             ///
-            /// \addtogroup codepage 
+            /// \addtogroup codepage
             ///
             /// @{
 
@@ -31,7 +31,7 @@ namespace boost {
             public:
                 conversion_error() : std::runtime_error("Conversion failed") {}
             };
-            
+
             ///
             /// \brief This exception is thrown in case of use of unsupported
             /// or invalid character set
@@ -40,12 +40,12 @@ namespace boost {
             public:
 
                 /// Create an error for charset \a charset
-                invalid_charset_error(std::string charset) : 
+                invalid_charset_error(std::string charset) :
                     std::runtime_error("Invalid or unsupported charset:" + charset)
                 {
                 }
             };
-            
+
 
             ///
             /// enum that defines conversion policy

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -22,7 +22,7 @@
 
 namespace boost {
     namespace locale {
-        
+
         ///
         /// \defgroup format Format
         ///
@@ -44,7 +44,7 @@ namespace boost {
                     writer_(&formattible::void_write)
                 {
                 }
-                
+
                 formattible(formattible const &other) :
                     pointer_(other.pointer_),
                     writer_(other.writer_)
@@ -59,7 +59,7 @@ namespace boost {
                     }
                     return *this;
                 }
-                
+
                 template<typename Type>
                 formattible(Type const &value)
                 {
@@ -92,18 +92,18 @@ namespace boost {
                 {
                     output << *static_cast<Type const *>(ptr);
                 }
-                
+
                 void const *pointer_;
                 writer_type writer_;
             }; // formattible
-    
+
             class BOOST_LOCALE_DECL format_parser  {
             public:
                 format_parser(std::ios_base &ios,void *,void (*imbuer)(void *,std::locale const &));
                 ~format_parser();
-                
+
                 unsigned get_position();
-                
+
                 void set_one_flag(std::string const &key,std::string const &value);
 
                 template<typename CharType>
@@ -149,7 +149,7 @@ namespace boost {
         ///
         /// For example:
         ///
-        /// \code 
+        /// \code
         ///   cout << format("The height of water at {1,time} is {2,num=fixed,precision=3}") % time % height;
         /// \endcode
         ///
@@ -161,10 +161,10 @@ namespace boost {
         ///     -  \c oct -- display in octal format
         ///     -  \c sci or \c scientific -- display in scientific format
         ///     -  \c fix or \c fixed -- display in fixed format
-        ///     .      
+        ///     .
         ///     For example \c number=sci
         /// -  \c cur or \c currency -- format currency. Optional values are:
-        /// 
+        ///
         ///     -  \c iso -- display using ISO currency symbol.
         ///     -  \c nat or \c national -- display using national currency symbol.
         ///     .
@@ -196,28 +196,28 @@ namespace boost {
         ///    \code
         ///    cout << format("Local time is: {1,time,local}, universal time is {1,time,gmt}") % time;
         ///    \endcode
-        /// 
-        /// 
+        ///
+        ///
         /// Invalid formatting strings are slightly ignored. This would prevent from translator
         /// to crash the program in unexpected location.
-        /// 
+        ///
         template<typename CharType>
         class basic_format {
         public:
             typedef CharType char_type; ///< Underlying character type
             typedef basic_message<char_type> message_type; ///< The translation message type
             /// \cond INTERNAL
-            typedef details::formattible<CharType> formattible_type; 
-            /// \endcond 
+            typedef details::formattible<CharType> formattible_type;
+            /// \endcond
 
             typedef std::basic_string<CharType> string_type; ///< string type for this type of character
             typedef std::basic_ostream<CharType> stream_type; ///< output stream type for this type of character
- 
+
 
             ///
             /// Create a format class for \a format_string
             ///
-            basic_format(string_type format_string) : 
+            basic_format(string_type format_string) :
                 format_(format_string),
                 translate_(false),
                 parameters_count_(0)
@@ -227,7 +227,7 @@ namespace boost {
             /// Create a format class using message \a trans. The message if translated first according
             /// to the rules of target locale and then interpreted as format string
             ///
-            basic_format(message_type const &trans) : 
+            basic_format(message_type const &trans) :
                 message_(trans),
                 translate_(true),
                 parameters_count_(0)
@@ -266,17 +266,17 @@ namespace boost {
                     format = message_.str(out.getloc(),ios_info::get(out).domain_id());
                 else
                     format = format_;
-               
+
                 format_output(out,format);
 
             }
-                        
-            
+
+
         private:
 
             class format_guard {
             public:
-                format_guard(details::format_parser &fmt) : 
+                format_guard(details::format_parser &fmt) :
                     fmt_(&fmt),
                     restored_(false)
                 {
@@ -300,7 +300,7 @@ namespace boost {
                 details::format_parser *fmt_;
                 bool restored_;
             };
-            
+
             void format_output(stream_type &out,string_type const &sformat) const
             {
                 char_type obrk='{';
@@ -331,12 +331,12 @@ namespace boost {
                         continue;
                     }
                     pos++;
-                  
+
                     details::format_parser fmt(out,static_cast<void *>(&out),&basic_format::imbue_locale);
 
                     format_guard guard(fmt);
 
-                    while(pos < size) { 
+                    while(pos < size) {
                         std::string key;
                         std::string svalue;
                         string_type value;
@@ -384,9 +384,9 @@ namespace boost {
                         if(use_svalue) {
                             fmt.set_one_flag(key,svalue);
                         }
-                        else 
+                        else
                             fmt.set_flag_with_str(key,value);
-                        
+
                         if(format[pos]==comma) {
                             pos++;
                             continue;
@@ -398,7 +398,7 @@ namespace boost {
                             pos++;
                             break;
                         }
-                        else {                        
+                        else {
                             guard.restore();
                             break;
                         }
@@ -406,9 +406,9 @@ namespace boost {
                 }
             }
 
-      
+
             //
-            // Non-copyable 
+            // Non-copyable
             //
             basic_format(basic_format const &other);
             void operator=(basic_format const &other);
@@ -417,7 +417,7 @@ namespace boost {
             {
                 if(parameters_count_ >= base_params_)
                     ext_params_.push_back(param);
-                else 
+                else
                     parameters_[parameters_count_] = param;
                 parameters_count_++;
             }
@@ -440,7 +440,7 @@ namespace boost {
 
 
             static unsigned const base_params_ = 8;
-            
+
             message_type message_;
             string_type format_;
             bool translate_;

--- a/include/boost/locale/formatting.hpp
+++ b/include/boost/locale/formatting.hpp
@@ -87,7 +87,7 @@ namespace boost {
                 domain_id           ///< Domain code - for message formatting
             } value_type;
 
-            
+
         } // flags
 
         ///
@@ -117,37 +117,37 @@ namespace boost {
             /// Set a flags that define a way for format data like number, spell, currency etc.
             ///
             void display_flags(uint64_t flags);
-            
+
             ///
             /// Set a flags that define how to format currency
             ///
             void currency_flags(uint64_t flags);
-            
+
             ///
             /// Set a flags that define how to format date
             ///
             void date_flags(uint64_t flags);
-            
+
             ///
             /// Set a flags that define how to format time
             ///
             void time_flags(uint64_t flags);
-            
+
             ///
             /// Set a flags that define how to format both date and time
             ///
             void datetime_flags(uint64_t flags);
-            
+
             ///
             /// Set special message domain identification
             ///
             void domain_id(int);
-            
+
             ///
             /// Set time zone for formatting dates and time
             ///
             void time_zone(std::string const &);
-            
+
 
             ///
             /// Set date/time pattern (strftime like)
@@ -164,18 +164,18 @@ namespace boost {
             /// Get a flags that define a way for format data like number, spell, currency etc.
             ///
             uint64_t display_flags() const;
-            
+
             ///
             /// Get a flags that define how to format currency
             ///
             uint64_t currency_flags() const;
 
-            
+
             ///
             /// Get a flags that define how to format date
             ///
             uint64_t date_flags() const;
-            
+
             ///
             /// Get a flags that define how to format time
             ///
@@ -185,17 +185,17 @@ namespace boost {
             /// Get a flags that define how to format both date and time
             ///
             uint64_t datetime_flags() const;
-            
+
             ///
             /// Get special message domain identification
             ///
             int domain_id() const;
-            
+
             ///
             /// Get time zone for formatting dates and time
             ///
             std::string time_zone() const;
-            
+
             ///
             /// Get date/time pattern (strftime like)
             ///
@@ -205,26 +205,26 @@ namespace boost {
                 string_set const &s = date_time_pattern_set();
                 return s.get<CharType>();
             }
-            
+
             /// \cond INTERNAL
             void on_imbue();
             /// \endcond
-            
+
         private:
 
             class string_set;
 
             string_set const &date_time_pattern_set() const;
             string_set &date_time_pattern_set();
-            
+
             class BOOST_LOCALE_DECL string_set {
             public:
-                string_set(); 
+                string_set();
                 ~string_set();
                 string_set(string_set const &other);
                 string_set const &operator=(string_set const &other);
                 void swap(string_set &other);
-                
+
                 template<typename Char>
                 void set(Char const *s)
                 {
@@ -279,7 +279,7 @@ namespace boost {
             /// Format values with "POSIX" or "C"  locale. Note, if locale was created with additional non-classic locale then
             /// These numbers may be localized
             ///
-            
+
             inline std::ios_base & posix(std::ios_base & ios)
             {
                 ios_info::get(ios).display_flags(flags::posix);
@@ -295,7 +295,7 @@ namespace boost {
                 ios_info::get(ios).display_flags(flags::number);
                 return ios;
             }
-            
+
             ///
             /// Format currency, number is treated like amount of money
             ///
@@ -304,7 +304,7 @@ namespace boost {
                 ios_info::get(ios).display_flags(flags::currency);
                 return ios;
             }
-            
+
             ///
             /// Format percent, value 0.3 is treated as 30%.
             ///
@@ -313,7 +313,7 @@ namespace boost {
                 ios_info::get(ios).display_flags(flags::percent);
                 return ios;
             }
-            
+
             ///
             /// Format a date, number is treated as POSIX time
             ///
@@ -350,7 +350,7 @@ namespace boost {
                 ios_info::get(ios).display_flags(flags::strftime);
                 return ios;
             }
-            
+
             ///
             /// Spell the number, like "one hundred and ten"
             ///
@@ -359,7 +359,7 @@ namespace boost {
                 ios_info::get(ios).display_flags(flags::spellout);
                 return ios;
             }
-            
+
             ///
             /// Write an order of the number like 4th.
             ///
@@ -484,10 +484,10 @@ namespace boost {
             {
                 ios_info::get(ios).date_flags(flags::date_full);
                 return ios;
-            }            
-            
-            
-            /// \cond INTERNAL 
+            }
+
+
+            /// \cond INTERNAL
             namespace details {
                 template<typename CharType>
                 struct add_ftime {
@@ -508,7 +508,7 @@ namespace boost {
                     fmt.apply(out);
                     return out;
                 }
-                
+
                 template<typename CharType>
                 std::basic_istream<CharType> &operator>>(std::basic_istream<CharType> &in,add_ftime<CharType> const &fmt)
                 {
@@ -517,7 +517,7 @@ namespace boost {
                 }
 
             }
-            /// \endcond 
+            /// \endcond
 
             ///
             /// Set strftime like formatting string
@@ -559,7 +559,7 @@ namespace boost {
             #ifdef BOOST_LOCALE_DOXYGEN
             unspecified_type
             #else
-            details::add_ftime<CharType> 
+            details::add_ftime<CharType>
             #endif
             ftime(std::basic_string<CharType> const &format)
             {
@@ -575,7 +575,7 @@ namespace boost {
             #ifdef BOOST_LOCALE_DOXYGEN
             unspecified_type
             #else
-            details::add_ftime<CharType> 
+            details::add_ftime<CharType>
             #endif
             ftime(CharType const *format)
             {
@@ -595,7 +595,7 @@ namespace boost {
                     ios_info::get(out).time_zone(fmt.id);
                     return out;
                 }
-                
+
                 template<typename CharType>
                 std::basic_istream<CharType> &operator>>(std::basic_istream<CharType> &in,set_timezone const &fmt)
                 {
@@ -604,10 +604,10 @@ namespace boost {
                 }
             }
             /// \endcond
-            
+
             ///
             /// Set GMT time zone to stream
-            /// 
+            ///
             inline std::ios_base &gmt(std::ios_base &ios)
             {
                 ios_info::get(ios).time_zone("GMT");
@@ -626,13 +626,13 @@ namespace boost {
             ///
             /// Set time zone using \a id
             ///
-            inline 
+            inline
             #ifdef BOOST_LOCALE_DOXYGEN
             unspecified_type
             #else
-            details::set_timezone 
+            details::set_timezone
             #endif
-            time_zone(char const *id) 
+            time_zone(char const *id)
             {
                 details::set_timezone tz;
                 tz.id=id;
@@ -642,13 +642,13 @@ namespace boost {
             ///
             /// Set time zone using \a id
             ///
-            inline 
+            inline
             #ifdef BOOST_LOCALE_DOXYGEN
             unspecified_type
             #else
-            details::set_timezone 
-            #endif            
-            time_zone(std::string const &id) 
+            details::set_timezone
+            #endif
+            time_zone(std::string const &id)
             {
                 details::set_timezone tz;
                 tz.id=id;
@@ -661,7 +661,7 @@ namespace boost {
         ///
 
         } // as manipulators
-        
+
     } // locale
 } // boost
 

--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -22,7 +22,7 @@
 namespace boost {
 
     ///
-    /// \brief This is the main namespace that encloses all localization classes 
+    /// \brief This is the main namespace that encloses all localization classes
     ///
     namespace locale {
 
@@ -38,7 +38,7 @@ namespace boost {
         static const uint32_t character_first_facet = char_facet;  ///< First facet specific for character type
         static const uint32_t character_last_facet = char32_t_facet; ///< Last facet specific for character type
         static const uint32_t all_characters = 0xFFFF;     ///< Special mask -- generate all
-        
+
         typedef uint32_t character_facet_type; ///<type that specifies the character type that locales can be generated for
 
         static const uint32_t     convert_facet   = 1 << 0;   ///< Generate conversion facets
@@ -48,19 +48,19 @@ namespace boost {
         static const uint32_t     message_facet   = 1 << 4;   ///< Generate message facets
         static const uint32_t     codepage_facet  = 1 << 5;   ///< Generate character set conversion facets (derived from std::codecvt)
         static const uint32_t     boundary_facet  = 1 << 6;   ///< Generate boundary analysis facet
-            
+
         static const uint32_t     per_character_facet_first = convert_facet; ///< First facet specific for character
         static const uint32_t     per_character_facet_last = boundary_facet; ///< Last facet specific for character
 
         static const uint32_t     calendar_facet  = 1 << 16;   ///< Generate boundary analysis facet
         static const uint32_t     information_facet = 1 << 17;   ///< Generate general locale information facet
 
-        static const uint32_t    non_character_facet_first = calendar_facet; ///< First character independent facet 
-        static const uint32_t    non_character_facet_last = information_facet;///< Last character independent facet 
+        static const uint32_t    non_character_facet_first = calendar_facet; ///< First character independent facet
+        static const uint32_t    non_character_facet_last = information_facet;///< Last character independent facet
 
-            
+
         static const uint32_t    all_categories  = 0xFFFFFFFFu;   ///< Generate all of them
-        
+
         typedef uint32_t locale_category_type; ///< a type used for more fine grained generation of facets
 
         ///
@@ -74,11 +74,11 @@ namespace boost {
         public:
 
             ///
-            /// Create new generator using global localization_backend_manager 
+            /// Create new generator using global localization_backend_manager
             ///
             generator();
             ///
-            /// Create new generator using specific localization_backend_manager 
+            /// Create new generator using specific localization_backend_manager
             ///
             generator(localization_backend_manager const &);
 
@@ -92,7 +92,7 @@ namespace boost {
             /// Get types of facets that should be generated, default all
             ///
             locale_category_type categories() const;
-            
+
             ///
             /// Set the characters type for which the facets should be generated, default all supported
             ///
@@ -141,13 +141,13 @@ namespace boost {
             ///
             /// - Under the Windows platform the path is treated as a path in the locale's encoding so
             ///   if you create locale "en_US.windows-1251" then path would be treated as cp1255,
-            ///   and if it is en_US.UTF-8 it is treated as UTF-8. File name is always opened with 
+            ///   and if it is en_US.UTF-8 it is treated as UTF-8. File name is always opened with
             ///   a wide file name as wide file names are the native file name on Windows.
             ///
             /// - Under POSIX platforms all paths passed as-is regardless of encoding as narrow
             ///   encodings are the native encodings for POSIX platforms.
-            ///   
-            /// 
+            ///
+            ///
             void add_messages_path(std::string const &path);
 
             ///
@@ -200,7 +200,7 @@ namespace boost {
             {
                 return generate(id);
             }
-            
+
             ///
             /// Set backend specific option
             ///
@@ -230,5 +230,5 @@ namespace boost {
 
 
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/include/boost/locale/generic_codecvt.hpp
+++ b/include/boost/locale/generic_codecvt.hpp
@@ -47,7 +47,7 @@ public:
 ///
 /// Implementations should dervide from this class defining itself as CodecvtImpl and provide following members
 ///
-/// - `state_type` - a type of special object that allows to store intermediate cached data, for example `iconv_t` descriptor 
+/// - `state_type` - a type of special object that allows to store intermediate cached data, for example `iconv_t` descriptor
 /// - `state_type initial_state(generic_codecvt_base::initial_convertion_state direction) const` - member function that creates initial state
 /// - `int max_encoding_length() const` - a maximal length that one Unicode code point is represented, for UTF-8 for example it is 4 from ISO-8859-1 it is 1
 /// - `utf::code_point to_unicode(state_type &state,char const *&begin,char const *end)` - extract first code point from the text in range [begin,end), in case of success begin would point to the next character sequence to be encoded to next code point, in case of incomplete sequence - utf::incomplete shell be returned, and in case of invalid input sequence utf::illegal shell be returned and begin would remain unmodified
@@ -59,12 +59,12 @@ public:
 /// \code
 ///
 /// template<typename CharType>
-/// class latin1_codecvt :boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> > 
+/// class latin1_codecvt :boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >
 /// {
 /// public:
-///    
-///     /* Standard codecvt constructor */ 
-///     latin1_codecvt(size_t refs = 0) : boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >(refs) 
+///
+///     /* Standard codecvt constructor */
+///     latin1_codecvt(size_t refs = 0) : boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >(refs)
 ///     {
 ///     }
 ///
@@ -75,7 +75,7 @@ public:
 ///     {
 ///         return state_type();
 ///     }
-///     
+///
 ///     int max_encoding_length() const
 ///     {
 ///         return 1;
@@ -85,7 +85,7 @@ public:
 ///     {
 ///        if(begin == end)
 ///           return boost::locale::utf::incomplete;
-///        return *begin++; 
+///        return *begin++;
 ///     }
 ///
 ///     boost::locale::utf::code_point from_unicode(state_type &,boost::locale::utf::code_point u,char *begin,char const *end) const
@@ -95,23 +95,23 @@ public:
 ///        if(begin == end)
 ///           return boost::locale::utf::incomplete;
 ///        *begin = u;
-///        return 1; 
+///        return 1;
 ///     }
 /// };
-/// 
+///
 /// \endcode
-/// 
+///
 /// When external tools used for encoding conversion, the `state_type` is useful to save objects used for conversions. For example,
 /// icu::UConverter can be saved in such a state for an efficient use:
 ///
 /// \code
 /// template<typename CharType>
-/// class icu_codecvt :boost::locale::generic_codecvt<CharType,icu_codecvt<CharType> > 
+/// class icu_codecvt :boost::locale::generic_codecvt<CharType,icu_codecvt<CharType> >
 /// {
 /// public:
-///    
-///     /* Standard codecvt constructor */ 
-///     icu_codecvt(std::string const &name,refs = 0) : 
+///
+///     /* Standard codecvt constructor */
+///     icu_codecvt(std::string const &name,refs = 0) :
 ///         boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >(refs)
 ///     { ... }
 ///
@@ -124,7 +124,7 @@ public:
 ///         state_type ptr(ucnv_safeClone(converter_,0,0,&err,ucnv_close);
 ///         return std::move(ptr);
 ///     }
-///     
+///
 ///     boost::locale::utf::code_point to_unicode(state_type &ptr,char const *&begin,char const *end) const
 ///     {
 ///         UErrorCode err = U_ZERO_ERROR;
@@ -154,7 +154,7 @@ public:
 
     typedef CharType uchar;
 
-    generic_codecvt(size_t refs = 0) : 
+    generic_codecvt(size_t refs = 0) :
         std::codecvt<CharType,char,std::mbstate_t>(refs)
     {
     }
@@ -169,9 +169,9 @@ protected:
     std::codecvt_base::result do_unshift(std::mbstate_t &s,char *from,char * /*to*/,char *&next) const BOOST_OVERRIDE
     {
         boost::uint16_t &state = *reinterpret_cast<boost::uint16_t *>(&s);
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Entering unshift " << std::hex << state << std::dec << std::endl;
-#endif            
+#endif
         if(state != 0)
             return std::codecvt_base::error;
         next=from;
@@ -191,9 +191,9 @@ protected:
     }
 
     int
-    do_length(  std::mbstate_t 
+    do_length(  std::mbstate_t
     #ifdef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
-            const   
+            const
     #endif
             &std_state,
             char const *from,
@@ -225,7 +225,7 @@ protected:
                 else {
                     state = 0;
                 }
-            }        
+            }
         }
         #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
         return static_cast<int>(from - save_from);
@@ -234,7 +234,7 @@ protected:
         #endif
     }
 
-    
+
     std::codecvt_base::result
     do_in(  std::mbstate_t &std_state,
             char const *from,
@@ -245,7 +245,7 @@ protected:
             uchar *&to_next) const BOOST_OVERRIDE
     {
         std::codecvt_base::result r=std::codecvt_base::ok;
-        
+
         // mbstate_t is POD type and should be initialized to 0 (i.a. state = stateT())
         // according to standard. We use it to keep a flag 0/1 for surrogate pair writing
         //
@@ -255,15 +255,15 @@ protected:
         typename CodecvtImpl::state_type cvt_state = implementation().initial_state(generic_codecvt_base::to_unicode_state);
         while(to < to_end && from < from_end)
         {
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
             std::cout << "Entering IN--------------" << std::endl;
             std::cout << "State " << std::hex << state <<std::endl;
             std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif           
+#endif
             char const *from_saved = from;
-            
+
             uint32_t ch=implementation().to_unicode(cvt_state,from,from_end);
-            
+
             if(ch==boost::locale::utf::illegal) {
                 from = from_saved;
                 r=std::codecvt_base::error;
@@ -306,7 +306,7 @@ protected:
         to_next=to;
         if(r == std::codecvt_base::ok && (from!=from_end || state!=0))
             r = std::codecvt_base::partial;
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
@@ -324,10 +324,10 @@ protected:
         }
         std::cout << "State " << std::hex << state <<std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif            
+#endif
         return r;
     }
-    
+
     std::codecvt_base::result
     do_out( std::mbstate_t &std_state,
             uchar const *from,
@@ -349,18 +349,18 @@ protected:
         typename CodecvtImpl::state_type cvt_state = implementation().initial_state(generic_codecvt_base::from_unicode_state);
         while(to < to_end && from < from_end)
         {
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Entering OUT --------------" << std::endl;
         std::cout << "State " << std::hex << state <<std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif            
+#endif
             boost::uint32_t ch=0;
             if(state != 0) {
                 // if the state indicates that 1st surrogate pair was written
                 // we should make sure that the second one that comes is actually
                 // second surrogate
                 boost::uint16_t w1 = state;
-                boost::uint16_t w2 = *from; 
+                boost::uint16_t w2 = *from;
                 // we don't forward from as writing may fail to incomplete or
                 // partial conversion
                 if(0xDC00 <= w2 && w2<=0xDFFF) {
@@ -386,7 +386,7 @@ protected:
                     continue;
                 }
                 else if(0xDC00 <= ch && ch<=0xDFFF) {
-                    // if we observe second surrogate pair and 
+                    // if we observe second surrogate pair and
                     // first only may be expected we should break from the loop with error
                     // as it is illegal input
                     r=std::codecvt_base::error;
@@ -415,7 +415,7 @@ protected:
         to_next=to;
         if(r==std::codecvt_base::ok && from!=from_end)
             r = std::codecvt_base::partial;
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
@@ -433,10 +433,10 @@ protected:
         }
         std::cout << "State " << std::hex << state <<std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif            
+#endif
         return r;
     }
-    
+
 };
 
 ///
@@ -451,16 +451,16 @@ class generic_codecvt<CharType,CodecvtImpl,4> : public std::codecvt<CharType,cha
 public:
     typedef CharType uchar;
 
-    generic_codecvt(size_t refs = 0) : 
+    generic_codecvt(size_t refs = 0) :
         std::codecvt<CharType,char,std::mbstate_t>(refs)
     {
     }
-    
+
     CodecvtImpl const &implementation() const
     {
         return *static_cast<CodecvtImpl const *>(this);
     }
-    
+
 protected:
 
     std::codecvt_base::result do_unshift(std::mbstate_t &/*s*/,char *from,char * /*to*/,char *&next) const BOOST_OVERRIDE
@@ -482,16 +482,16 @@ protected:
     }
 
     int
-    do_length(  std::mbstate_t 
+    do_length(  std::mbstate_t
     #ifdef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
-            const   
-    #endif    
+            const
+    #endif
             &/*state*/,
             char const *from,
             char const *from_end,
             size_t max) const BOOST_OVERRIDE
     {
-        #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST 
+        #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
         char const *start_from = from;
         #else
         size_t save_max = max;
@@ -506,14 +506,14 @@ protected:
             }
             max--;
         }
-        #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST 
+        #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
         return from - start_from;
         #else
         return save_max - max;
         #endif
     }
 
-    
+
     std::codecvt_base::result
     do_in(  std::mbstate_t &/*state*/,
             char const *from,
@@ -524,7 +524,7 @@ protected:
             uchar *&to_next) const BOOST_OVERRIDE
     {
         std::codecvt_base::result r=std::codecvt_base::ok;
-        
+
         // mbstate_t is POD type and should be initialized to 0 (i.a. state = stateT())
         // according to standard. We use it to keep a flag 0/1 for surrogate pair writing
         //
@@ -534,15 +534,15 @@ protected:
         state_type cvt_state = implementation().initial_state(generic_codecvt_base::to_unicode_state);
         while(to < to_end && from < from_end)
         {
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
             std::cout << "Entering IN--------------" << std::endl;
             std::cout << "State " << std::hex << state <<std::endl;
             std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif           
+#endif
             char const *from_saved = from;
-            
+
             uint32_t ch=implementation().to_unicode(cvt_state,from,from_end);
-            
+
             if(ch==boost::locale::utf::illegal) {
                 r=std::codecvt_base::error;
                 from = from_saved;
@@ -559,7 +559,7 @@ protected:
         to_next=to;
         if(r == std::codecvt_base::ok && from!=from_end)
             r = std::codecvt_base::partial;
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
@@ -577,10 +577,10 @@ protected:
         }
         std::cout << "State " << std::hex << state <<std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif            
+#endif
         return r;
     }
-    
+
     std::codecvt_base::result
     do_out( std::mbstate_t &/*std_state*/,
             uchar const *from,
@@ -595,11 +595,11 @@ protected:
         state_type cvt_state = implementation().initial_state(generic_codecvt_base::from_unicode_state);
         while(to < to_end && from < from_end)
         {
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Entering OUT --------------" << std::endl;
         std::cout << "State " << std::hex << state <<std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif            
+#endif
             boost::uint32_t ch=0;
             ch = *from;
             if(!boost::locale::utf::is_valid_codepoint(ch)) {
@@ -622,7 +622,7 @@ protected:
         to_next=to;
         if(r==std::codecvt_base::ok && from!=from_end)
             r = std::codecvt_base::partial;
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
@@ -640,7 +640,7 @@ protected:
         }
         std::cout << "State " << std::hex << state <<std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
-#endif            
+#endif
         return r;
     }
 };

--- a/include/boost/locale/gnu_gettext.hpp
+++ b/include/boost/locale/gnu_gettext.hpp
@@ -39,7 +39,7 @@ namespace gnu_gettext {
         {
         }
 
-        std::string language;   ///< The language we load the catalog for, like "ru", "en", "de" 
+        std::string language;   ///< The language we load the catalog for, like "ru", "en", "de"
         std::string country;    ///< The country we load the catalog for, like "US", "IL"
         std::string variant;    ///< Language variant, like "euro" so it would look for catalog like de_DE\@euro
         std::string encoding;   ///< Required target charset encoding. Ignored for wide characters.
@@ -48,7 +48,7 @@ namespace gnu_gettext {
         ///
         /// \brief This type represents GNU Gettext domain name for the messages.
         ///
-        /// It consists of two parameters: 
+        /// It consists of two parameters:
         ///
         /// - name - the name of the domain - used for opening the file name
         /// - encoding - the encoding of the keys in the sources, default - UTF-8
@@ -64,7 +64,7 @@ namespace gnu_gettext {
             /// be "cp1255" and if n is "hello" then the name would be the same but encoding would be
             /// "UTF-8"
             ///
-            domain(std::string const &n) 
+            domain(std::string const &n)
             {
                 size_t pos = n.find("/");
                 if(pos==std::string::npos) {
@@ -94,14 +94,14 @@ namespace gnu_gettext {
             }
 
         };
-        
+
         typedef std::vector<domain> domains_type;   ///< Type that defines a list of domains that are loaded
                                                     ///< The first one is the default one
         domains_type domains;           ///< Message domains - application name, like my_app. So files named my_app.mo
                                         ///< would be loaded
         std::vector<std::string> paths; ///< Paths to search files in. Under MS Windows it uses encoding
                                         ///< parameter to convert them to wide OS specific paths.
-        
+
         ///
         /// The callback for custom file system support. This callback should read the file named \a file_name
         /// encoded in \a encoding character set into std::vector<char> and return it.
@@ -116,13 +116,13 @@ namespace gnu_gettext {
                     std::vector<char>(
                         std::string const &file_name,
                         std::string const &encoding
-                    ) 
+                    )
                 > callback_type;
 
         ///
         /// The callback for handling custom file systems, if it is empty, the real OS file-system
         /// is being used.
-        /// 
+        ///
         callback_type callback;
 
     };
@@ -136,10 +136,10 @@ namespace gnu_gettext {
     message_format<CharType> *create_messages_facet(messages_info const &info);
 
     /// \cond INTERNAL
-    
+
     template<>
     BOOST_LOCALE_DECL message_format<char> *create_messages_facet(messages_info const &info);
-    
+
     template<>
     BOOST_LOCALE_DECL message_format<wchar_t> *create_messages_facet(messages_info const &info);
 
@@ -147,7 +147,7 @@ namespace gnu_gettext {
     template<>
     BOOST_LOCALE_DECL message_format<char16_t> *create_messages_facet(messages_info const &info);
     #endif
-    
+
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     template<>
     BOOST_LOCALE_DECL message_format<char32_t> *create_messages_facet(messages_info const &info);

--- a/include/boost/locale/hold_ptr.hpp
+++ b/include/boost/locale/hold_ptr.hpp
@@ -10,7 +10,7 @@
 
 #include <boost/locale/config.hpp>
 
-namespace boost { 
+namespace boost {
 namespace locale {
     ///
     /// \brief a smart pointer similar to std::auto_ptr but it is non-copyable and the
@@ -18,7 +18,7 @@ namespace locale {
     ///
     template<typename T>
     class hold_ptr {
-        hold_ptr(hold_ptr const &other); // non copyable 
+        hold_ptr(hold_ptr const &other); // non copyable
         hold_ptr const &operator=(hold_ptr const &other); // non assignable
     public:
         ///
@@ -33,7 +33,7 @@ namespace locale {
         ///
         /// Destroy smart pointer and the object it owns.
         ///
-        ~hold_ptr() 
+        ~hold_ptr()
         {
             delete ptr_;
         }
@@ -43,15 +43,15 @@ namespace locale {
         ///
         T const *get() const { return ptr_; }
         ///
-        /// Get a mutable pointer to the object 
+        /// Get a mutable pointer to the object
         ///
         T *get() { return ptr_; }
 
-        /// 
+        ///
         /// Get a const reference to the object
         ///
         T const &operator *() const { return *ptr_; }
-        /// 
+        ///
         /// Get a mutable reference to the object
         ///
         T &operator *() { return *ptr_; }
@@ -60,7 +60,7 @@ namespace locale {
         ///
         T const *operator->() const { return ptr_; }
         ///
-        /// Get a mutable pointer to the object 
+        /// Get a mutable pointer to the object
         ///
         T *operator->() { return ptr_; }
 

--- a/include/boost/locale/info.hpp
+++ b/include/boost/locale/info.hpp
@@ -30,7 +30,7 @@ namespace boost {
         public:
             ~info();
 
-            static std::locale::id id; ///< This member uniquely defines this facet, required by STL 
+            static std::locale::id id; ///< This member uniquely defines this facet, required by STL
 
             ///
             /// String information about the locale
@@ -50,17 +50,17 @@ namespace boost {
                 utf8_property       ///< Non zero value if uses UTF-8 encoding
             };
 
-          
+
             ///
             /// Standard facet's constructor
-            /// 
+            ///
             info(size_t refs = 0) : std::locale::facet(refs)
             {
             }
             ///
             /// Get language name
             ///
-            std::string language() const 
+            std::string language() const
             {
                 return get_string_property(language_property);
             }
@@ -101,7 +101,7 @@ namespace boost {
             {
                 return get_integer_property(utf8_property) != 0;
             }
-            
+
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
             std::locale::id& __get_id (void) const { return id; }
 #endif

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -26,7 +26,7 @@ namespace boost {
 
         ///
         /// \brief this class represents a localization backend that can be used for localizing your application.
-        /// 
+        ///
         /// Backends are usually registered inside the localization backends manager and allow transparent support
         /// of different backends, so a user can switch the backend by simply linking the application to the correct one.
         ///
@@ -38,18 +38,18 @@ namespace boost {
         ///     by default
         /// -# \c message_path - path to the location of message catalogs (vector of strings)
         /// -# \c message_application - the name of applications that use message catalogs (vector of strings)
-        /// 
+        ///
         /// Each backend can be installed with a different default priotiry so when you work with two different backends, you
         /// can specify priotiry so this backend will be chosen according to their priority.
         ///
-        
+
         class localization_backend {
             localization_backend(localization_backend const &);
             void operator=(localization_backend const &);
         public:
 
             localization_backend() {}
-            
+
             virtual ~localization_backend() {}
 
             ///
@@ -68,11 +68,11 @@ namespace boost {
             virtual void clear_options() = 0;
 
             ///
-            /// Create a facet for category \a category and character type \a type 
+            /// Create a facet for category \a category and character type \a type
             ///
             virtual std::locale install(std::locale const &base,locale_category_type category,character_facet_type type = nochar_facet) = 0;
 
-        }; // localization_backend 
+        }; // localization_backend
 
 
         ///
@@ -83,15 +83,15 @@ namespace boost {
         class BOOST_LOCALE_DECL localization_backend_manager {
         public:
             ///
-            /// New empty localization_backend_manager 
+            /// New empty localization_backend_manager
             ///
             localization_backend_manager();
             ///
-            /// Copy localization_backend_manager 
+            /// Copy localization_backend_manager
             ///
             localization_backend_manager(localization_backend_manager const &);
             ///
-            /// Assign localization_backend_manager 
+            /// Assign localization_backend_manager
             ///
             localization_backend_manager const &operator=(localization_backend_manager const &);
 
@@ -143,29 +143,29 @@ namespace boost {
             /// Clear backend
             ///
             void remove_all_backends();
-            
+
             ///
             /// Get list of all available backends
             ///
             std::vector<std::string> get_all_backends() const;
-            
+
             ///
             /// Select specific backend by name for a category \a category. It allows combining different
             /// backends for user preferences.
             ///
             void select(std::string const &backend_name,locale_category_type category = all_categories);
-           
+
             ///
             /// Set new global backend manager, the old one is returned.
             ///
             /// This function is thread safe
-            /// 
+            ///
             static localization_backend_manager global(localization_backend_manager const &);
             ///
             /// Get global backend manager
             ///
             /// This function is thread safe
-            /// 
+            ///
             static localization_backend_manager global();
         private:
             class impl;
@@ -181,5 +181,5 @@ namespace boost {
 #endif
 
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -30,14 +30,14 @@
 namespace boost {
     namespace locale {
         ///
-        /// \defgroup message Message Formatting (translation) 
+        /// \defgroup message Message Formatting (translation)
         ///
         ///This module provides message translation functionality, i.e. allow your application to speak native language
         ///
         /// @{
-        /// 
+        ///
 
-        /// \cond INTERNAL 
+        /// \cond INTERNAL
 
         template<typename CharType>
         struct base_message_format;
@@ -76,12 +76,12 @@ namespace boost {
             /// If \a context is NULL it is not considered to be a part of the key
             ///
             /// If a translated string is found, it is returned, otherwise NULL is returned
-            /// 
+            ///
             ///
             virtual char_type const *get(int domain_id,char_type const *context,char_type const *id) const = 0;
             ///
             /// This function returns a pointer to the string for a plural message defined by a \a context
-            /// and identification string \a single_id. 
+            /// and identification string \a single_id.
             ///
             /// If \a context is NULL it is not considered to be a part of the key
             ///
@@ -90,7 +90,7 @@ namespace boost {
             /// number.
             ///
             /// If a translated string is found, it is returned, otherwise NULL is returned
-            /// 
+            ///
             ///
             virtual char_type const *get(int domain_id,char_type const *context,char_type const *single_id,int n) const = 0;
 
@@ -115,14 +115,14 @@ namespace boost {
         protected:
             virtual ~message_format() {}
         };
-        
+
         /// \cond INTERNAL
 
         namespace details {
             inline bool is_us_ascii_char(char c)
             {
                 // works for null terminated strings regardless char "signness"
-                return 0<c && c<0x7F; 
+                return 0<c && c<0x7F;
             }
             inline bool is_us_ascii_string(char const *msg)
             {
@@ -164,7 +164,7 @@ namespace boost {
         /// \brief This class represents a message that can be converted to a specific locale message
         ///
         /// It holds the original ASCII string that is queried in the dictionary when converting to the output string.
-        /// The created string may be UTF-8, UTF-16, UTF-32 or other 8-bit encoded string according to the target 
+        /// The created string may be UTF-8, UTF-16, UTF-32 or other 8-bit encoded string according to the target
         /// character type and locale encoding.
         ///
         template<typename CharType>
@@ -177,7 +177,7 @@ namespace boost {
 
             ///
             /// Create default empty message
-            /// 
+            ///
             basic_message() :
                 n_(0),
                 c_id_(0),
@@ -189,7 +189,7 @@ namespace boost {
             ///
             /// Create a simple message from 0 terminated string. The string should exist
             /// until the message is destroyed. Generally useful with static constant strings
-            /// 
+            ///
             explicit basic_message(char_type const *id) :
                 n_(0),
                 c_id_(id),
@@ -203,7 +203,7 @@ namespace boost {
             /// until the message is destroyed. Generally useful with static constant strings.
             ///
             /// \a n is the number, \a single and \a plural are singular and plural forms of the message
-            /// 
+            ///
             explicit basic_message(char_type const *single,char_type const *plural,int n) :
                 n_(n),
                 c_id_(single),
@@ -216,7 +216,7 @@ namespace boost {
             /// Create a simple message from 0 terminated strings, with context
             /// information. The string should exist
             /// until the message is destroyed. Generally useful with static constant strings
-            /// 
+            ///
             explicit basic_message(char_type const *context,char_type const *id) :
                 n_(0),
                 c_id_(id),
@@ -230,7 +230,7 @@ namespace boost {
             /// until the message is destroyed. Generally useful with static constant strings.
             ///
             /// \a n is the number, \a single and \a plural are singular and plural forms of the message
-            /// 
+            ///
             explicit basic_message(char_type const *context,char_type const *single,char_type const *plural,int n) :
                 n_(n),
                 c_id_(single),
@@ -256,7 +256,7 @@ namespace boost {
             /// Create a simple plural form message from strings.
             ///
             /// \a n is the number, \a single and \a plural are single and plural forms of the message
-            /// 
+            ///
             explicit basic_message(string_type const &single,string_type const &plural,int number) :
                 n_(number),
                 c_id_(0),
@@ -284,7 +284,7 @@ namespace boost {
             /// Create a simple plural form message from strings.
             ///
             /// \a n is the number, \a single and \a plural are single and plural forms of the message
-            /// 
+            ///
             explicit basic_message(string_type const &context,string_type const &single,string_type const &plural,int number) :
                 n_(number),
                 c_id_(0),
@@ -355,7 +355,7 @@ namespace boost {
                 std::locale loc;
                 return str(loc,0);
             }
-            
+
             ///
             /// Translate message to a string in the locale \a locale, using default domain
             ///
@@ -363,10 +363,10 @@ namespace boost {
             {
                 return str(locale,0);
             }
-           
+
             ///
             /// Translate message to a string using locale \a locale and message domain  \a domain_id
-            /// 
+            ///
             string_type str(std::locale const &locale,std::string const &domain_id) const
             {
                 int id=0;
@@ -377,7 +377,7 @@ namespace boost {
 
             ///
             /// Translate message to a string using the default locale and message domain  \a domain_id
-            /// 
+            ///
             string_type str(std::string const &domain_id) const
             {
                 int id=0;
@@ -387,13 +387,13 @@ namespace boost {
                 return str(loc,id);
             }
 
-            
+
             ///
             /// Translate message to a string using locale \a loc and message domain index  \a id
-            /// 
+            ///
             string_type str(std::locale const &loc,int id) const
             {
-                string_type buffer;                
+                string_type buffer;
                 char_type const *ptr = write(loc,id,buffer);
                 if(ptr == buffer.c_str())
                     return buffer;
@@ -404,7 +404,7 @@ namespace boost {
 
 
             ///
-            /// Translate message and write to stream \a out, using imbued locale and domain set to the 
+            /// Translate message and write to stream \a out, using imbued locale and domain set to the
             /// stream
             ///
             void write(std::basic_ostream<char_type> &out) const
@@ -437,7 +437,7 @@ namespace boost {
             {
                 return c_id_ ? c_id_ : id_.c_str();
             }
-            
+
             char_type const *write(std::locale const &loc,int domain_id,string_type &buffer) const
             {
                 char_type const *translated = 0;
@@ -446,15 +446,15 @@ namespace boost {
                 char_type const *id = this->id();
                 char_type const *context = this->context();
                 char_type const *plural = this->plural();
-                
+
                 if(*id == 0)
                     return empty_string;
-                
+
                 facet_type const *facet = 0;
                 if(std::has_facet<facet_type>(loc))
                     facet = &std::use_facet<facet_type>(loc);
 
-                if(facet) { 
+                if(facet) {
                     if(!plural) {
                         translated = facet->get(domain_id,context,id);
                     }
@@ -524,7 +524,7 @@ namespace boost {
         /// @{
 
         ///
-        /// \brief Translate a message, \a msg is not copied 
+        /// \brief Translate a message, \a msg is not copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(CharType const *msg)
@@ -532,7 +532,7 @@ namespace boost {
             return basic_message<CharType>(msg);
         }
         ///
-        /// \brief Translate a message in context, \a msg and \a context are not copied 
+        /// \brief Translate a message in context, \a msg and \a context are not copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(   CharType const *context,
@@ -541,7 +541,7 @@ namespace boost {
             return basic_message<CharType>(context,msg);
         }
         ///
-        /// \brief Translate a plural message form, \a single and \a plural are not copied 
+        /// \brief Translate a plural message form, \a single and \a plural are not copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(   CharType const *single,
@@ -551,7 +551,7 @@ namespace boost {
             return basic_message<CharType>(single,plural,n);
         }
         ///
-        /// \brief Translate a plural message from in constext, \a context, \a single and \a plural are not copied 
+        /// \brief Translate a plural message from in constext, \a context, \a single and \a plural are not copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(   CharType const *context,
@@ -561,18 +561,18 @@ namespace boost {
         {
             return basic_message<CharType>(context,single,plural,n);
         }
-        
+
         ///
-        /// \brief Translate a message, \a msg is copied 
+        /// \brief Translate a message, \a msg is copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(std::basic_string<CharType> const &msg)
         {
             return basic_message<CharType>(msg);
         }
-        
+
         ///
-        /// \brief Translate a message in context,\a context and \a msg is copied 
+        /// \brief Translate a message in context,\a context and \a msg is copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(   std::basic_string<CharType> const &context,
@@ -581,7 +581,7 @@ namespace boost {
             return basic_message<CharType>(context,msg);
         }
         ///
-        /// \brief Translate a plural message form in constext, \a context, \a single and \a plural are copied 
+        /// \brief Translate a plural message form in constext, \a context, \a single and \a plural are copied
         ///
         template<typename CharType>
         inline basic_message<CharType> translate(   std::basic_string<CharType> const &context,
@@ -593,7 +593,7 @@ namespace boost {
         }
 
         ///
-        /// \brief Translate a plural message form, \a single and \a plural are copied 
+        /// \brief Translate a plural message form, \a single and \a plural are copied
         ///
 
         template<typename CharType>
@@ -606,8 +606,8 @@ namespace boost {
 
         /// @}
 
-        /// 
-        /// \anchor boost_locale_gettext_family \name Direct message translation functions family 
+        ///
+        /// \anchor boost_locale_gettext_family \name Direct message translation functions family
         ///
 
         ///
@@ -705,7 +705,7 @@ namespace boost {
         ///
 
         template<>
-        struct BOOST_LOCALE_DECL base_message_format<char> : public std::locale::facet 
+        struct BOOST_LOCALE_DECL base_message_format<char> : public std::locale::facet
         {
             base_message_format(size_t refs = 0) : std::locale::facet(refs)
             {
@@ -714,7 +714,7 @@ namespace boost {
         };
 
         template<>
-        struct BOOST_LOCALE_DECL base_message_format<wchar_t> : public std::locale::facet 
+        struct BOOST_LOCALE_DECL base_message_format<wchar_t> : public std::locale::facet
         {
             base_message_format(size_t refs = 0) : std::locale::facet(refs)
             {
@@ -725,7 +725,7 @@ namespace boost {
         #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
 
         template<>
-        struct BOOST_LOCALE_DECL base_message_format<char16_t> : public std::locale::facet 
+        struct BOOST_LOCALE_DECL base_message_format<char16_t> : public std::locale::facet
         {
             base_message_format(size_t refs = 0) : std::locale::facet(refs)
             {
@@ -738,7 +738,7 @@ namespace boost {
         #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
 
         template<>
-        struct BOOST_LOCALE_DECL base_message_format<char32_t> : public std::locale::facet 
+        struct BOOST_LOCALE_DECL base_message_format<char32_t> : public std::locale::facet
         {
             base_message_format(size_t refs = 0) : std::locale::facet(refs)
             {
@@ -774,17 +774,17 @@ namespace boost {
             /// \addtogroup manipulators
             ///
             /// @{
-            
+
             ///
             /// Manipulator for switching message domain in ostream,
             ///
             /// \note The returned object throws std::bad_cast if the I/O stream does not have \ref message_format facet installed
-            /// 
-            inline 
+            ///
+            inline
             #ifdef BOOST_LOCALE_DOXYGEN
             unspecified_type
             #else
-            details::set_domain 
+            details::set_domain
             #endif
             domain(std::string const &id)
             {
@@ -793,7 +793,7 @@ namespace boost {
             }
             /// @}
         } // as
-    } // locale 
+    } // locale
 } // boost
 
 #ifdef BOOST_MSVC

--- a/include/boost/locale/utf.hpp
+++ b/include/boost/locale/utf.hpp
@@ -14,7 +14,7 @@
 namespace boost {
 namespace locale {
 ///
-/// \brief Namespace that holds basic operations on UTF encoded sequences 
+/// \brief Namespace that holds basic operations on UTF encoded sequences
 ///
 /// All functions defined in this namespace do not require linking with Boost.Locale library
 ///
@@ -79,7 +79,7 @@ namespace utf {
         /// Postconditions
         ///
         /// - p points to the last consumed character
-        /// 
+        ///
         template<typename Iterator>
         static code_point decode(Iterator &p,Iterator e);
 
@@ -103,7 +103,7 @@ namespace utf {
         /// Get the size of the trail part of variable length encoded sequence.
         ///
         /// Returns -1 if C is not valid lead character
-        /// 
+        ///
         static int trail_length(char_type c);
         ///
         /// Returns true if c is trail code unit, always false for UTF-32
@@ -117,11 +117,11 @@ namespace utf {
         ///
         /// Convert valid Unicode code point \a value to the UTF sequence.
         ///
-        /// Requirements: 
+        /// Requirements:
         ///
         /// - \a value is valid code point
         /// - \a out is an output iterator should be able to accept at least width(value) units
-        /// 
+        ///
         /// Returns the iterator past the last written code unit.
         ///
         template<typename Iterator>
@@ -134,7 +134,7 @@ namespace utf {
         template<typename Iterator>
         static code_point decode_valid(Iterator &p);
     };
-    
+
     #else
 
     template<typename CharType,int size=sizeof(CharType)>
@@ -144,8 +144,8 @@ namespace utf {
     struct utf_traits<CharType,1> {
 
         typedef CharType char_type;
-        
-        static int trail_length(char_type ci) 
+
+        static int trail_length(char_type ci)
         {
             unsigned char c = ci;
             if(c < 128)
@@ -160,7 +160,7 @@ namespace utf {
                 return 3;
             return -1;
         }
-        
+
         static const int max_width = 4;
 
         static int width(code_point value)
@@ -189,7 +189,7 @@ namespace utf {
         {
             return !is_trail(ci);
         }
-        
+
         template<typename Iterator>
         static code_point decode(Iterator &p,Iterator e)
         {
@@ -210,7 +210,7 @@ namespace utf {
             //
             if(trail_size == 0)
                 return lead;
-            
+
             code_point c = lead & ((1<<(6-trail_size))-1);
 
             // Read the rest
@@ -253,7 +253,7 @@ namespace utf {
             return c;
 
         }
-        
+
         template<typename Iterator>
         static code_point decode_valid(Iterator &p)
         {
@@ -269,7 +269,7 @@ namespace utf {
                 trail_size = 2;
             else
                 trail_size = 3;
-            
+
             code_point c = lead & ((1<<(6-trail_size))-1);
 
             switch(trail_size) {
@@ -402,7 +402,7 @@ namespace utf {
         }
     }; // utf16;
 
-        
+
     template<typename CharType>
     struct utf_traits<CharType,4> {
         typedef CharType char_type;

--- a/include/boost/locale/utf8_codecvt.hpp
+++ b/include/boost/locale/utf8_codecvt.hpp
@@ -18,12 +18,12 @@ namespace locale {
 
 ///
 /// \brief Geneneric utf8 codecvt facet, it allows to convert UTF-8 strings to UTF-16 and UTF-32 using wchar_t, char32_t and char16_t
-/// 
+///
 template<typename CharType>
-class utf8_codecvt : public generic_codecvt<CharType,utf8_codecvt<CharType> > 
+class utf8_codecvt : public generic_codecvt<CharType,utf8_codecvt<CharType> >
 {
 public:
-   
+
     struct state_type {};
 
     utf8_codecvt(size_t refs = 0) : generic_codecvt<CharType,utf8_codecvt<CharType> >(refs)
@@ -39,7 +39,7 @@ public:
     {
         return state_type();
     }
-    static utf::code_point to_unicode(state_type &,char const *&begin,char const *end) 
+    static utf::code_point to_unicode(state_type &,char const *&begin,char const *end)
     {
         char const *p=begin;
 
@@ -49,7 +49,7 @@ public:
         return c;
     }
 
-    static utf::code_point from_unicode(state_type &,utf::code_point u,char *begin,char const *end) 
+    static utf::code_point from_unicode(state_type &,utf::code_point u,char *begin,char const *end)
     {
         if(!utf::is_valid_codepoint(u))
             return utf::illegal;

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -25,13 +25,13 @@ namespace locale {
 /// implementations
 ///
 namespace util {
-    
+
     ///
     /// \brief Return default system locale name in POSIX format.
     ///
     /// This function tries to detect the locale using, LC_CTYPE, LC_ALL and LANG environment
     /// variables in this order and if all of them unset, in POSIX platforms it returns "C"
-    /// 
+    ///
     /// On Windows additionally to check the above environment variables, this function
     /// tries to creates locale name from ISO-339 and ISO-3199 country codes defined
     /// for user default locale.
@@ -60,7 +60,7 @@ namespace util {
     /// is assumed to be US-ASCII and missing language is assumed to be "C"
     ///
     BOOST_LOCALE_DECL
-    std::locale create_info(std::locale const &in,std::string const &name); 
+    std::locale create_info(std::locale const &in,std::string const &name);
 
 
     ///
@@ -88,17 +88,17 @@ namespace util {
         static const uint32_t illegal=utf::illegal;
 
         ///
-        /// This value is returned in following cases: The of incomplete input sequence was found or 
+        /// This value is returned in following cases: The of incomplete input sequence was found or
         /// insufficient output buffer was provided so complete output could not be written.
         ///
         static const uint32_t incomplete=utf::incomplete;
-        
+
         virtual ~base_converter();
         ///
         /// Return the maximal length that one Unicode code-point can be converted to, for example
         /// for UTF-8 it is 4, for Shift-JIS it is 2 and ISO-8859-1 is 1
         ///
-        virtual int max_len() const 
+        virtual int max_len() const
         {
             return 1;
         }
@@ -111,14 +111,14 @@ namespace util {
         /// for example if you use iconv_t descriptor or UConverter as conversion object return false,
         /// and this object will be cloned for each use.
         ///
-        virtual bool is_thread_safe() const 
+        virtual bool is_thread_safe() const
         {
             return false;
         }
         ///
         /// Create a polymorphic copy of this object, usually called only if is_thread_safe() return false
         ///
-        virtual base_converter *clone() const 
+        virtual base_converter *clone() const
         {
             BOOST_ASSERT(typeid(*this)==typeid(base_converter));
             return new base_converter();
@@ -137,9 +137,9 @@ namespace util {
         /// if invalid input sequence found, i.e. there is a sequence [\a begin, \a code_point_end) such as \a code_point_end <= \a end
         /// that is illegal for this encoding, \a illegal is returned and begin stays unchanged. For example if *begin = 0xFF and begin < end
         /// for UTF-8, then \a illegal is returned.
-        /// 
         ///
-        virtual uint32_t to_unicode(char const *&begin,char const *end) 
+        ///
+        virtual uint32_t to_unicode(char const *&begin,char const *end)
         {
             if(begin == end)
                 return incomplete;
@@ -157,12 +157,12 @@ namespace util {
         /// \a illegal should be returned
         ///
         /// If u can be converted to a sequence of bytes c1, ... , cN (1<= N <= max_len() ) then
-        /// 
+        ///
         /// -# If end - begin >= N, c1, ... cN are written starting at begin and N is returned
         /// -# If end - begin < N, incomplete is returned, it is unspecified what would be
         ///    stored in bytes in range [begin,end)
 
-        virtual uint32_t from_unicode(uint32_t u,char *begin,char const *end) 
+        virtual uint32_t from_unicode(uint32_t u,char *begin,char const *end)
         {
             if(begin==end)
                 return incomplete;
@@ -182,7 +182,7 @@ namespace util {
     ///
     /// This function creates a \a base_converter that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
-    /// 
+    ///
     /// If \a encoding is not supported, empty pointer is returned. You should check if
     /// std::auto_ptr<base_converter>::get() != 0
     ///
@@ -195,7 +195,7 @@ namespace util {
     ///
     /// codecvt facet would convert between narrow and wide/char16_t/char32_t encodings using \a cvt converter.
     /// If \a cvt is null pointer, always failure conversion would be used that fails on every first input or output.
-    /// 
+    ///
     /// Note: the codecvt facet handles both UTF-16 and UTF-32 wide encodings, it knows to break and join
     /// Unicode code-points above 0xFFFF to and from surrogate pairs correctly. \a cvt should be unaware
     /// of wide encoding type
@@ -213,7 +213,7 @@ namespace util {
     ///
     /// This function creates a \a base_converter that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
-    /// 
+    ///
     /// If \a encoding is not supported, empty pointer is returned. You should check if
     /// std::unique_ptr<base_converter>::get() != 0
     ///
@@ -225,7 +225,7 @@ namespace util {
     ///
     /// codecvt facet would convert between narrow and wide/char16_t/char32_t encodings using \a cvt converter.
     /// If \a cvt is null pointer, always failure conversion would be used that fails on every first input or output.
-    /// 
+    ///
     /// Note: the codecvt facet handles both UTF-16 and UTF-32 wide encodings, it knows to break and join
     /// Unicode code-points above 0xFFFF to and from surrogate pairs correctly. \a cvt should be unaware
     /// of wide encoding type
@@ -242,7 +242,7 @@ namespace util {
     ///
     /// This function creates a \a base_converter that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
-    /// 
+    ///
     /// If \a encoding is not supported, empty pointer is returned. You should check if
     /// std::unique_ptr<base_converter>::get() != 0
     ///
@@ -254,33 +254,33 @@ namespace util {
     ///
     /// codecvt facet would convert between narrow and wide/char16_t/char32_t encodings using \a cvt converter.
     /// If \a cvt is null pointer, always failure conversion would be used that fails on every first input or output.
-    /// 
+    ///
     /// Note: the codecvt facet handles both UTF-16 and UTF-32 wide encodings, it knows to break and join
     /// Unicode code-points above 0xFFFF to and from surrogate pairs correctly. \a cvt should be unaware
     /// of wide encoding type
     ///
-    /// ownership of cvt is transfered 
+    /// ownership of cvt is transfered
     ///
     BOOST_LOCALE_DECL
     std::locale create_codecvt_from_pointer(std::locale const &in,base_converter *cvt,character_facet_type type);
 
-    /// 
+    ///
     /// Install utf8 codecvt to UTF-16 or UTF-32 into locale \a in and return
-    /// new locale that is based on \a in and uses new facet. 
-    /// 
+    /// new locale that is based on \a in and uses new facet.
+    ///
     BOOST_LOCALE_DECL
     std::locale create_utf8_codecvt(std::locale const &in,character_facet_type type);
 
     ///
     /// This function installs codecvt that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
-    /// 
+    ///
     /// Throws boost::locale::conv::invalid_charset_error if the chacater set is not supported or isn't single byte character
     /// set
     BOOST_LOCALE_DECL
     std::locale create_simple_codecvt(std::locale const &in,std::string const &encoding,character_facet_type type);
 } // util
-} // locale 
+} // locale
 } // boost
 
 #endif

--- a/src/encoding/codepage.cpp
+++ b/src/encoding/codepage.cpp
@@ -32,7 +32,7 @@ namespace boost {
     namespace locale {
         namespace conv {
             namespace impl {
-                
+
                 std::string convert_between(char const *begin,
                                             char const *end,
                                             char const *to_charset,
@@ -125,12 +125,12 @@ namespace boost {
                     }
                     return charset;
                 }
-                
 
-            } // impl 
+
+            } // impl
 
             using namespace impl;
-            
+
             std::string between(char const *begin,char const *end,
                                 std::string const &to_charset,std::string const &from_charset,method_type how)
             {

--- a/src/encoding/conv.hpp
+++ b/src/encoding/conv.hpp
@@ -53,26 +53,26 @@ namespace boost {
                 }
 
                 std::string normalize_encoding(char const *encoding);
-                
+
                 inline int compare_encodings(char const *l,char const *r)
                 {
                     return normalize_encoding(l).compare(normalize_encoding(r));
                 }
-            
+
                 #if defined(BOOST_WINDOWS)  || defined(__CYGWIN__)
                 int encoding_to_windows_codepage(char const *ccharset);
                 #endif
-            
+
                 class converter_between {
                 public:
                     typedef char char_type;
 
                     typedef std::string string_type;
-                    
+
                     virtual bool open(char const *to_charset,char const *from_charset,method_type how) = 0;
-                    
+
                     virtual std::string convert(char const *begin,char const *end) = 0;
-                    
+
                     virtual ~converter_between() {}
                 };
 
@@ -82,11 +82,11 @@ namespace boost {
                     typedef CharType char_type;
 
                     typedef std::basic_string<char_type> string_type;
-                    
+
                     virtual bool open(char const *charset,method_type how) = 0;
-                    
+
                     virtual std::string convert(CharType const *begin,CharType const *end) = 0;
-                    
+
                     virtual ~converter_from_utf() {}
                 };
 

--- a/src/encoding/iconv_codepage.ipp
+++ b/src/encoding/iconv_codepage.ipp
@@ -20,8 +20,8 @@ namespace impl {
 
 class iconverter_base {
 public:
-    
-    iconverter_base() : 
+
+    iconverter_base() :
     cvt_((iconv_t)(-1))
     {
     }
@@ -45,12 +45,12 @@ public:
         how_ = how;
         return cvt_ != (iconv_t)(-1);
     }
-    
+
     template<typename OutChar,typename InChar>
     std::basic_string<OutChar> real_convert(InChar const *ubegin,InChar const *uend)
     {
         std::basic_string<OutChar> sresult;
-        
+
         sresult.reserve(uend - ubegin);
 
         OutChar result[64];
@@ -58,20 +58,20 @@ public:
         char *out_start   = reinterpret_cast<char *>(&result[0]);
         char const *begin = reinterpret_cast<char const *>(ubegin);
         char const *end   = reinterpret_cast<char const *>(uend);
-        
+
         enum { normal , unshifting , done } state = normal;
 
         while(state!=done) {
 
             size_t in_left = end - begin;
             size_t out_left = sizeof(result);
-            
+
             char *out_ptr = out_start;
             size_t res = 0;
             if(in_left == 0)
                 state = unshifting;
 
-            if(state == normal) 
+            if(state == normal)
                 res = conv(&begin,&in_left,&out_ptr,&out_left);
             else
                 res = conv(0,0,&out_ptr,&out_left);
@@ -79,7 +79,7 @@ public:
             int err = errno;
 
             size_t output_count = (out_ptr - out_start) / sizeof(OutChar);
-            
+
             if(res!=0 && res!=(size_t)(-1)) {
                     if(how_ == stop) {
                         throw conversion_error();
@@ -131,7 +131,7 @@ private:
             cvt_ = (iconv_t)(-1);
         }
     }
-    
+
     iconv_t cvt_;
 
     method_type how_;
@@ -199,7 +199,7 @@ private:
 
 } // impl
 } // conv
-} // locale 
+} // locale
 } // boost
 
 

--- a/src/encoding/uconv_codepage.ipp
+++ b/src/encoding/uconv_codepage.ipp
@@ -64,8 +64,8 @@ namespace impl {
         hold_ptr<to_type> cvt_to_;
 
     };
-  
-  
+
+
     template<typename CharType>
     class uconv_from_utf : public converter_from_utf<CharType> {
     public:
@@ -89,7 +89,7 @@ namespace impl {
             cvt_to_.reset();
         }
 
-        std::string convert(CharType const *begin,CharType const *end) BOOST_OVERRIDE 
+        std::string convert(CharType const *begin,CharType const *end) BOOST_OVERRIDE
         {
             try {
                 return cvt_to_->std(cvt_from_->icu_checked(begin,end));
@@ -153,7 +153,7 @@ namespace impl {
 
 } // impl
 } // conv
-} // locale 
+} // locale
 } // boost
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/encoding/wconv_codepage.ipp
+++ b/src/encoding/wconv_codepage.ipp
@@ -27,7 +27,7 @@ namespace boost {
 namespace locale {
 namespace conv {
 namespace impl {
-    
+
     struct windows_encoding {
         char const *name;
         unsigned codepage;
@@ -115,13 +115,13 @@ namespace impl {
             if(len == 2 && begin+1==end)
                 return;
             n = MultiByteToWideChar(codepage,MB_ERR_INVALID_CHARS,begin,len,wide_buf,4);
-            for(int i=0;i<n;i++) 
+            for(int i=0;i<n;i++)
                 buf.push_back(wide_buf[i]);
             begin+=len;
         }
     }
 
-    
+
     void multibyte_to_wide(int codepage,char const *begin,char const *end,bool do_skip,std::vector<wchar_t> &buf)
     {
         if(begin==end)
@@ -151,23 +151,23 @@ namespace impl {
         BOOL *substitute_ptr = codepage == 65001 || codepage == 65000 ? 0 : &substitute;
         char subst_char = 0;
         char *subst_char_ptr = codepage == 65001 || codepage == 65000 ? 0 : &subst_char;
-        
+
         const std::ptrdiff_t num_chars = end - begin;
         if(num_chars > std::numeric_limits<int>::max())
             throw conversion_error();
         int n = WideCharToMultiByte(codepage,0,begin,static_cast<int>(num_chars),0,0,subst_char_ptr,substitute_ptr);
         buf.resize(n);
-        
+
         if(WideCharToMultiByte(codepage,0,begin,static_cast<int>(num_chars),&buf[0],n,subst_char_ptr,substitute_ptr)==0)
             throw conversion_error();
         if(substitute) {
-            if(do_skip) 
+            if(do_skip)
                 remove_substitutions(buf);
-            else 
+            else
                 throw conversion_error();
         }
     }
-    
+
     void wide_to_multibyte(int codepage,wchar_t const *begin,wchar_t const *end,bool do_skip,std::vector<char> &buf)
     {
         if(begin==end)
@@ -186,12 +186,12 @@ namespace impl {
                 b=e+1;
                 e=std::find(b,end,L'0');
             }
-            else 
+            else
                 break;
         }
     }
 
-    
+
     int encoding_to_windows_codepage(char const *ccharset)
     {
         std::string charset = normalize_encoding(ccharset);
@@ -216,7 +216,7 @@ namespace impl {
             }
         }
         return -1;
-        
+
     }
 
     template<typename CharType>
@@ -259,7 +259,7 @@ namespace impl {
 
     class wconv_between : public converter_between {
     public:
-        wconv_between() : 
+        wconv_between() :
             how_(skip),
             to_code_page_ (-1),
             from_code_page_ ( -1)
@@ -280,12 +280,12 @@ namespace impl {
                 return utf_to_utf<char>(begin,end,how_);
 
             std::string res;
-            
+
             std::vector<wchar_t> tmp;   // buffer for mb2w
             std::wstring tmps;          // buffer for utf_to_utf
             wchar_t const *wbegin=0;
             wchar_t const *wend=0;
-            
+
             if(from_code_page_ == 65001) {
                 tmps = utf_to_utf<wchar_t>(begin,end,how_);
                 if(tmps.empty())
@@ -300,7 +300,7 @@ namespace impl {
                 wbegin = &tmp[0];
                 wend = wbegin + tmp.size();
             }
-            
+
             if(to_code_page_ == 65001) {
                 return utf_to_utf<char>(wbegin,wend,how_);
             }
@@ -317,7 +317,7 @@ namespace impl {
         int to_code_page_;
         int from_code_page_;
     };
-    
+
     template<typename CharType, int size = sizeof(CharType) >
     class wconv_to_utf;
 
@@ -338,7 +338,7 @@ namespace impl {
     private:
       wconv_between cvt;
     };
-    
+
     template<>
     class wconv_from_utf<char, 1> : public converter_from_utf<char> {
     public:
@@ -353,7 +353,7 @@ namespace impl {
     private:
       wconv_between cvt;
     };
-    
+
     template<typename CharType>
     class wconv_to_utf<CharType, 2> : public converter_to_utf<CharType> {
     public:
@@ -361,7 +361,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_to_utf() : 
+        wconv_to_utf() :
             how_(skip),
             code_page_(-1)
         {
@@ -391,7 +391,7 @@ namespace impl {
         method_type how_;
         int code_page_;
     };
-  
+
     template<typename CharType>
     class wconv_from_utf<CharType, 2> : public converter_from_utf<CharType> {
     public:
@@ -399,7 +399,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_from_utf() : 
+        wconv_from_utf() :
             how_(skip),
             code_page_(-1)
         {
@@ -463,7 +463,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_to_utf() : 
+        wconv_to_utf() :
             how_(skip),
             code_page_(-1)
         {
@@ -493,7 +493,7 @@ namespace impl {
         method_type how_;
         int code_page_;
     };
-  
+
     template<typename CharType>
     class wconv_from_utf<CharType,4> : public converter_from_utf<CharType> {
     public:
@@ -501,7 +501,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_from_utf() : 
+        wconv_from_utf() :
             how_(skip),
             code_page_(-1)
         {
@@ -542,7 +542,7 @@ namespace impl {
 
 } // impl
 } // conv
-} // locale 
+} // locale
 } // boost
 
 #endif

--- a/src/icu/all_generator.hpp
+++ b/src/icu/all_generator.hpp
@@ -15,7 +15,7 @@ namespace boost {
         namespace impl_icu {
             struct cdata;
             std::locale create_convert(std::locale const &,cdata const &,character_facet_type); // ok
-            std::locale create_collate(std::locale const &,cdata const &,character_facet_type); // ok 
+            std::locale create_collate(std::locale const &,cdata const &,character_facet_type); // ok
             std::locale create_formatting(std::locale const &,cdata const &,character_facet_type); // ok
             std::locale create_parsing(std::locale const &,cdata const &,character_facet_type);  // ok
             std::locale create_codecvt(std::locale const &,std::string const &encoding,character_facet_type); // ok

--- a/src/icu/boundary.cpp
+++ b/src/icu/boundary.cpp
@@ -38,7 +38,7 @@ index_type map_direct(boundary_type t,icu::BreakIterator *it,int reserve)
 #else
     icu::RuleBasedBreakIterator *rbbi=dynamic_cast<icu::RuleBasedBreakIterator *>(it);
 #endif
-    
+
     indx.push_back(break_info());
     it->first();
     int pos=0;
@@ -56,7 +56,7 @@ index_type map_direct(boundary_type t,icu::BreakIterator *it,int reserve)
 
             UErrorCode err=U_ZERO_ERROR;
             int n = rbbi->getRuleStatusVec(buf,8,err);
-            
+
             if(err == U_BUFFER_OVERFLOW_ERROR) {
                 buf=&buffer.front();
                 buffer.resize(n,0);
@@ -137,7 +137,7 @@ index_type do_map(boundary_type t,CharType const *begin,CharType const *end,icu:
 {
     index_type indx;
     hold_ptr<icu::BreakIterator> bi(get_iterator(t,loc));
-   
+
 #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 306
     UErrorCode err=U_ZERO_ERROR;
     if(sizeof(CharType) == 2 || (sizeof(CharType)==1 && encoding=="UTF-8"))
@@ -164,7 +164,7 @@ index_type do_map(boundary_type t,CharType const *begin,CharType const *end,icu:
         }
         if(ut) utext_close(ut);
     }
-    else 
+    else
 #endif
     {
         icu_std_converter<CharType> cvt(encoding);
@@ -190,7 +190,7 @@ public:
         encoding_(data.encoding)
     {
     }
-    index_type map(boundary_type t,CharType const *begin,CharType const *end) const 
+    index_type map(boundary_type t,CharType const *begin,CharType const *end) const
     {
         return do_map<CharType>(t,begin,end,locale_,encoding_);
     }

--- a/src/icu/codecvt.cpp
+++ b/src/icu/codecvt.cpp
@@ -19,7 +19,7 @@
 #include "icu_util.hpp"
 
 #ifdef BOOST_MSVC
-#  pragma warning(disable : 4244) // loose data 
+#  pragma warning(disable : 4244) // loose data
 #endif
 
 namespace boost {
@@ -27,12 +27,12 @@ namespace locale {
 namespace impl_icu {
     class uconv_converter : public util::base_converter {
     public:
-       
+
         uconv_converter(std::string const &encoding) :
             encoding_(encoding)
         {
             UErrorCode err=U_ZERO_ERROR;
-            
+
             // No need to check err each time, this
             // is how ICU works.
             cvt_ = ucnv_open(encoding.c_str(),&err);
@@ -44,10 +44,10 @@ namespace impl_icu {
                     ucnv_close(cvt_);
                 throw conv::invalid_charset_error(encoding);
             }
-            
+
             max_len_ = ucnv_getMaxCharSize(cvt_);
         }
-        
+
         ~uconv_converter()
         {
             ucnv_close(cvt_);
@@ -116,7 +116,7 @@ namespace impl_icu {
         UConverter *cvt_;
         int max_len_;
     };
-    
+
     util::base_converter *create_uconv_converter(std::string const &encoding)
     {
         hold_ptr<util::base_converter> cvt;
@@ -152,7 +152,7 @@ namespace impl_icu {
     }
 
 } // impl_icu
-} // locale 
+} // locale
 } // boost
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/icu/codecvt.hpp
+++ b/src/icu/codecvt.hpp
@@ -17,7 +17,7 @@ namespace impl_icu {
     util::base_converter *create_uconv_converter(std::string const &encoding);
 
 } // impl_icu
-} // locale 
+} // locale
 } // boost
 
 #endif

--- a/src/icu/collator.cpp
+++ b/src/icu/collator.cpp
@@ -26,7 +26,7 @@ namespace boost {
     namespace locale {
         namespace impl_icu {
             template<typename CharType>
-            class collate_impl : public collator<CharType> 
+            class collate_impl : public collator<CharType>
             {
             public:
                 typedef typename collator<CharType>::level_type level_type;
@@ -51,7 +51,7 @@ namespace boost {
 
                 }
                 #endif
-        
+
                 int do_ustring_compare( level_type level,
                                         CharType const *b1,CharType const *e1,
                                         CharType const *b2,CharType const *e2,
@@ -61,7 +61,7 @@ namespace boost {
                     icu::UnicodeString right=cvt_.icu(b2,e2);
                     return get_collator(level)->compare(left,right,status);
                 }
-                
+
                 int do_real_compare(level_type level,
                                     CharType const *b1,CharType const *e1,
                                     CharType const *b2,CharType const *e2,
@@ -75,9 +75,9 @@ namespace boost {
                                CharType const *b2,CharType const *e2) const BOOST_OVERRIDE
                 {
                     UErrorCode status=U_ZERO_ERROR;
-                    
+
                     int res = do_real_compare(level,b1,e1,b2,e2,status);
-                    
+
                     if(U_FAILURE(status))
                             throw std::runtime_error(std::string("Collation failed:") + u_errorName(status));
                     if(res < 0)
@@ -86,8 +86,8 @@ namespace boost {
                         return 1;
                     return 0;
                 }
-               
-                std::vector<uint8_t> do_basic_transform(level_type level,CharType const *b,CharType const *e) const 
+
+                std::vector<uint8_t> do_basic_transform(level_type level,CharType const *b,CharType const *e) const
                 {
                     icu::UnicodeString str=cvt_.icu(b,e);
                     std::vector<uint8_t> tmp;
@@ -98,7 +98,7 @@ namespace boost {
                         tmp.resize(len);
                         collate->getSortKey(str,&tmp[0],tmp.size());
                     }
-                    else 
+                    else
                         tmp.resize(len);
                     return tmp;
                 }
@@ -107,7 +107,7 @@ namespace boost {
                     std::vector<uint8_t> tmp = do_basic_transform(level,b,e);
                     return std::basic_string<CharType>(tmp.begin(),tmp.end());
                 }
-                
+
                 long do_hash(level_type level,CharType const *b,CharType const *e) const BOOST_OVERRIDE
                 {
                     std::vector<uint8_t> tmp = do_basic_transform(level,b,e);
@@ -115,25 +115,25 @@ namespace boost {
                     return gnu_gettext::pj_winberger_hash_function(reinterpret_cast<char *>(&tmp.front()));
                 }
 
-                collate_impl(cdata const &d) : 
+                collate_impl(cdata const &d) :
                     cvt_(d.encoding),
                     locale_(d.locale),
                     is_utf8_(d.utf8)
                 {
-                
+
                 }
                 icu::Collator *get_collator(level_type ilevel) const
                 {
                     int l = limit(ilevel);
-                    static const icu::Collator::ECollationStrength levels[level_count] = 
-                    { 
+                    static const icu::Collator::ECollationStrength levels[level_count] =
+                    {
                         icu::Collator::PRIMARY,
                         icu::Collator::SECONDARY,
                         icu::Collator::TERTIARY,
                         icu::Collator::QUATERNARY,
                         icu::Collator::IDENTICAL
                     };
-                    
+
                     icu::Collator *col = collates_[l].get();
                     if(col)
                         return col;
@@ -160,7 +160,7 @@ namespace boost {
 
             #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 402
             template<>
-            int collate_impl<char>::do_real_compare(    
+            int collate_impl<char>::do_real_compare(
                                     level_type level,
                                     char const *b1,char const *e1,
                                     char const *b2,char const *e2,
@@ -172,7 +172,7 @@ namespace boost {
                     return do_ustring_compare(level,b1,e1,b2,e2,status);
             }
             #endif
-        
+
             std::locale create_collate(std::locale const &in,cdata const &cd,character_facet_type type)
             {
                 switch(type) {

--- a/src/icu/conversion.cpp
+++ b/src/icu/conversion.cpp
@@ -26,8 +26,8 @@
 namespace boost {
 namespace locale {
 namespace impl_icu {
-    
-    
+
+
     namespace {
         void normalize_string(icu::UnicodeString &str,int flags)
         {
@@ -94,7 +94,7 @@ namespace impl_icu {
             }
             return cvt.std(str);
         }
-    
+
     private:
         icu::Locale locale_;
         std::string encoding_;
@@ -138,7 +138,7 @@ namespace impl_icu {
 
     class utf8_converter_impl : public converter<char> {
     public:
-        
+
         utf8_converter_impl(cdata const &d) :
             locale_id_(d.locale.getName()),
             map_(locale_id_)
@@ -147,15 +147,15 @@ namespace impl_icu {
 
         std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const BOOST_OVERRIDE
         {
-            
+
             if(how == converter_base::normalization) {
                 icu_std_converter<char> cvt("UTF-8");
                 icu::UnicodeString str=cvt.icu(begin,end);
                 normalize_string(str,flags);
                 return cvt.std(str);
             }
-            
-            switch(how) 
+
+            switch(how)
             {
             case converter_base::upper_case:
                 return map_.convert(ucasemap_utf8ToUpper,begin,end);
@@ -203,7 +203,7 @@ namespace impl_icu {
             return in;
         }
     }
-    
+
 
 } // impl_icu
 } // locale

--- a/src/icu/date_time.cpp
+++ b/src/icu/date_time.cpp
@@ -26,7 +26,7 @@
 namespace boost {
 namespace locale {
 namespace impl_icu {
-    
+
     static void check_and_throw_dt(UErrorCode &e)
     {
         if(U_FAILURE(e)) {
@@ -64,7 +64,7 @@ namespace impl_icu {
 
     class calendar_impl : public abstract_calendar {
     public:
-        
+
         calendar_impl(cdata const &dat)
         {
             UErrorCode err=U_ZERO_ERROR;
@@ -148,7 +148,7 @@ namespace impl_icu {
         }
         posix_time get_time() const BOOST_OVERRIDE
         {
-            
+
             UErrorCode code=U_ZERO_ERROR;
             double rtime = 0;
             {
@@ -213,7 +213,7 @@ namespace impl_icu {
             //
             // fieldDifference has side effect of moving calendar (WTF?)
             // So we clone it for performing this operation
-            // 
+            //
             hold_ptr<icu::Calendar> self(calendar_->clone());
 
             calendar_impl const *other_cal=dynamic_cast<calendar_impl const *>(other_ptr);
@@ -257,10 +257,10 @@ namespace impl_icu {
         std::string encoding_;
         hold_ptr<icu::Calendar> calendar_;
     };
-    
+
     class icu_calendar_facet : public calendar_facet  {
     public:
-        icu_calendar_facet(cdata const &d,size_t refs = 0) : 
+        icu_calendar_facet(cdata const &d,size_t refs = 0) :
             calendar_facet(refs),
             data_(d)
         {
@@ -272,7 +272,7 @@ namespace impl_icu {
     private:
         cdata data_;
     };
-    
+
     std::locale create_calendar(std::locale const &in,cdata const &d)
     {
         return std::locale(in,new icu_calendar_facet(d));

--- a/src/icu/formatter.cpp
+++ b/src/icu/formatter.cpp
@@ -26,27 +26,27 @@
 #include "time_zone.hpp"
 
 #ifdef BOOST_MSVC
-#  pragma warning(disable : 4244) // lose data 
+#  pragma warning(disable : 4244) // lose data
 #endif
 
 namespace boost {
 namespace locale {
     namespace impl_icu {
-        
-        
+
+
         std::locale::id icu_formatters_cache::id;
 
         namespace {
             struct init { init() { std::has_facet<icu_formatters_cache>(std::locale::classic()); } } instance;
         }
 
-        
+
         template<typename CharType>
         class number_format : public formatter<CharType> {
         public:
             typedef CharType char_type;
             typedef std::basic_string<CharType> string_type;
-            
+
             string_type format(double value,size_t &code_points) const BOOST_OVERRIDE
             {
                 icu::UnicodeString tmp;
@@ -65,7 +65,7 @@ namespace locale {
             string_type format(int32_t value,size_t &code_points) const BOOST_OVERRIDE
             {
                 icu::UnicodeString tmp;
-                #ifdef __SUNPRO_CC 
+                #ifdef __SUNPRO_CC
                 icu_fmt_->format(static_cast<int>(value),tmp);
                 #else
                 icu_fmt_->format(::int32_t(value),tmp);
@@ -93,9 +93,9 @@ namespace locale {
                 icu_fmt_(fmt)
             {
             }
- 
+
         private:
-            
+
             bool get_value(double &v,icu::Formattable &fmt) const
             {
                 UErrorCode err=U_ZERO_ERROR;
@@ -146,14 +146,14 @@ namespace locale {
             icu_std_converter<CharType> cvt_;
             icu::NumberFormat *icu_fmt_;
         };
-        
-        
+
+
         template<typename CharType>
         class date_format : public formatter<CharType> {
         public:
             typedef CharType char_type;
             typedef std::basic_string<CharType> string_type;
-            
+
             string_type format(double value,size_t &code_points) const BOOST_OVERRIDE
             {
                 return do_format(value,code_points);
@@ -192,7 +192,7 @@ namespace locale {
                     icu_fmt_ = fmt;
                 }
             }
- 
+
         private:
 
             template<typename ValueType>
@@ -215,8 +215,8 @@ namespace locale {
                 return cut;
 
             }
-            
-            string_type do_format(double value,size_t &codepoints) const 
+
+            string_type do_format(double value,size_t &codepoints) const
             {
                 UDate date = value * 1000.0; /// UDate is time_t in miliseconds
                 icu::UnicodeString tmp;
@@ -371,7 +371,7 @@ namespace locale {
                 result+="'";
             return result;
         }
-        
+
         template<typename CharType>
         formatter<CharType> *generate_formatter(
                     std::ios_base &ios,
@@ -389,9 +389,9 @@ namespace locale {
 
             if(disp == posix)
                 return fmt.release();
-           
+
             UErrorCode err=U_ZERO_ERROR;
-            
+
             switch(disp) {
             case number:
                 {
@@ -402,7 +402,7 @@ namespace locale {
                         nf = cache.number_format(icu_formatters_cache::fmt_sci);
                     else
                         nf = cache.number_format(icu_formatters_cache::fmt_number);
-                    
+
                     nf->setMaximumFractionDigits(ios.precision());
                     if(how == std::ios_base::scientific || how == std::ios_base::fixed ) {
                         nf->setMinimumFractionDigits(ios.precision());
@@ -416,7 +416,7 @@ namespace locale {
             case currency:
                 {
                     icu::NumberFormat *nf;
-                    
+
                     uint64_t curr = info.currency_flags();
 
                     if(curr == currency_default || curr == currency_national)
@@ -439,7 +439,7 @@ namespace locale {
                         nf->setMinimumFractionDigits(0);
                     }
                     fmt.reset(new number_format<CharType>(nf,encoding));
-                    
+
                 }
                 break;
             case spellout:
@@ -505,7 +505,7 @@ namespace locale {
                             break;
                         case strftime:
                             {
-                                if( !cache.date_format_[1].isEmpty() 
+                                if( !cache.date_format_[1].isEmpty()
                                     && !cache.time_format_[1].isEmpty()
                                     && !cache.date_time_format_[1][1].isEmpty())
                                 {
@@ -523,11 +523,11 @@ namespace locale {
                         }
                         sdf = 0;
                     }
-                    
+
                     if(!df) {
                         icu::DateFormat::EStyle dstyle = icu::DateFormat::kDefault;
                         icu::DateFormat::EStyle tstyle = icu::DateFormat::kDefault;
-                        
+
                         switch(info.time_flags()) {
                         case time_short:    tstyle=icu::DateFormat::kShort; break;
                         case time_medium:   tstyle=icu::DateFormat::kMedium; break;
@@ -540,7 +540,7 @@ namespace locale {
                         case date_long:     dstyle=icu::DateFormat::kLong; break;
                         case date_full:     dstyle=icu::DateFormat::kFull; break;
                         }
-                        
+
                         if(disp==date)
                             adf.reset(icu::DateFormat::createDateInstance(dstyle,locale));
                         else if(disp==time)
@@ -553,13 +553,13 @@ namespace locale {
                             icu::UnicodeString fmt = strftime_to_icu(cvt_.icu(f.data(),f.data()+f.size()),locale);
                             adf.reset(new icu::SimpleDateFormat(fmt,locale,err));
                         }
-                        if(U_FAILURE(err)) 
+                        if(U_FAILURE(err))
                             return fmt.release();
                         df = adf.get();
                     }
 
                     df->adoptTimeZone(get_time_zone(info.time_zone()));
-                        
+
                     // Depending if we own formatter or not
                     if(adf.get())
                         fmt.reset(new date_format<CharType>(adf.release(),true,encoding));
@@ -604,7 +604,7 @@ namespace locale {
     }
 
     #endif
-    
+
 } // impl_icu
 
 } // locale

--- a/src/icu/formatter.hpp
+++ b/src/icu/formatter.hpp
@@ -16,7 +16,7 @@
 
 namespace boost {
 namespace locale {
-namespace impl_icu {        
+namespace impl_icu {
 
     ///
     /// \brief Special base polymorphic class that is used as a character type independent base for all formatter classes
@@ -87,7 +87,7 @@ namespace impl_icu {
         ///
         static formatter *create(std::ios_base &ios,icu::Locale const &l,std::string const &enc);
     }; // class formatter
-    
+
     ///
     /// Specialization for real implementation
     ///

--- a/src/icu/icu_backend.cpp
+++ b/src/icu/icu_backend.cpp
@@ -20,15 +20,15 @@
 
 namespace boost {
 namespace locale {
-namespace impl_icu { 
+namespace impl_icu {
     class icu_localization_backend : public localization_backend {
     public:
-        icu_localization_backend() : 
+        icu_localization_backend() :
             invalid_(true),
             use_ansi_encoding_(false)
         {
         }
-        icu_localization_backend(icu_localization_backend const &other) : 
+        icu_localization_backend(icu_localization_backend const &other) :
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
@@ -74,7 +74,7 @@ namespace impl_icu {
                 bool utf8 = ! use_ansi_encoding_;
                 real_id_ = util::get_system_locale(utf8);
             }
-            
+
             util::locale_data d;
             d.parse(real_id_);
 
@@ -85,7 +85,7 @@ namespace impl_icu {
             country_ = d.country;
             variant_ = d.variant;
         }
-        
+
         std::locale install(std::locale const &base,
                             locale_category_type category,
                             character_facet_type type = nochar_facet) BOOST_OVERRIDE
@@ -130,7 +130,7 @@ namespace impl_icu {
                     }
                 }
             case boundary_facet:
-                return create_boundary(base,data_,type); 
+                return create_boundary(base,data_,type);
             case calendar_facet:
                 return create_calendar(base,data_);
             case information_facet:
@@ -154,7 +154,7 @@ namespace impl_icu {
         bool invalid_;
         bool use_ansi_encoding_;
     };
-    
+
     localization_backend *create_localization_backend()
     {
         return new icu_localization_backend();
@@ -163,4 +163,4 @@ namespace impl_icu {
 }  // impl icu
 }  // locale
 }  // boost
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/icu/icu_backend.hpp
+++ b/src/icu/icu_backend.hpp
@@ -10,11 +10,11 @@
 namespace boost {
     namespace locale {
         class localization_backend;
-        namespace impl_icu { 
+        namespace impl_icu {
             localization_backend *create_localization_backend();
         } // impl_icu
-    } // locale 
+    } // locale
 } // boost
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/src/icu/icu_util.hpp
+++ b/src/icu/icu_util.hpp
@@ -29,4 +29,4 @@ namespace impl_icu {
 } // boost
 
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/icu/numeric.cpp
+++ b/src/icu/numeric.cpp
@@ -25,7 +25,7 @@ namespace impl_icu {
 namespace details {
     template<typename V,int n=std::numeric_limits<V>::digits,bool integer=std::numeric_limits<V>::is_integer>
     struct cast_traits;
-    
+
     template<typename v>
     struct cast_traits<v,7,true> {
         typedef int32_t cast_type;
@@ -71,7 +71,7 @@ namespace details {
                 bool Int=std::numeric_limits<V>::is_integer,
                 bool Big=(sizeof(V) >= 8)
             >
-    struct use_parent_traits 
+    struct use_parent_traits
     {
         static bool use(V /*v*/) { return false; }
     };
@@ -118,14 +118,14 @@ public:
     typedef formatter<CharType> formatter_type;
     typedef hold_ptr<formatter_type> formatter_ptr;
 
-    num_format(cdata const &d,size_t refs = 0) : 
+    num_format(cdata const &d,size_t refs = 0) :
         std::num_put<CharType>(refs),
         loc_(d.locale),
         enc_(d.encoding)
     {
     }
-protected: 
-    
+protected:
+
 
     iter_type do_put(iter_type out, std::ios_base& ios, char_type fill, long val) const BOOST_OVERRIDE
     {
@@ -143,8 +143,8 @@ protected:
     {
         return do_real_put(out,ios,fill,val);
     }
-    
-    #ifndef BOOST_NO_LONG_LONG 
+
+    #ifndef BOOST_NO_LONG_LONG
     iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
@@ -168,18 +168,18 @@ private:
 
         formatter_ptr formatter(formatter_type::create(ios,loc_,enc_));
 
-        if(formatter.get() == 0) 
+        if(formatter.get() == 0)
             return std::num_put<char_type>::do_put(out,ios,fill,val);
-        
+
         size_t code_points;
         typedef typename details::cast_traits<ValueType>::cast_type cast_type;
         string_type const &str = formatter->format(static_cast<cast_type>(val),code_points);
         std::streamsize on_left=0,on_right = 0,points = code_points;
         if(points < ios.width()) {
             std::streamsize n = ios.width() - points;
-            
+
             std::ios_base::fmtflags flags = ios.flags() & std::ios_base::adjustfield;
-            
+
             //
             // We do not really know internal point, so we assume that it does not
             // exist. So according to the standard field should be right aligned
@@ -212,13 +212,13 @@ template<typename CharType>
 class num_parse : public std::num_get<CharType>, protected num_base
 {
 public:
-    num_parse(cdata const &d,size_t refs = 0) : 
+    num_parse(cdata const &d,size_t refs = 0) :
         std::num_get<CharType>(refs),
         loc_(d.locale),
         enc_(d.encoding)
     {
     }
-protected: 
+protected:
     typedef typename std::num_get<CharType>::iter_type iter_type;
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
@@ -261,7 +261,7 @@ protected:
         return do_real_get(in,end,ios,err,val);
     }
 
-    #ifndef BOOST_NO_LONG_LONG 
+    #ifndef BOOST_NO_LONG_LONG
     iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
@@ -275,7 +275,7 @@ protected:
     #endif
 
 private:
-    
+
 
     //
     // This is not really an efficient solution, but it works
@@ -333,7 +333,7 @@ private:
         typedef std::numeric_limits<CastedType> casted_limits;
         if(v < 0 && value_limits::is_signed == false)
             return false;
-        
+
         static const CastedType max_val = value_limits::max();
 
         if(sizeof(CastedType) > sizeof(ValueType) && v > max_val)
@@ -348,7 +348,7 @@ private:
         }
         return true;
     }
-    
+
     icu::Locale loc_;
     std::string enc_;
 
@@ -360,7 +360,7 @@ std::locale install_formatting_facets(std::locale const &in,cdata const &cd)
 {
     std::locale tmp=std::locale(in,new num_format<CharType>(cd));
     if(!std::has_facet<icu_formatters_cache>(in)) {
-        tmp=std::locale(tmp,new icu_formatters_cache(cd.locale)); 
+        tmp=std::locale(tmp,new icu_formatters_cache(cd.locale));
     }
     return tmp;
 }
@@ -370,7 +370,7 @@ std::locale install_parsing_facets(std::locale const &in,cdata const &cd)
 {
     std::locale tmp=std::locale(in,new num_parse<CharType>(cd));
     if(!std::has_facet<icu_formatters_cache>(in)) {
-        tmp=std::locale(tmp,new icu_formatters_cache(cd.locale)); 
+        tmp=std::locale(tmp,new icu_formatters_cache(cd.locale));
     }
     return tmp;
 }
@@ -418,7 +418,7 @@ std::locale create_parsing(std::locale const &in,cdata const &cd,character_facet
 
 } // impl_icu
 
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/icu/predefined_formatters.hpp
+++ b/src/icu/predefined_formatters.hpp
@@ -24,7 +24,7 @@
 
 namespace boost {
 namespace locale {
-    namespace impl_icu {        
+    namespace impl_icu {
 
         class icu_formatters_cache : public std::locale::facet {
         public:
@@ -35,7 +35,7 @@ namespace locale {
                 locale_(locale)
             {
 
-                static const icu::DateFormat::EStyle styles[4] = { 
+                static const icu::DateFormat::EStyle styles[4] = {
                     icu::DateFormat::kShort,
                     icu::DateFormat::kMedium,
                     icu::DateFormat::kLong,
@@ -145,7 +145,7 @@ namespace locale {
                 if(U_FAILURE(err))
                     throw std::runtime_error("Failed to create a formatter");
             }
-            
+
             icu::UnicodeString date_format_[4];
             icu::UnicodeString time_format_[4];
             icu::UnicodeString date_time_format_[4][4];
@@ -160,14 +160,14 @@ namespace locale {
                     icu::DateFormat::kMedium,
                     icu::DateFormat::kMedium,
                     locale_));
-                
+
                 if(dynamic_cast<icu::SimpleDateFormat *>(fmt.get())) {
                     p = static_cast<icu::SimpleDateFormat *>(fmt.release());
                     date_formatter_.reset(p);
                 }
                 return p;
             }
-        
+
         private:
 
             mutable boost::thread_specific_ptr<icu::NumberFormat>    number_format_[fmt_count];

--- a/src/icu/time_zone.cpp
+++ b/src/icu/time_zone.cpp
@@ -7,6 +7,7 @@
 //
 #define BOOST_LOCALE_SOURCE
 #include "time_zone.hpp"
+#include <boost/predef/os.h>
 
 //
 // Bug - when ICU tries to find a file that is equivalent to /etc/localtime it finds /usr/share/zoneinfo/localtime
@@ -19,7 +20,7 @@
 //
 
 #if U_ICU_VERSION_MAJOR_NUM == 4 && (U_ICU_VERSION_MINOR_NUM * 100 + U_ICU_VERSION_PATCHLEVEL_NUM) <= 402
-# if defined(__linux) || defined(__FreeBSD__) || defined(__APPLE__)
+# if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
 #   define BOOST_LOCALE_WORKAROUND_ICU_BUG
 # endif
 #endif

--- a/src/icu/time_zone.cpp
+++ b/src/icu/time_zone.cpp
@@ -61,11 +61,11 @@ namespace boost {
 
             //
             // This is a workaround for an ICU timezone detection bug.
-            // It is \b very ICU specific and should not be used 
+            // It is \b very ICU specific and should not be used
             // in general. It is also designed to work only on
             // specific patforms: Linux, BSD and Apple, where this bug may actually
             // occur
-            // 
+            //
             namespace {
 
                 // Under BSD, Linux and Mac OS X dirent has normal size
@@ -99,7 +99,7 @@ namespace boost {
                     struct dirent de;
                     struct dirent *read_result;
                 };
-               
+
                 bool files_equal(std::string const &left,std::string const &right)
                 {
                     char l[256],r[256];
@@ -122,19 +122,19 @@ namespace boost {
                         return false;
                     return true;
                 }
-                
+
                 std::string find_file_in(std::string const &ref,size_t size,std::string const &dir)
                 {
                     directory d(dir.c_str());
                     if(!d.is_open())
                         return std::string();
-                
+
                     char const *name=0;
                     while((name=d.next())!=0) {
                         std::string file_name = name;
-                        if( file_name == "." 
-                            || file_name ==".." 
-                            || file_name=="posixrules" 
+                        if( file_name == "."
+                            || file_name ==".."
+                            || file_name=="posixrules"
                             || file_name=="localtime")
                         {
                             continue;
@@ -147,7 +147,7 @@ namespace boost {
                                 if(!res.empty())
                                     return file_name + "/" + res;
                             }
-                            else { 
+                            else {
                                 if(size_t(st.st_size) == size && files_equal(path,ref)) {
                                     return file_name;
                                 }
@@ -161,7 +161,7 @@ namespace boost {
                 // algorithm... just it ignores localtime
                 std::string detect_correct_time_zone()
                 {
-                     
+
                     char const *tz_dir = "/usr/share/zoneinfo";
                     char const *tz_file = "/etc/localtime";
 
@@ -177,7 +177,7 @@ namespace boost {
                     return r;
                 }
 
-                
+
                 //
                 // Using pthread as:
                 // - This bug is relevant for only Linux, BSD, Mac OS X and

--- a/src/icu/uconv.hpp
+++ b/src/icu/uconv.hpp
@@ -28,14 +28,14 @@ namespace impl_icu {
         cvt_stop
     } cpcvt_type;
 
-       
+
     template<typename CharType,int char_size = sizeof(CharType) >
     class icu_std_converter {
     public:
         typedef CharType char_type;
         typedef std::basic_string<char_type> string_type;
 
-        icu_std_converter(std::string charset,cpcvt_type cv=cvt_skip);         
+        icu_std_converter(std::string charset,cpcvt_type cv=cvt_skip);
         icu::UnicodeString icu(char_type const *begin,char_type const *end) const;
         string_type std(icu::UnicodeString const &str) const;
         size_t cut(icu::UnicodeString const &str,char_type const *begin,char_type const *end,size_t n,size_t from_u=0,size_t from_c=0) const;
@@ -47,7 +47,7 @@ namespace impl_icu {
         typedef CharType char_type;
         typedef std::basic_string<char_type> string_type;
 
-        
+
         icu::UnicodeString icu_checked(char_type const *vb,char_type const *ve) const
         {
             return icu(vb,ve); // Already done
@@ -62,14 +62,14 @@ namespace impl_icu {
             check_and_throw_icu_error(err);
             return tmp;
         }
-        
+
         string_type std(icu::UnicodeString const &str) const
         {
             uconv cvt(charset_,cvt_type_);
             return cvt.go(str.getBuffer(),str.length(),max_len_);
         }
 
-        icu_std_converter(std::string charset,cpcvt_type cvt_type = cvt_skip) : 
+        icu_std_converter(std::string charset,cpcvt_type cvt_type = cvt_skip) :
             charset_(charset),
             cvt_type_(cvt_type)
         {
@@ -89,7 +89,7 @@ namespace impl_icu {
             uconv(uconv const &other);
             void operator=(uconv const &other);
         public:
-            uconv(std::string const &charset,cpcvt_type cvt_type=cvt_skip) 
+            uconv(std::string const &charset,cpcvt_type cvt_type=cvt_skip)
             {
                 UErrorCode err=U_ZERO_ERROR;
                 cvt_ = ucnv_open(charset.c_str(),&err);
@@ -98,12 +98,12 @@ namespace impl_icu {
                         ucnv_close(cvt_);
                     throw conv::invalid_charset_error(charset);
                 }
-                
+
                 try {
                     if(cvt_type==cvt_skip) {
                         ucnv_setFromUCallBack(cvt_,UCNV_FROM_U_CALLBACK_SKIP,0,0,0,&err);
                         check_and_throw_icu_error(err);
-                
+
                         err=U_ZERO_ERROR;
                         ucnv_setToUCallBack(cvt_,UCNV_TO_U_CALLBACK_SKIP,0,0,0,&err);
                         check_and_throw_icu_error(err);
@@ -111,7 +111,7 @@ namespace impl_icu {
                     else {
                         ucnv_setFromUCallBack(cvt_,UCNV_FROM_U_CALLBACK_STOP,0,0,0,&err);
                         check_and_throw_icu_error(err);
-                
+
                         err=U_ZERO_ERROR;
                         ucnv_setToUCallBack(cvt_,UCNV_TO_U_CALLBACK_STOP,0,0,0,&err);
                         check_and_throw_icu_error(err);
@@ -156,7 +156,7 @@ namespace impl_icu {
             {
                 ucnv_close(cvt_);
             }
-                
+
         private:
             UConverter *cvt_;
         };
@@ -166,14 +166,14 @@ namespace impl_icu {
         std::string charset_;
         cpcvt_type cvt_type_;
     };
-   
+
     template<typename CharType>
     class icu_std_converter<CharType,2> {
     public:
         typedef CharType char_type;
         typedef std::basic_string<char_type> string_type;
 
-        
+
         icu::UnicodeString icu_checked(char_type const *begin,char_type const *end) const
         {
             icu::UnicodeString tmp(end-begin,0,0); // make inital capacity
@@ -199,7 +199,7 @@ namespace impl_icu {
                     throw_if_needed();
             }
             return tmp;
-        }     
+        }
         void throw_if_needed() const
         {
             if(mode_ == cvt_stop)
@@ -224,7 +224,7 @@ namespace impl_icu {
         {
             return n;
         }
-        
+
         icu_std_converter(std::string /*charset*/,cpcvt_type mode=cvt_skip) :
             mode_(mode)
         {
@@ -233,7 +233,7 @@ namespace impl_icu {
         cpcvt_type mode_;
 
     };
-    
+
     template<typename CharType>
     class icu_std_converter<CharType,4> {
     public:
@@ -252,13 +252,13 @@ namespace impl_icu {
                     throw_if_needed();
             }
             return tmp;
-        }     
+        }
         void throw_if_needed() const
         {
             if(mode_ == cvt_stop)
                 throw conv::conversion_error();
         }
- 
+
         icu::UnicodeString icu(char_type const *begin,char_type const *end) const
         {
             icu::UnicodeString tmp(end-begin,0,0); // make inital capacity
@@ -291,7 +291,7 @@ namespace impl_icu {
 
             return tmp;
         }
-        
+
         size_t cut(icu::UnicodeString const &str,char_type const * /*begin*/,char_type const * /*end*/,size_t n,
                 size_t from_u=0,size_t /*from_c*/=0) const
         {

--- a/src/posix/codecvt.cpp
+++ b/src/posix/codecvt.cpp
@@ -29,7 +29,7 @@ namespace impl_posix {
 #ifdef BOOST_LOCALE_WITH_ICONV
     class mb2_iconv_converter : public util::base_converter {
     public:
-       
+
         mb2_iconv_converter(std::string const &encoding) :
             encoding_(encoding),
             to_utf_((iconv_t)(-1)),
@@ -55,7 +55,7 @@ namespace impl_posix {
                         first_byte_table.push_back(obuf[0]);
                         continue;
                     }
-                    
+
                     // Test if this is illegal first byte or incomplete
                     in = ibuf;
                     insize = 1;
@@ -63,8 +63,8 @@ namespace impl_posix {
                     outsize = 8;
                     call_iconv(d,0,0,0,0);
                     size_t res = call_iconv(d,&in,&insize,&out,&outsize);
-                    
-                    // Now if this single byte starts a sequence we add incomplete 
+
+                    // Now if this single byte starts a sequence we add incomplete
                     // to know to ask that we need two bytes, othewise it may only be
                     // illegal
 
@@ -94,7 +94,7 @@ namespace impl_posix {
             from_utf_((iconv_t)(-1))
         {
         }
-        
+
         ~mb2_iconv_converter()
         {
             if(to_utf_ != (iconv_t)(-1))
@@ -117,7 +117,7 @@ namespace impl_posix {
         {
             if(begin == end)
                 return incomplete;
-            
+
             unsigned char seq0 = *begin;
             uint32_t index = (*first_byte_table_)[seq0];
             if(index == illegal)
@@ -128,7 +128,7 @@ namespace impl_posix {
             }
             else if(begin+1 == end)
                 return incomplete;
-            
+
             open(to_utf_,utf32_encoding(),encoding_.c_str());
 
             // maybe illegal or may be double byte
@@ -244,7 +244,7 @@ namespace impl_posix {
     }
 
 } // impl_posix
-} // locale 
+} // locale
 } // boost
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/posix/codecvt.hpp
+++ b/src/posix/codecvt.hpp
@@ -20,7 +20,7 @@ namespace impl_posix {
     util::base_converter *create_iconv_converter(std::string const &encoding);
 
 } // impl_posix
-} // locale 
+} // locale
 } // boost
 
 #endif

--- a/src/posix/collate.cpp
+++ b/src/posix/collate.cpp
@@ -58,7 +58,7 @@ class collator : public std::collate<CharType> {
 public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
-    collator(boost::shared_ptr<locale_t> l,size_t refs = 0) : 
+    collator(boost::shared_ptr<locale_t> l,size_t refs = 0) :
         std::collate<CharType>(refs),
         lc_(l)
     {
@@ -114,7 +114,7 @@ std::locale create_collate( std::locale const &in,
 
 
 } // impl_std
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/posix/converter.cpp
+++ b/src/posix/converter.cpp
@@ -56,13 +56,13 @@ struct case_traits<wchar_t> {
 
 
 template<typename CharType>
-class std_converter : public converter<CharType> 
+class std_converter : public converter<CharType>
 {
 public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
     typedef std::ctype<char_type> ctype_type;
-    std_converter(boost::shared_ptr<locale_t> lc,size_t refs = 0) : 
+    std_converter(boost::shared_ptr<locale_t> lc,size_t refs = 0) :
         converter<CharType>(refs),
         lc_(lc)
     {
@@ -99,7 +99,7 @@ private:
 
 class utf8_converter : public converter<char> {
 public:
-    utf8_converter(boost::shared_ptr<locale_t> lc,size_t refs = 0) : 
+    utf8_converter(boost::shared_ptr<locale_t> lc,size_t refs = 0) :
         converter<char>(refs),
         lc_(lc)
     {
@@ -116,7 +116,7 @@ public:
                     wres+=towupper_l(tmp[i],*lc_);
                 return conv::from_utf<wchar_t>(wres,"UTF-8");
             }
-            
+
         case lower_case:
         case case_folding:
             {
@@ -140,7 +140,7 @@ std::locale create_convert( std::locale const &in,
                             character_facet_type type)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             {
                 std::string encoding = nl_langinfo_l(CODESET,*lc);
                 for(unsigned i=0;i<encoding.size();i++)
@@ -160,6 +160,6 @@ std::locale create_convert( std::locale const &in,
 
 
 } // namespace impl_std
-} // locale 
+} // locale
 } // boost
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/posix/numeric.cpp
+++ b/src/posix/numeric.cpp
@@ -48,12 +48,12 @@ public:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    num_format(boost::shared_ptr<locale_t> lc,size_t refs = 0) : 
+    num_format(boost::shared_ptr<locale_t> lc,size_t refs = 0) :
         util::base_num_format<CharType>(refs),
         lc_(lc)
     {
     }
-protected: 
+protected:
 
     iter_type do_format_currency(bool intl,iter_type out,std::ios_base &/*ios*/,char_type /*fill*/,long double val) const BOOST_OVERRIDE
     {
@@ -61,9 +61,9 @@ protected:
         char const *format = intl ? "%i" : "%n";
         errno=0;
         ssize_t n = strfmon_l(buf,sizeof(buf),*lc_,format,static_cast<double>(val));
-        if(n >= 0) 
+        if(n >= 0)
             return write_it(out,buf,n);
-        
+
         for(std::vector<char> tmp(sizeof(buf)*2);tmp.size() <= 4098;tmp.resize(tmp.size()*2)) {
             n = strfmon_l(&tmp.front(),tmp.size(),*lc_,format,static_cast<double>(val));
             if(n >= 0)
@@ -78,7 +78,7 @@ protected:
             *out++ = *ptr++;
         return out;
     }
-    
+
     std::ostreambuf_iterator<wchar_t> write_it(std::ostreambuf_iterator<wchar_t> out,char const *ptr,size_t n) const
     {
         std::wstring tmp = conv::to_utf<wchar_t>(ptr,ptr+n,nl_langinfo_l(CODESET,*lc_));
@@ -152,7 +152,7 @@ struct ftime_traits<wchar_t> {
 template<typename CharType>
 class time_put_posix : public std::time_put<CharType> {
 public:
-    time_put_posix(boost::shared_ptr<locale_t> lc, size_t refs = 0) : 
+    time_put_posix(boost::shared_ptr<locale_t> lc, size_t refs = 0) :
         std::time_put<CharType>(refs),
         lc_(lc)
     {
@@ -182,11 +182,11 @@ template<>
 class ctype_posix<char> : public std::ctype<char> {
 public:
 
-    ctype_posix(boost::shared_ptr<locale_t> lc) 
+    ctype_posix(boost::shared_ptr<locale_t> lc)
     {
         lc_ = lc;
     }
-   
+
     bool do_is(mask m,char c) const
     {
         if((m & space) && isspace_l(c,*lc_))
@@ -280,11 +280,11 @@ private:
 template<>
 class ctype_posix<wchar_t> : public std::ctype<wchar_t> {
 public:
-    ctype_posix(boost::shared_ptr<locale_t> lc) 
+    ctype_posix(boost::shared_ptr<locale_t> lc)
     {
         lc_ = lc;
     }
-   
+
     bool do_is(mask m,wchar_t c) const
     {
         if((m & space) && iswspace_l(c,*lc_))
@@ -382,11 +382,11 @@ struct basic_numpunct {
     std::string grouping;
     std::string thousands_sep;
     std::string decimal_point;
-    basic_numpunct() : 
+    basic_numpunct() :
         decimal_point(".")
     {
     }
-    basic_numpunct(locale_t lc) 
+    basic_numpunct(locale_t lc)
     {
     #if defined(__APPLE__) || defined(__FreeBSD__)
         lconv *cv = localeconv_l(lc);
@@ -407,7 +407,7 @@ template<typename CharType>
 class num_punct_posix : public std::numpunct<CharType> {
 public:
     typedef std::basic_string<CharType> string_type;
-    num_punct_posix(locale_t lc,size_t refs = 0) : 
+    num_punct_posix(locale_t lc,size_t refs = 0) :
         std::numpunct<CharType>(refs)
     {
         basic_numpunct np(lc);
@@ -480,7 +480,7 @@ std::locale create_formatting(  std::locale const &in,
                                 character_facet_type type)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             return create_formatting_impl<char>(in,lc);
         case wchar_t_facet:
             return create_formatting_impl<wchar_t>(in,lc);
@@ -494,7 +494,7 @@ std::locale create_parsing( std::locale const &in,
                             character_facet_type type)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             return create_parsing_impl<char>(in,lc);
         case wchar_t_facet:
             return create_parsing_impl<wchar_t>(in,lc);
@@ -506,7 +506,7 @@ std::locale create_parsing( std::locale const &in,
 
 
 } // impl_std
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/posix/numeric.cpp
+++ b/src/posix/numeric.cpp
@@ -12,6 +12,7 @@
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
+#include <boost/predef/os.h>
 #include <boost/shared_ptr.hpp>
 #include <cctype>
 #include <cerrno>
@@ -31,7 +32,7 @@
 #include "all_generator.hpp"
 
 
-#if defined(__linux) || defined(__APPLE__)
+#if BOOST_OS_LINUX || defined(__APPLE__)
 #define BOOST_LOCALE_HAVE_WCSFTIME_L
 #endif
 

--- a/src/posix/posix_backend.cpp
+++ b/src/posix/posix_backend.cpp
@@ -25,15 +25,15 @@
 
 namespace boost {
 namespace locale {
-namespace impl_posix { 
-    
+namespace impl_posix {
+
     class posix_localization_backend : public localization_backend {
     public:
-        posix_localization_backend() : 
+        posix_localization_backend() :
             invalid_(true)
         {
         }
-        posix_localization_backend(posix_localization_backend const &other) : 
+        posix_localization_backend(posix_localization_backend const &other) :
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
@@ -80,18 +80,18 @@ namespace impl_posix {
             real_id_ = locale_id_;
             if(real_id_.empty())
                 real_id_ = util::get_system_locale();
-            
+
             locale_t tmp = newlocale(LC_ALL_MASK,real_id_.c_str(),0);
-            
+
             if(!tmp) {
                 tmp=newlocale(LC_ALL_MASK,"C",0);
             }
             if(!tmp) {
                 throw std::runtime_error("newlocale failed");
             }
-            
+
             locale_t *tmp_p = 0;
-            
+
             try {
                 tmp_p = new locale_t();
             }
@@ -99,11 +99,11 @@ namespace impl_posix {
                 freelocale(tmp);
                 throw;
             }
-            
+
             *tmp_p = tmp;
             lc_ = boost::shared_ptr<locale_t>(tmp_p,free_locale_by_ptr);
         }
-        
+
         std::locale install(std::locale const &base,
                             locale_category_type category,
                             character_facet_type type = nochar_facet) BOOST_OVERRIDE
@@ -172,7 +172,7 @@ namespace impl_posix {
         bool invalid_;
         boost::shared_ptr<locale_t> lc_;
     };
-    
+
     localization_backend *create_localization_backend()
     {
         return new posix_localization_backend();
@@ -181,4 +181,4 @@ namespace impl_posix {
 }  // impl posix
 }  // locale
 }  // boost
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/posix/posix_backend.hpp
+++ b/src/posix/posix_backend.hpp
@@ -10,11 +10,11 @@
 namespace boost {
     namespace locale {
         class localization_backend;
-        namespace impl_posix { 
+        namespace impl_posix {
             localization_backend *create_localization_backend();
         } // impl_std
-    } // locale 
+    } // locale
 } // boost
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/src/shared/date_time.cpp
+++ b/src/shared/date_time.cpp
@@ -51,7 +51,7 @@ calendar::calendar(std::ios_base &ios) :
     impl_(std::use_facet<calendar_facet>(locale_).create_calendar())
 {
     impl_->set_timezone(tz_);
-    
+
 }
 
 calendar::calendar() :
@@ -72,7 +72,7 @@ calendar::calendar(calendar const &other) :
 {
 }
 
-calendar const &calendar::operator = (calendar const &other) 
+calendar const &calendar::operator = (calendar const &other)
 {
     if(this !=&other) {
         impl_.reset(other.impl_->clone());
@@ -255,25 +255,25 @@ date_time date_time::operator>>(date_time_period const &v) const
     return tmp;
 }
 
-date_time const &date_time::operator+=(date_time_period const &v) 
+date_time const &date_time::operator+=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::move,v.value);
     return *this;
 }
 
-date_time const &date_time::operator-=(date_time_period const &v) 
+date_time const &date_time::operator-=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::move,-v.value);
     return *this;
 }
 
-date_time const &date_time::operator<<=(date_time_period const &v) 
+date_time const &date_time::operator<<=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::roll,v.value);
     return *this;
 }
 
-date_time const &date_time::operator>>=(date_time_period const &v) 
+date_time const &date_time::operator>>=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::roll,-v.value);
     return *this;
@@ -308,7 +308,7 @@ date_time date_time::operator>>(date_time_period_set const &v) const
     return tmp;
 }
 
-date_time const &date_time::operator+=(date_time_period_set const &v) 
+date_time const &date_time::operator+=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this+=v[i];
@@ -316,7 +316,7 @@ date_time const &date_time::operator+=(date_time_period_set const &v)
     return *this;
 }
 
-date_time const &date_time::operator-=(date_time_period_set const &v) 
+date_time const &date_time::operator-=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this-=v[i];
@@ -324,7 +324,7 @@ date_time const &date_time::operator-=(date_time_period_set const &v)
     return *this;
 }
 
-date_time const &date_time::operator<<=(date_time_period_set const &v) 
+date_time const &date_time::operator<<=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this<<=v[i];
@@ -332,7 +332,7 @@ date_time const &date_time::operator<<=(date_time_period_set const &v)
     return *this;
 }
 
-date_time const &date_time::operator>>=(date_time_period_set const &v) 
+date_time const &date_time::operator>>=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this>>=v[i];

--- a/src/shared/format.cpp
+++ b/src/shared/format.cpp
@@ -27,7 +27,7 @@ namespace boost {
                 void (*imbuer)(void *,std::locale const &);
             };
 
-            format_parser::format_parser(std::ios_base &ios,void *cookie,void (*imbuer)(void *,std::locale const &)) : 
+            format_parser::format_parser(std::ios_base &ios,void *cookie,void (*imbuer)(void *,std::locale const &)) :
                 ios_(ios),
                 d(new data)
             {
@@ -92,7 +92,7 @@ namespace boost {
                 }
                 else if(key=="cur" || key=="currency") {
                     as::currency(ios_);
-                    if(value=="iso") 
+                    if(value=="iso")
                         as::currency_iso(ios_);
                     else if(value=="nat" || value=="national")
                         as::currency_national(ios_);
@@ -170,9 +170,9 @@ namespace boost {
                     std::string encoding=std::use_facet<info>(d->saved_locale).encoding();
                     generator gen;
                     gen.categories(formatting_facet);
-                   
+
                     std::locale new_loc;
-                    if(value.find('.')==std::string::npos) 
+                    if(value.find('.')==std::string::npos)
                         new_loc = gen(value + "." +  encoding);
                     else
                         new_loc = gen(value);

--- a/src/shared/formatting.cpp
+++ b/src/shared/formatting.cpp
@@ -15,7 +15,7 @@
 namespace boost {
     namespace locale {
 
-        ios_info::string_set::string_set() : 
+        ios_info::string_set::string_set() :
             type(0),
             size(0),
             ptr(0)
@@ -39,14 +39,14 @@ namespace boost {
                 type=0;
             }
         }
-        
+
         void ios_info::string_set::swap(string_set &other)
         {
             std::swap(type,other.type);
             std::swap(size,other.size);
             std::swap(ptr,other.ptr);
         }
-        
+
         ios_info::string_set const &ios_info::string_set::operator=(string_set const &other)
         {
             if(this!=&other) {
@@ -58,7 +58,7 @@ namespace boost {
 
         struct ios_info::data {};
 
-        ios_info::ios_info() : 
+        ios_info::ios_info() :
             flags_(0),
             domain_id_(0),
             d(0)
@@ -68,7 +68,7 @@ namespace boost {
         ios_info::~ios_info()
         {
         }
-        
+
         ios_info::ios_info(ios_info const &other)
         {
             flags_ = other.flags_;
@@ -89,23 +89,23 @@ namespace boost {
             return *this;
         }
 
-        void ios_info::display_flags(uint64_t f) 
+        void ios_info::display_flags(uint64_t f)
         {
             flags_ = (flags_ & ~uint64_t(flags::display_flags_mask)) | f;
         }
-        void ios_info::currency_flags(uint64_t f) 
+        void ios_info::currency_flags(uint64_t f)
         {
             flags_ = (flags_ & ~uint64_t(flags::currency_flags_mask)) | f;
         }
-        void ios_info::date_flags(uint64_t f) 
+        void ios_info::date_flags(uint64_t f)
         {
             flags_ = (flags_ & ~uint64_t(flags::date_flags_mask)) | f;
         }
-        void ios_info::time_flags(uint64_t f) 
+        void ios_info::time_flags(uint64_t f)
         {
             flags_ = (flags_ & ~uint64_t(flags::time_flags_mask)) | f;
         }
-        
+
         void ios_info::domain_id(int id)
         {
             domain_id_ = id;
@@ -130,7 +130,7 @@ namespace boost {
         {
             return flags_ & flags::date_flags_mask;
         }
-        
+
         uint64_t ios_info::time_flags() const
         {
             return flags_ & flags::time_flags_mask;
@@ -151,7 +151,7 @@ namespace boost {
             return datetime_;
         }
 
-        
+
         ios_info::string_set &ios_info::date_time_pattern_set()
         {
             return datetime_;

--- a/src/shared/generator.cpp
+++ b/src/shared/generator.cpp
@@ -72,7 +72,7 @@ namespace boost {
         {
             d->chars=t;
         }
-        
+
         character_facet_type generator::characters() const
         {
             return d->chars;
@@ -83,7 +83,7 @@ namespace boost {
             if(std::find(d->domains.begin(),d->domains.end(),domain) == d->domains.end())
                 d->domains.push_back(domain);
         }
-        
+
         void generator::set_default_messages_domain(std::string const &domain)
         {
             std::vector<std::string>::iterator p;
@@ -171,11 +171,11 @@ namespace boost {
         {
             return d->caching_enabled;
         }
-        void generator::locale_cache_enabled(bool enabled) 
+        void generator::locale_cache_enabled(bool enabled)
         {
             d->caching_enabled = enabled;
         }
-        
+
         void generator::set_all_options(localization_backend& backend,std::string const &id) const
         {
             backend.set_option("locale",id);
@@ -186,7 +186,7 @@ namespace boost {
             for(size_t i=0;i<d->paths.size();i++)
                 backend.set_option("message_path",d->paths[i]);
         }
-        
+
     } // locale
 } // boost
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/shared/ids.cpp
+++ b/src/shared/ids.cpp
@@ -47,7 +47,7 @@ namespace boost {
 
         #endif
 
-        namespace boundary {        
+        namespace boundary {
 
             std::locale::id boundary_indexing<char>::id;
             boundary_indexing<char>::~boundary_indexing() {}

--- a/src/shared/ios_prop.hpp
+++ b/src/shared/ios_prop.hpp
@@ -12,8 +12,8 @@
 namespace boost {
     namespace locale {
         namespace impl {
-       
-            template<typename Property> 
+
+            template<typename Property>
             class ios_prop {
             public:
                 static void set(Property const &prop,std::ios_base &ios)
@@ -30,7 +30,7 @@ namespace boost {
                         *static_cast<Property *>(ios.pword(id))=prop;
                     }
                 }
-                
+
                 static Property &get(std::ios_base &ios)
                 {
                     int id=get_id();
@@ -38,7 +38,7 @@ namespace boost {
                         set(Property(),ios);
                     return *static_cast<Property *>(ios.pword(id));
                 }
-                
+
                 static bool has(std::ios_base &ios)
                 {
                     int id=get_id();
@@ -62,7 +62,7 @@ namespace boost {
                 }
             private:
                 static void * const invalid;
-                
+
                 static void callback(std::ios_base::event ev,std::ios_base &ios,int id)
                 {
                     switch(ev) {
@@ -79,9 +79,9 @@ namespace boost {
                     case std::ios_base::imbue_event:
                         if(ios.pword(id)==invalid || ios.pword(id)==0)
                             break;
-                        reinterpret_cast<Property *>(ios.pword(id))->on_imbue(); 
+                        reinterpret_cast<Property *>(ios.pword(id))->on_imbue();
                         break;
-                        
+
                     default: ;
                     }
                 }
@@ -105,5 +105,5 @@ namespace boost {
 
 #endif
 
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/src/shared/localization_backend.cpp
+++ b/src/shared/localization_backend.cpp
@@ -44,7 +44,7 @@ namespace boost {
                     all_backends_.push_back(v);
                 }
             }
-            impl() : 
+            impl() :
                 default_backends_(32,-1)
             {
             }
@@ -64,7 +64,7 @@ namespace boost {
                     for(unsigned i=0;i<default_backends_.size();i++)
                         default_backends_[i]=0;
                 }
-                else { 
+                else {
                     for(unsigned i=0;i<all_backends_.size();i++)
                         if(all_backends_[i].first == name)
                             return;
@@ -142,7 +142,7 @@ namespace boost {
                         return l;
                     if(unsigned(id) >= index_.size())
                         return l;
-                    if(index_[id]==-1) 
+                    if(index_[id]==-1)
                         return l;
                     return backends_[index_[id]]->install(l,category,type);
                 }
@@ -158,7 +158,7 @@ namespace boost {
 
 
 
-        localization_backend_manager::localization_backend_manager() : 
+        localization_backend_manager::localization_backend_manager() :
             pimpl_(new impl())
         {
         }
@@ -241,7 +241,7 @@ namespace boost {
             }
 
             struct init {
-                init() { 
+                init() {
                     localization_backend_manager mgr;
                     #ifdef BOOST_LOCALE_WITH_ICU
                     mgr.adopt_backend("icu",impl_icu::create_localization_backend());
@@ -254,7 +254,7 @@ namespace boost {
                     #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
                     mgr.adopt_backend("winapi",impl_win::create_localization_backend());
                     #endif
-                    
+
                     #ifndef BOOST_LOCALE_NO_STD_BACKEND
                     mgr.adopt_backend("std",impl_std::create_localization_backend());
                     #endif
@@ -282,4 +282,4 @@ namespace boost {
 
     } // locale
 } // boost
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -42,15 +42,15 @@
 namespace boost {
     namespace locale {
         namespace gnu_gettext {
-            
+
             class c_file {
                 c_file(c_file const &);
                 void operator=(c_file const &);
             public:
-                
+
                 FILE *file;
 
-                c_file() : 
+                c_file() :
                     file(0)
                 {
                 }
@@ -90,7 +90,7 @@ namespace boost {
                 #else // POSIX systems do not have all this Wide API crap, as native codepages are UTF-8
 
                 // We do not use encoding as we use native file name encoding
-                
+
                 bool open(std::string const &file_name,std::string const &/* encoding */)
                 {
                     close();
@@ -107,7 +107,7 @@ namespace boost {
             class mo_file {
             public:
                 typedef std::pair<char const *,char const *> pair_type;
-                
+
                 mo_file(std::vector<char> &file) :
                     native_byteorder_(true),
                     size_(0)
@@ -137,13 +137,13 @@ namespace boost {
                         st = pj_winberger_hash::update_state(st,context_in);
                         st = pj_winberger_hash::update_state(st,'\4'); // EOT
                         st = pj_winberger_hash::update_state(st,key_in);
-                        hkey = st; 
+                        hkey = st;
                     }
                     uint32_t incr = 1 + hkey % (hash_size_-2);
                     hkey %= hash_size_;
                     uint32_t orig=hkey;
-                    
-                    
+
+
                     do {
                         uint32_t idx = get(hash_offset_ + 4*hkey);
                         /// Not found
@@ -168,13 +168,13 @@ namespace boost {
                         size_t key_len = strlen(key);
                         if(cntx_len + 1 + key_len != real_len)
                             return false;
-                        return 
+                        return
                             memcmp(real_key,cntx,cntx_len) == 0
                             && real_key[cntx_len] == '\4'
                             && memcmp(real_key + cntx_len + 1 ,key,key_len) == 0;
                     }
                 }
-                
+
                 char const *key(int id) const
                 {
                     uint32_t off = get(keys_offset_ + id*8 + 4);
@@ -240,14 +240,14 @@ namespace boost {
                     // ok to ingnore fread result
                     size_t four_bytes = fread(&magic,4,1,file);
                     (void)four_bytes; // shut GCC
-                    
+
                     if(magic == 0x950412de)
                         native_byteorder_ = true;
                     else if(magic == 0xde120495)
                         native_byteorder_ = false;
                     else
                         throw std::runtime_error("Invalid file format");
-                    
+
                     fseek(file,0,SEEK_END);
                     long len=ftell(file);
                     if(len < 0) {
@@ -260,7 +260,7 @@ namespace boost {
                     data_ = &vdata_[0];
                     file_size_ = len;
                 }
-                
+
                 uint32_t get(unsigned offset) const
                 {
                     uint32_t tmp;
@@ -304,7 +304,7 @@ namespace boost {
                     return pair_type((char_type const *)(0),(char_type const *)(0));
                 }
             };
-            
+
             template<>
             struct mo_file_use_traits<char> {
                 static const bool in_use = true;
@@ -332,7 +332,7 @@ namespace boost {
             private:
                 std::string in_;
             };
-            
+
             template<>
             class converter<char> {
             public:
@@ -377,7 +377,7 @@ namespace boost {
                     if(c!=0)
                         c_context_ = c;
                     else
-                        c_context_ = &empty; 
+                        c_context_ = &empty;
                 }
                 bool operator < (message_key const &other) const
                 {
@@ -453,8 +453,8 @@ namespace boost {
                     return state;
                 }
             };
-            
-           
+
+
             // By default for wide types the conversion is not requiredyy
             template<typename CharType>
             CharType const *runtime_conversion(CharType const *msg,
@@ -507,7 +507,7 @@ namespace boost {
                     if(!ptr.first)
                         return 0;
                     int form=0;
-                    if(plural_forms_.at(domain_id)) 
+                    if(plural_forms_.at(domain_id))
                         form = (*plural_forms_[domain_id])(n);
                     else
                         form = n == 1 ? 0 : 1; // Fallback to english plural form
@@ -541,17 +541,17 @@ namespace boost {
                     std::string lc_cat = inf.locale_category;
                     std::vector<messages_info::domain> const &domains = inf.domains;
                     std::vector<std::string> const &search_paths = inf.paths;
-                    
+
                     //
-                    // List of fallbacks: en_US@euro, en@euro, en_US, en. 
+                    // List of fallbacks: en_US@euro, en@euro, en_US, en.
                     //
                     std::vector<std::string> paths;
 
 
-                    if(!variant.empty() && !country.empty()) 
+                    if(!variant.empty() && !country.empty())
                         paths.push_back(language + "_" + country + "@" + variant);
 
-                    if(!variant.empty()) 
+                    if(!variant.empty())
                         paths.push_back(language + "@" + variant);
 
                     if(!country.empty())
@@ -570,7 +570,7 @@ namespace boost {
                         domains_[domain]=i;
 
 
-                        bool found=false; 
+                        bool found=false;
                         for(unsigned j=0;!found && j<paths.size();j++) {
                             for(unsigned k=0;!found && k<search_paths.size();k++) {
                                 std::string full_path = search_paths[k]+"/"+paths[j]+"/" + lc_cat + "/"+domain+".mo";
@@ -579,7 +579,7 @@ namespace boost {
                         }
                     }
                 }
-                
+
                 char_type const *convert(char_type const *msg,string_type &buffer) const BOOST_OVERRIDE
                 {
                     return runtime_conversion<char_type>(msg,buffer,key_conversion_required_,locale_encoding_,key_encoding_);
@@ -588,7 +588,7 @@ namespace boost {
             private:
                 int compare_encodings(std::string const &left,std::string const &right)
                 {
-                    return convert_encoding_name(left).compare(convert_encoding_name(right)); 
+                    return convert_encoding_name(left).compare(convert_encoding_name(right));
                 }
 
                 std::string convert_encoding_name(std::string const &in)
@@ -616,15 +616,15 @@ namespace boost {
                 {
                     locale_encoding_ = locale_encoding;
                     key_encoding_ = key_encoding;
-                    
-                    key_conversion_required_ =  sizeof(CharType) == 1 
+
+                    key_conversion_required_ =  sizeof(CharType) == 1
                                                 && compare_encodings(locale_encoding,key_encoding)!=0;
 
                     boost::shared_ptr<mo_file> mo;
 
                     if(callback) {
                         std::vector<char> vfile = callback(file_name,locale_encoding);
-                        if(vfile.empty()) 
+                        if(vfile.empty())
                             return false;
                         mo.reset(new mo_file(vfile));
                     }
@@ -635,7 +635,7 @@ namespace boost {
                             return false;
                         mo.reset(new mo_file(the_file.file));
                     }
-                    
+
                     std::string plural = extract(mo->value(0).first,"plural=","\r\n;");
 
                     std::string mo_encoding = extract(mo->value(0).first,"charset="," \r\n;");
@@ -658,7 +658,7 @@ namespace boost {
                             char const *ckey = mo->key(i);
                             string_type skey = cvt_key(ckey,ckey+strlen(ckey));
                             key_type key(skey);
-                            
+
                             mo_file::pair_type tmp = mo->value(i);
                             string_type value = cvt_value(tmp.first,tmp.second);
                             catalogs_[idx][key].swap(value);
@@ -695,7 +695,7 @@ BOOST_LOCALE_END_CONST_CONDITION
                     return true;
                 }
 
-                
+
 
                 static std::string extract(std::string const &meta,std::string const &key,char const *separator)
                 {
@@ -737,7 +737,7 @@ BOOST_LOCALE_END_CONST_CONDITION
                 domains_map_type domains_;
 
                 std::string locale_encoding_;
-                std::string key_encoding_; 
+                std::string key_encoding_;
                 bool key_conversion_required_;
             };
 
@@ -752,7 +752,7 @@ BOOST_LOCALE_END_CONST_CONDITION
             {
                 return new mo_message<wchar_t>(info);
             }
-            
+
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
 
             template<>
@@ -761,7 +761,7 @@ BOOST_LOCALE_END_CONST_CONDITION
                 return new mo_message<char16_t>(info);
             }
             #endif
-            
+
             #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
 
             template<>

--- a/src/shared/mo_lambda.cpp
+++ b/src/shared/mo_lambda.cpp
@@ -26,9 +26,9 @@ namespace { // anon
         }
     };
 
-    struct unary : public plural 
+    struct unary : public plural
     {
-        unary(plural_ptr ptr) : 
+        unary(plural_ptr ptr) :
             op1(ptr)
         {
         }
@@ -37,7 +37,7 @@ namespace { // anon
     };
 
 
-    struct binary : public plural 
+    struct binary : public plural
     {
         binary(plural_ptr p1,plural_ptr p2) :
             op1(p1),
@@ -50,7 +50,7 @@ namespace { // anon
 
     struct number : public plural
     {
-        number(int v) : 
+        number(int v) :
             val(v)
         {
         }
@@ -179,12 +179,12 @@ namespace { // anon
             return (*op1)(n) ? (*op2)(n) : (*op3)(n);
         }
         conditional *clone() const BOOST_OVERRIDE
-        {                                           
-            plural_ptr op1_copy(op1->clone());      
-            plural_ptr op2_copy(op2->clone());      
-            plural_ptr op3_copy(op3->clone());      
-            return new conditional(op1_copy,op2_copy,op3_copy);     
-        }                                           
+        {
+            plural_ptr op1_copy(op1->clone());
+            plural_ptr op2_copy(op2->clone());
+            plural_ptr op3_copy(op3->clone());
+            return new conditional(op1_copy,op2_copy,op3_copy);
+        }
     private:
         plural_ptr op1,op2,op3;
     };
@@ -254,11 +254,11 @@ namespace { // anon
         {
             return c==' ' || c=='\r' || c=='\n' || c=='\t';
         }
-        bool isdigit(char c) 
+        bool isdigit(char c)
         {
-            return '0'<=c && c<='9'; 
+            return '0'<=c && c<='9';
         }
-        void step() 
+        void step()
         {
             while(text[pos] && is_blank(text[pos])) pos++;
             char const *ptr=text+pos;
@@ -339,14 +339,14 @@ namespace { // anon
             static int level_unary[]={3,'-','!','~'};
             if(is_in(t.next(),level_unary)) {
                 int op=t.get();
-                if((op1=un_expr()).get()==0) 
+                if((op1=un_expr()).get()==0)
                     return plural_ptr();
                 switch(op) {
-                case '-': 
+                case '-':
                     return plural_ptr(new minus(op1));
-                case '!': 
+                case '!':
                     return plural_ptr(new l_not(op1));
-                case '~': 
+                case '~':
                     return plural_ptr(new bin_not(op1));
                 default:
                     return plural_ptr();
@@ -407,5 +407,5 @@ plural_ptr compile(char const *str)
 } // locale
 } // boost
 
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/src/shared/mo_lambda.hpp
+++ b/src/shared/mo_lambda.hpp
@@ -14,7 +14,7 @@ namespace boost {
     namespace locale {
         namespace gnu_gettext {
             namespace lambda {
-                
+
                 struct plural {
 
                     virtual int operator()(int n) const = 0;
@@ -26,11 +26,11 @@ namespace boost {
 
                 plural_ptr compile(char const *c_expression);
 
-            } // lambda 
+            } // lambda
         } // gnu_gettext
-     } // locale 
+     } // locale
 } // boost
 
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/src/std/all_generator.hpp
+++ b/src/std/all_generator.hpp
@@ -45,7 +45,7 @@ namespace boost {
             std::locale create_codecvt( std::locale const &in,
                                         std::string const &locale_name,
                                         character_facet_type type,
-                                        utf8_support utf = utf8_none); 
+                                        utf8_support utf = utf8_none);
 
         }
     }

--- a/src/std/codecvt.cpp
+++ b/src/std/codecvt.cpp
@@ -23,7 +23,7 @@ namespace impl_std {
     std::locale create_codecvt( std::locale const &in,
                                 std::string const &locale_name,
                                 character_facet_type type,
-                                utf8_support utf) 
+                                utf8_support utf)
     {
         if(utf == utf8_from_wide) {
             return util::create_utf8_codecvt(in,type);
@@ -47,7 +47,7 @@ namespace impl_std {
     }
 
 } // impl_std
-} // locale 
+} // locale
 } // boost
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/std/collate.cpp
+++ b/src/std/collate.cpp
@@ -19,7 +19,7 @@ namespace impl_std {
 class utf8_collator_from_wide : public std::collate<char> {
 public:
     typedef std::collate<wchar_t> wfacet;
-    utf8_collator_from_wide(std::locale const &base,size_t refs = 0) : 
+    utf8_collator_from_wide(std::locale const &base,size_t refs = 0) :
         std::collate<char>(refs),
         base_(base)
     {
@@ -39,7 +39,7 @@ public:
     std::string do_transform(char const *b,char const *e) const BOOST_OVERRIDE
     {
         std::wstring tmp=conv::to_utf<wchar_t>(b,e,"UTF-8");
-        std::wstring wkey = 
+        std::wstring wkey =
             std::use_facet<wfacet>(base_).transform(tmp.c_str(),tmp.c_str()+tmp.size());
         std::string key;
 BOOST_LOCALE_START_CONST_CONDITION
@@ -107,7 +107,7 @@ std::locale create_collate( std::locale const &in,
 
 
 } // impl_std
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/std/converter.cpp
+++ b/src/std/converter.cpp
@@ -26,13 +26,13 @@ namespace locale {
 namespace impl_std {
 
 template<typename CharType>
-class std_converter : public converter<CharType> 
+class std_converter : public converter<CharType>
 {
 public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
     typedef std::ctype<char_type> ctype_type;
-    std_converter(std::locale const &base,size_t refs = 0) : 
+    std_converter(std::locale const &base,size_t refs = 0) :
         converter<CharType>(refs),
         base_(base)
     {
@@ -67,7 +67,7 @@ class utf8_converter : public converter<char> {
 public:
     typedef std::ctype<char> ctype_type;
     typedef std::ctype<wchar_t> wctype_type;
-    utf8_converter(std::locale const &base,size_t refs = 0) : 
+    utf8_converter(std::locale const &base,size_t refs = 0) :
         converter<char>(refs),
         base_(base)
     {
@@ -105,7 +105,7 @@ std::locale create_convert( std::locale const &in,
                             utf8_support utf)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             {
                 if(utf == utf8_native_with_wide || utf == utf8_from_wide) {
                     std::locale base(std::locale::classic(),new std::ctype_byname<wchar_t>(locale_name.c_str()));
@@ -140,6 +140,6 @@ std::locale create_convert( std::locale const &in,
 
 
 } // namespace impl_std
-} // locale 
+} // locale
 } // boost
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/std/numeric.cpp
+++ b/src/std/numeric.cpp
@@ -25,7 +25,7 @@ namespace impl_std {
 template<typename CharType>
 class time_put_from_base : public std::time_put<CharType> {
 public:
-    time_put_from_base(std::locale const &base, size_t refs = 0) : 
+    time_put_from_base(std::locale const &base, size_t refs = 0) :
         std::time_put<CharType>(refs),
         base_(base)
     {
@@ -44,7 +44,7 @@ private:
 
 class utf8_time_put_from_wide : public std::time_put<char> {
 public:
-    utf8_time_put_from_wide(std::locale const &base, size_t refs = 0) : 
+    utf8_time_put_from_wide(std::locale const &base, size_t refs = 0) :
         std::time_put<char>(refs),
         base_(base)
     {
@@ -71,14 +71,14 @@ public:
     {
         typedef std::numpunct<wchar_t> wfacet_type;
         wfacet_type const &wfacet = std::use_facet<wfacet_type>(base);
-        
+
         truename_ = conv::from_utf<wchar_t>(wfacet.truename(),"UTF-8");
         falsename_ = conv::from_utf<wchar_t>(wfacet.falsename(),"UTF-8");
-        
+
         wchar_t tmp_decimal_point = wfacet.decimal_point();
         wchar_t tmp_thousands_sep = wfacet.thousands_sep();
         std::string tmp_grouping = wfacet.grouping();
-        
+
         if( 32 <= tmp_thousands_sep && tmp_thousands_sep <=126 &&
             32 <= tmp_decimal_point && tmp_decimal_point <=126)
         {
@@ -131,7 +131,7 @@ private:
     char thousands_sep_;
     char decimal_point_;
     std::string grouping_;
-    
+
 };
 
 template<bool Intl>
@@ -230,7 +230,7 @@ private:
     std::string negative_sign_;
     int frac_digits_;
     std::money_base::pattern pos_format_,neg_format_;
-    
+
 };
 
 class utf8_numpunct : public std::numpunct_byname<char> {
@@ -315,11 +315,11 @@ std::locale create_formatting(  std::locale const &in,
                                 utf8_support utf)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             {
                 if(utf == utf8_from_wide ) {
                     std::locale base = std::locale(locale_name.c_str());
-                    
+
                     std::locale tmp = std::locale(in,new utf8_time_put_from_wide(base));
                     tmp = std::locale(tmp,new utf8_numpunct_from_wide(base));
                     tmp = std::locale(tmp,new utf8_moneypunct_from_wide<true>(base));
@@ -388,7 +388,7 @@ std::locale create_parsing( std::locale const &in,
             {
                 if(utf == utf8_from_wide ) {
                     std::locale base = std::locale::classic();
-                    
+
                     base = std::locale(base,new std::numpunct_byname<wchar_t>(locale_name.c_str()));
                     base = std::locale(base,new std::moneypunct_byname<wchar_t,true>(locale_name.c_str()));
                     base = std::locale(base,new std::moneypunct_byname<wchar_t,false>(locale_name.c_str()));
@@ -412,7 +412,7 @@ std::locale create_parsing( std::locale const &in,
                     tmp = std::locale(tmp,new utf8_moneypunct_from_wide<false>(base));
                     return std::locale(tmp,new util::base_num_parse<char>());
                 }
-                else 
+                else
                 {
                     std::locale tmp = create_basic_parsing<char>(in,locale_name);
                     tmp = std::locale(in,new util::base_num_parse<char>());
@@ -448,7 +448,7 @@ std::locale create_parsing( std::locale const &in,
 
 
 } // impl_std
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/std/std_backend.cpp
+++ b/src/std/std_backend.cpp
@@ -28,16 +28,16 @@
 
 namespace boost {
 namespace locale {
-namespace impl_std { 
-    
+namespace impl_std {
+
     class std_localization_backend : public localization_backend {
     public:
-        std_localization_backend() : 
+        std_localization_backend() :
             invalid_(true),
             use_ansi_encoding_(false)
         {
         }
-        std_localization_backend(std_localization_backend const &other) : 
+        std_localization_backend(std_localization_backend const &other) :
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
@@ -100,8 +100,8 @@ namespace impl_std {
                     utf_mode_ = utf8_none;
                 }
                 #if defined(BOOST_WINDOWS)
-                else if(loadable(win_name) 
-                        && win_codepage == conv::impl::encoding_to_windows_codepage(data_.encoding.c_str())) 
+                else if(loadable(win_name)
+                        && win_codepage == conv::impl::encoding_to_windows_codepage(data_.encoding.c_str()))
                 {
                     name_ = win_name;
                     utf_mode_ = utf8_none;
@@ -121,7 +121,7 @@ namespace impl_std {
                 #endif
             }
         }
-        
+
         #if defined(BOOST_WINDOWS)
         std::pair<std::string,int> to_windows_name(std::string const &l)
         {
@@ -137,7 +137,7 @@ namespace impl_std {
                 lc_name += "_";
                 lc_name += win_country;
             }
-            
+
             res.first = lc_name;
 
             if(GetLocaleInfoA(lcid,LOCALE_IDEFAULTANSICODEPAGE,win_codepage,sizeof(win_codepage))!=0)
@@ -145,7 +145,7 @@ namespace impl_std {
             return res;
         }
         #endif
-        
+
         bool loadable(std::string name)
         {
             try {
@@ -156,7 +156,7 @@ namespace impl_std {
                 return false;
             }
         }
-        
+
         std::locale install(std::locale const &base,
                                     locale_category_type category,
                                     character_facet_type type = nochar_facet) BOOST_OVERRIDE
@@ -222,7 +222,7 @@ namespace impl_std {
         bool invalid_;
         bool use_ansi_encoding_;
     };
-    
+
     localization_backend *create_localization_backend()
     {
         return new std_localization_backend();
@@ -231,4 +231,4 @@ namespace impl_std {
 }  // impl icu
 }  // locale
 }  // boost
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/std/std_backend.hpp
+++ b/src/std/std_backend.hpp
@@ -10,11 +10,11 @@
 namespace boost {
     namespace locale {
         class localization_backend;
-        namespace impl_std { 
+        namespace impl_std {
             localization_backend *create_localization_backend();
         } // impl_std
-    } // locale 
+    } // locale
 } // boost
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/src/util/codecvt_converter.cpp
+++ b/src/util/codecvt_converter.cpp
@@ -17,12 +17,12 @@
 #include "../encoding/conv.hpp"
 
 //#define DEBUG_CODECVT
-#ifdef DEBUG_CODECVT            
+#ifdef DEBUG_CODECVT
 #include <iostream>
 #endif
 
 #ifdef BOOST_MSVC
-#  pragma warning(disable : 4244 4996) // loose data 
+#  pragma warning(disable : 4244 4996) // loose data
 #endif
 
 namespace boost {
@@ -30,7 +30,7 @@ namespace locale {
 namespace util {
 
     base_converter::~base_converter() {}
-    
+
     class utf8_converter  : public base_converter {
     public:
         int max_len() const BOOST_OVERRIDE
@@ -51,7 +51,7 @@ namespace util {
         uint32_t to_unicode(char const *&begin,char const *end) BOOST_OVERRIDE
         {
             char const *p=begin;
-                        
+
             utf::code_point c = utf::utf_traits<char>::decode(p,end);
 
             if(c==utf::illegal)
@@ -79,7 +79,7 @@ namespace util {
 
     class simple_converter_impl {
     public:
-        
+
         static const int hash_table_size = 1024;
 
         simple_converter_impl(std::string const &encoding)
@@ -147,7 +147,7 @@ namespace util {
     class simple_converter : public base_converter {
     public:
 
-        simple_converter(std::string const &encoding) : 
+        simple_converter(std::string const &encoding) :
             cvt_(encoding)
         {
         }
@@ -163,7 +163,7 @@ namespace util {
         }
         base_converter *clone() const BOOST_OVERRIDE
         {
-           return new simple_converter(*this); 
+           return new simple_converter(*this);
         }
 
         uint32_t to_unicode(char const *&begin,char const *end) BOOST_OVERRIDE
@@ -190,7 +190,7 @@ namespace util {
         }
 
         struct state_type {};
-        static state_type initial_state(generic_codecvt_base::initial_convertion_state /* unused */) 
+        static state_type initial_state(generic_codecvt_base::initial_convertion_state /* unused */)
         {
             return state_type();
         }
@@ -199,7 +199,7 @@ namespace util {
             return 1;
         }
 
-        utf::code_point to_unicode(state_type &,char const *&begin,char const *end) const 
+        utf::code_point to_unicode(state_type &,char const *&begin,char const *end) const
         {
             return cvt_.to_unicode(begin,end);
         }
@@ -209,8 +209,8 @@ namespace util {
             return cvt_.from_unicode(u,begin,end);
         }
     private:
-        simple_converter_impl cvt_;        
-         
+        simple_converter_impl cvt_;
+
     };
 
     namespace {
@@ -262,7 +262,7 @@ namespace util {
                         compare_strings);
         return 0;
     }
-    
+
     #if BOOST_LOCALE_USE_AUTO_PTR
     std::auto_ptr<base_converter> create_utf8_converter()
     {
@@ -307,7 +307,7 @@ namespace util {
     {
         return new utf8_converter();
     }
-    
+
     template<typename CharType>
     class code_converter : public generic_codecvt<CharType,code_converter<CharType> >
     {
@@ -320,8 +320,8 @@ namespace util {
         #define PTR_TRANS(x) (x)
         #endif
         typedef base_converter_ptr state_type;
-        
-        code_converter(base_converter_ptr cvt,size_t refs = 0) : 
+
+        code_converter(base_converter_ptr cvt,size_t refs = 0) :
             generic_codecvt<CharType,code_converter<CharType> >(refs),
             cvt_(PTR_TRANS(cvt))
         {
@@ -343,7 +343,7 @@ namespace util {
             return r;
         }
 
-        utf::code_point to_unicode(base_converter_ptr &ptr,char const *&begin,char const *end) const 
+        utf::code_point to_unicode(base_converter_ptr &ptr,char const *&begin,char const *end) const
         {
             if(thread_safe_)
                 return cvt_->to_unicode(begin,end);
@@ -358,7 +358,7 @@ namespace util {
             else
                 return ptr->from_unicode(u,begin,end);
         }
-        
+
     private:
         base_converter_ptr cvt_;
         int max_len_;
@@ -390,10 +390,10 @@ namespace util {
     }
 
 
-    /// 
+    ///
     /// Install utf8 codecvt to UTF-16 or UTF-32 into locale \a in and return
-    /// new locale that is based on \a in and uses new facet. 
-    /// 
+    /// new locale that is based on \a in and uses new facet.
+    ///
     std::locale create_utf8_codecvt(std::locale const &in,character_facet_type type)
     {
         switch(type) {
@@ -417,7 +417,7 @@ namespace util {
     ///
     /// This function installs codecvt that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
-    /// 
+    ///
     /// Throws invalid_charset_error if the chacater set is not supported or isn't single byte character
     /// set
     std::locale create_simple_codecvt(std::locale const &in,std::string const &encoding,character_facet_type type)
@@ -446,7 +446,7 @@ namespace util {
 
 
 } // util
-} // locale 
+} // locale
 } // boost
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/util/default_locale.cpp
+++ b/src/util/default_locale.cpp
@@ -68,7 +68,7 @@ namespace boost {
                     lc_name += ".UTF-8";
                 }
                 return lc_name;
-                
+
                 #endif
             }
         } // impl

--- a/src/util/gregorian.cpp
+++ b/src/util/gregorian.cpp
@@ -70,7 +70,7 @@ namespace util {
             };
             return days[is_leap(year)][month-1] + day - 1;
         }
-        
+
         std::time_t internal_timegm(std::tm const *t)
         {
             int year = t->tm_year + 1900;
@@ -88,10 +88,10 @@ namespace util {
             int day = t->tm_mday;
             int day_of_year = days_from_1jan(year,month,day);
             int days_since_epoch = days_from_1970(year) + day_of_year;
-            
+
             std::time_t seconds_in_day = 3600 * 24;
             std::time_t result =  seconds_in_day * days_since_epoch + 3600 * t->tm_hour + 60 * t->tm_min + t->tm_sec;
-            
+
             return result;
         }
 
@@ -108,7 +108,7 @@ namespace util {
         {
             return strcmp(left,right) < 0;
         }
-        
+
         //
         // Ref: CLDR 1.9 common/supplemental/supplementalData.xml
         //
@@ -128,7 +128,7 @@ namespace util {
                 "AR","AS","AZ","BW","CA","CN","FO","GE","GL","GU",
                 "HK","IL","IN","JM","JP","KG","KR","LA","MH","MN",
                 "MO","MP","MT","NZ","PH","PK","SG","TH","TT","TW",
-                "UM","US","UZ","VI","ZW" 
+                "UM","US","UZ","VI","ZW"
             };
             if(strcmp(terr,"MV") == 0)
                 return 5; // fri
@@ -143,7 +143,7 @@ namespace util {
 
     class gregorian_calendar : public abstract_calendar {
     public:
-            
+
             gregorian_calendar(std::string const &terr)
             {
                 first_day_of_week_ = first_day_of_week(terr.c_str());
@@ -152,7 +152,7 @@ namespace util {
                 tzoff_ = 0;
                 from_time(time_);
             }
-                
+
             ///
             /// Make a polymorphic copy of the calendar
             ///
@@ -200,7 +200,7 @@ namespace util {
                     tm_updated_.tm_mday += (value - (tm_updated_.tm_yday + 1));
                     break;
                 case day_of_week:           ///< Day of week, starting from Sunday, [1..7]
-                    if(value < 1) // make sure it is positive 
+                    if(value < 1) // make sure it is positive
                         value += (-value / 7) * 7 + 7;
                     // convert to local DOW
                     value = (value - 1 - first_day_of_week_ + 14) % 7 + 1;
@@ -259,9 +259,9 @@ namespace util {
                         if(!gmtime_r(&point,&val))
                             throw date_time_error("boost::locale::gregorian_calendar invalid time");
                         #endif
-                        
+
                     }
-                    
+
                     time_ = point - tzoff_;
                     tm_ = val;
                     tm_updated_ = val;
@@ -281,7 +281,7 @@ namespace util {
                 // Alaways use local week start
                 int current_dow = (wday - first_day_of_week_ + 7) % 7;
                 // Calculate local week day of Jan 1st.
-                int first_week_day = (current_dow + 700 - day) % 7; 
+                int first_week_day = (current_dow + 700 - day) % 7;
                     // adding something big devidable by 7
 
                 int start_of_period_in_weeks;
@@ -318,7 +318,7 @@ namespace util {
                         if(sizeof(std::time_t) == 4)
                             return 1901; // minimal year with 32 bit time_t
                         else
-                            return 1; 
+                            return 1;
                         #endif
                     case absolute_maximum:
                     case least_maximum:
@@ -479,7 +479,7 @@ BOOST_LOCALE_END_CONST_CONDITION
                     break;
                 case period::marks::first_day_of_week:          ///< For example Sunday in US, Monday in France
                     return first_day_of_week_ + 1;
-                
+
                 case week_of_year:               ///< The week number in the year
                     switch(v) {
                     case absolute_minimum:
@@ -557,7 +557,7 @@ BOOST_LOCALE_END_CONST_CONDITION
                     ;
                 }
                 return 0;
- 
+
             }
 
             ///
@@ -718,7 +718,7 @@ BOOST_LOCALE_END_CONST_CONDITION
                     }
                 case month:
                     {
-                        int diff = 12 * (other->tm_.tm_year - tm_.tm_year) 
+                        int diff = 12 * (other->tm_.tm_year - tm_.tm_year)
                                     + other->tm_.tm_mon - tm_.tm_mon;
                         return get_diff(period::marks::month,diff,other);
                     }
@@ -779,8 +779,8 @@ BOOST_LOCALE_END_CONST_CONDITION
                 gregorian_calendar const *gcal = dynamic_cast<gregorian_calendar const *>(other);
                 if(!gcal)
                     return false;
-                return 
-                    gcal->tzoff_ == tzoff_ 
+                return
+                    gcal->tzoff_ == tzoff_
                     && gcal->is_local_ == is_local_
                     && gcal->first_day_of_week_  == first_day_of_week_;
             }
@@ -814,9 +814,9 @@ BOOST_LOCALE_END_CONST_CONDITION
         bool is_local_;
         int tzoff_;
         std::string time_zone_name_;
-        
+
     };
-    
+
     abstract_calendar *create_gregorian_calendar(std::string const &terr)
     {
         return new gregorian_calendar(terr);
@@ -824,7 +824,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 
     class gregorian_facet : public calendar_facet {
     public:
-        gregorian_facet(std::string const &terr,size_t refs = 0) : 
+        gregorian_facet(std::string const &terr,size_t refs = 0) :
             calendar_facet(refs),
             terr_(terr)
         {
@@ -836,7 +836,7 @@ BOOST_LOCALE_END_CONST_CONDITION
     private:
         std::string terr_;
     };
-    
+
     std::locale install_gregorian_calendar(std::locale const &in,std::string const &terr)
     {
         return std::locale(in,new gregorian_facet(terr));
@@ -844,7 +844,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 
 
 } // util
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/util/gregorian.hpp
+++ b/src/util/gregorian.hpp
@@ -17,7 +17,7 @@ namespace util {
     std::locale install_gregorian_calendar(std::locale const &in,std::string const &terr);
 
 } // util
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/util/iconv.hpp
+++ b/src/util/iconv.hpp
@@ -51,7 +51,7 @@ namespace boost {
         }
 #endif
 
-    } // locale 
+    } // locale
 } // boost
 
 #endif

--- a/src/util/info.cpp
+++ b/src/util/info.cpp
@@ -60,7 +60,7 @@ namespace util {
         locale_data d;
         std::string name_;
     };
-    
+
     std::locale create_info(std::locale const &in,std::string const &name)
     {
         return std::locale(in,new simple_info(name));
@@ -68,7 +68,7 @@ namespace util {
 
 
 } // util
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/util/locale_data.cpp
+++ b/src/util/locale_data.cpp
@@ -23,7 +23,7 @@ namespace util {
         parse_from_lang(locale_name);
     }
 
-    void locale_data::parse_from_lang(std::string const &locale_name) 
+    void locale_data::parse_from_lang(std::string const &locale_name)
     {
         size_t end = locale_name.find_first_of("-_@.");
         std::string tmp = locale_name.substr(0,end);
@@ -50,7 +50,7 @@ namespace util {
         }
     }
 
-    void locale_data::parse_from_country(std::string const &locale_name) 
+    void locale_data::parse_from_country(std::string const &locale_name)
     {
         size_t end = locale_name.find_first_of("@.");
         std::string tmp = locale_name.substr(0,end);
@@ -74,8 +74,8 @@ namespace util {
            parse_from_variant(locale_name.substr(end+1));
         }
     }
-    
-    void locale_data::parse_from_encoding(std::string const &locale_name) 
+
+    void locale_data::parse_from_encoding(std::string const &locale_name)
     {
         size_t end = locale_name.find_first_of("@");
         std::string tmp = locale_name.substr(0,end);
@@ -86,7 +86,7 @@ namespace util {
                 tmp[i]=tmp[i]-'A'+'a';
         }
         encoding = tmp;
-        
+
         utf8 = conv::impl::normalize_encoding(encoding.c_str()) == "utf8";
 
         if(end >= locale_name.size())
@@ -107,7 +107,7 @@ namespace util {
     }
 
 } // util
-} // locale 
+} // locale
 } // boost
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/util/locale_data.hpp
+++ b/src/util/locale_data.hpp
@@ -13,10 +13,10 @@
 namespace boost {
     namespace locale {
         namespace util {
-            
+
             class locale_data {
             public:
-                locale_data() : 
+                locale_data() :
                     language("C"),
                     encoding("us-ascii"),
                     utf8(false)
@@ -40,7 +40,7 @@ namespace boost {
             };
 
         } // util
-    } // locale 
+    } // locale
 } // boost
 
 #endif

--- a/src/util/numeric.hpp
+++ b/src/util/numeric.hpp
@@ -9,6 +9,7 @@
 #define BOOST_LOCALE_IMPL_UTIL_NUMERIC_HPP
 #include <boost/locale/info.hpp>
 #include <boost/locale/formatting.hpp>
+#include <boost/predef/os.h>
 #include <ctime>
 #include <cstdlib>
 #include <ios>
@@ -189,7 +190,7 @@ private:
     {
         std::string tz = ios_info::get(ios).time_zone();
         std::tm tm;
-        #if defined(__linux) || defined(__FreeBSD__) || defined(__APPLE__) 
+        #if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
         std::vector<char> tmp_buf(tz.c_str(),tz.c_str()+tz.size()+1);
         #endif
         if(tz.empty()) {
@@ -210,7 +211,7 @@ private:
             gmtime_r(&time,&tm);
             #endif
             
-            #if defined(__linux) || defined(__FreeBSD__) || defined(__APPLE__) 
+            #if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
             // These have extra fields to specify timezone
             if(gmtoff!=0) {
                 // bsd and apple want tm_zone be non-const

--- a/src/util/numeric.hpp
+++ b/src/util/numeric.hpp
@@ -69,12 +69,12 @@ public:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    base_num_format(size_t refs = 0) : 
+    base_num_format(size_t refs = 0) :
         std::num_put<CharType>(refs)
     {
     }
-protected: 
-    
+protected:
+
 
     iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long val) const BOOST_OVERRIDE
     {
@@ -92,8 +92,8 @@ protected:
     {
         return do_real_put(out,ios,fill,val);
     }
-    
-    #ifndef BOOST_NO_LONG_LONG 
+
+    #ifndef BOOST_NO_LONG_LONG
     iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long long val) const BOOST_OVERRIDE
     {
         return do_real_put(out,ios,fill,val);
@@ -139,7 +139,7 @@ private:
             return format_time(out,ios,fill,static_cast<std::time_t>(val),info.date_time_pattern<char_type>());
         case flags::currency:
             {
-                bool nat =  info.currency_flags()==flags::currency_default 
+                bool nat =  info.currency_flags()==flags::currency_default
                             || info.currency_flags() == flags::currency_national;
                 bool intl = !nat;
                 return do_format_currency(intl,out,ios,fill,static_cast<long double>(val));
@@ -210,7 +210,7 @@ private:
             #else
             gmtime_r(&time,&tm);
             #endif
-            
+
             #if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
             // These have extra fields to specify timezone
             if(gmtoff!=0) {
@@ -224,13 +224,13 @@ private:
         std::use_facet<std::time_put<char_type> >(ios.getloc()).put(tmp_out,tmp_out,fill,&tm,format.c_str(),format.c_str()+format.size());
         string_type str = tmp_out.str();
         std::streamsize on_left=0,on_right = 0;
-        std::streamsize points = 
+        std::streamsize points =
             formatting_size_traits<char_type>::size(str,ios.getloc());
         if(points < ios.width()) {
             std::streamsize n = ios.width() - points;
-            
+
             std::ios_base::fmtflags flags = ios.flags() & std::ios_base::adjustfield;
-            
+
             //
             // we do not really know internal point, so we assume that it does not
             // exist. so according to the standard field should be right aligned
@@ -259,11 +259,11 @@ template<typename CharType>
 class base_num_parse : public std::num_get<CharType>
 {
 public:
-    base_num_parse(size_t refs = 0) : 
+    base_num_parse(size_t refs = 0) :
         std::num_get<CharType>(refs)
     {
     }
-protected: 
+protected:
     typedef typename std::num_get<CharType>::iter_type iter_type;
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
@@ -303,7 +303,7 @@ protected:
         return do_real_get(in,end,ios,err,val);
     }
 
-    #ifndef BOOST_NO_LONG_LONG 
+    #ifndef BOOST_NO_LONG_LONG
     iter_type do_get (iter_type in, iter_type end, std::ios_base &ios,std::ios_base::iostate &err,long long &val) const BOOST_OVERRIDE
     {
         return do_real_get(in,end,ios,err,val);
@@ -317,7 +317,7 @@ protected:
     #endif
 
 private:
-    
+
     template<typename ValueType>
     iter_type do_real_get(iter_type in,iter_type end,std::ios_base &ios,std::ios_base::iostate &err,ValueType &val) const
     {
@@ -383,7 +383,7 @@ private:
 };
 
 } // util
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/util/timezone.hpp
+++ b/src/util/timezone.hpp
@@ -14,7 +14,7 @@
 namespace boost {
 namespace locale {
 namespace util {
-    inline int parse_tz(std::string const &tz) 
+    inline int parse_tz(std::string const &tz)
     {
         int gmtoff = 0;
         std::string ltz;
@@ -46,7 +46,7 @@ namespace util {
     }
 
 } // util
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/win32/api.hpp
+++ b/src/win32/api.hpp
@@ -40,7 +40,7 @@
 namespace boost {
 namespace locale {
 namespace impl_win {
-    
+
     struct numeric_info {
         std::wstring thousands_sep;
         std::wstring decimal_point;
@@ -66,14 +66,14 @@ namespace impl_win {
         return flags;
     }
 
-    
-  
-    #ifdef BOOST_LOCALE_WINDOWS_2000_API 
-    
+
+
+    #ifdef BOOST_LOCALE_WINDOWS_2000_API
+
     class winlocale{
     public:
-        winlocale() : 
-            lcid(0) 
+        winlocale() :
+            lcid(0)
         {
         }
 
@@ -81,9 +81,9 @@ namespace impl_win {
         {
             lcid = locale_to_lcid(name);
         }
-        
+
         unsigned lcid;
-        
+
         bool is_c() const
         {
             return lcid == 0;
@@ -96,7 +96,7 @@ namespace impl_win {
     /// Number Format
     ///
     ////////////////////////////////////////////////////////////////////////
-    
+
     inline numeric_info wcsnumformat_l(winlocale const &l)
     {
         numeric_info res;
@@ -111,9 +111,9 @@ namespace impl_win {
         static const int de_size = 4;
         static const int gr_size = 10;
 
-        wchar_t th[th_size]={0}; 
+        wchar_t th[th_size]={0};
         wchar_t de[de_size]={0};
-        wchar_t gr[gr_size]={0}; 
+        wchar_t gr[gr_size]={0};
 
         if( GetLocaleInfoW(lcid,LOCALE_STHOUSAND,th,th_size)==0
             || GetLocaleInfoW(lcid,LOCALE_SDECIMAL ,de,de_size)==0
@@ -203,21 +203,21 @@ namespace impl_win {
     ///
     ////////////////////////////////////////////////////////////////////////
 
-    
+
     inline std::wstring wcs_format_date_l(wchar_t const *format,SYSTEMTIME const *tm,winlocale const &l)
     {
         int len = GetDateFormatW(l.lcid,0,tm,format,0,0);
         std::vector<wchar_t> buf(len+1);
         GetDateFormatW(l.lcid,0,tm,format,&buf.front(),len);
-        return &buf.front(); 
+        return &buf.front();
     }
-    
+
     inline std::wstring wcs_format_time_l(wchar_t const *format,SYSTEMTIME const *tm,winlocale const &l)
     {
         int len = GetTimeFormatW(l.lcid,0,tm,format,0,0);
         std::vector<wchar_t> buf(len+1);
         GetTimeFormatW(l.lcid,0,tm,format,&buf.front(),len);
-        return &buf.front(); 
+        return &buf.front();
     }
 
     inline std::wstring wcsfold(wchar_t const *begin,wchar_t const *end)

--- a/src/win32/collate.cpp
+++ b/src/win32/collate.cpp
@@ -20,7 +20,7 @@ namespace impl_win {
 
 class utf8_collator : public collator<char> {
 public:
-    utf8_collator(winlocale lc,size_t refs = 0) : 
+    utf8_collator(winlocale lc,size_t refs = 0) :
         collator<char>(refs),
         lc_(lc)
     {
@@ -71,7 +71,7 @@ private:
 class utf16_collator : public collator<wchar_t> {
 public:
     typedef std::collate<wchar_t> wfacet;
-    utf16_collator(winlocale lc,size_t refs = 0) : 
+    utf16_collator(winlocale lc,size_t refs = 0) :
         collator<wchar_t>(refs),
         lc_(lc)
     {
@@ -121,7 +121,7 @@ std::locale create_collate( std::locale const &in,
 
 
 } // impl_std
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/win32/converter.cpp
+++ b/src/win32/converter.cpp
@@ -20,10 +20,10 @@ namespace boost {
 namespace locale {
 namespace impl_win {
 
-class utf16_converter : public converter<wchar_t> 
+class utf16_converter : public converter<wchar_t>
 {
 public:
-    utf16_converter(winlocale const &lc,size_t refs = 0) : 
+    utf16_converter(winlocale const &lc,size_t refs = 0) :
         converter<wchar_t>(refs),
         lc_(lc)
     {
@@ -49,7 +49,7 @@ private:
 
 class utf8_converter : public converter<char> {
 public:
-    utf8_converter(winlocale const &lc,size_t refs = 0) : 
+    utf8_converter(winlocale const &lc,size_t refs = 0) :
         converter<char>(refs),
         lc_(lc)
     {
@@ -89,7 +89,7 @@ std::locale create_convert( std::locale const &in,
                             character_facet_type type)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             return std::locale(in,new utf8_converter(lc));
         case wchar_t_facet:
             return std::locale(in,new utf16_converter(lc));
@@ -100,6 +100,6 @@ std::locale create_convert( std::locale const &in,
 
 
 } // namespace impl_win32
-} // locale 
+} // locale
 } // boost
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/win32/lcid.cpp
+++ b/src/win32/lcid.cpp
@@ -53,7 +53,7 @@ BOOL CALLBACK proc(char *s)
         if(ss.fail() || !ss.eof()) {
             return FALSE;
         }
-            
+
         char iso_639_lang[16];
         char iso_3166_country[16];
         if(GetLocaleInfoA(lcid,LOCALE_SISO639LANGNAME,iso_639_lang,sizeof(iso_639_lang))==0)
@@ -98,7 +98,7 @@ unsigned locale_to_lcid(std::string const &locale_name)
 {
     if(locale_name.empty()) {
         return LOCALE_USER_DEFAULT;
-    } 
+    }
     boost::locale::util::locale_data d;
     d.parse(locale_name);
     std::string id = d.language;
@@ -112,7 +112,7 @@ unsigned locale_to_lcid(std::string const &locale_name)
 
     table_type const &tbl = get_ready_lcid_table();
     table_type::const_iterator p = tbl.find(id);
-    
+
     unsigned lcid = 0;
     if(p!=tbl.end())
         lcid = p->second;

--- a/src/win32/numeric.cpp
+++ b/src/win32/numeric.cpp
@@ -33,7 +33,7 @@ namespace impl_win {
                 *out++ = s[i];
             return out;
         }
-        
+
         std::ostreambuf_iterator<char> write_it(std::ostreambuf_iterator<char> out,std::wstring const &s)
         {
             std::string tmp = conv::from_utf(s,"UTF-8");
@@ -52,7 +52,7 @@ public:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    num_format(winlocale const &lc,size_t refs = 0) : 
+    num_format(winlocale const &lc,size_t refs = 0) :
         util::base_num_format<CharType>(refs),
         lc_(lc)
     {
@@ -88,7 +88,7 @@ private:
 template<typename CharType>
 class time_put_win : public std::time_put<CharType> {
 public:
-    time_put_win(winlocale const &lc, size_t refs = 0) : 
+    time_put_win(winlocale const &lc, size_t refs = 0) :
         std::time_put<CharType>(refs),
         lc_(lc)
     {
@@ -117,7 +117,7 @@ template<typename CharType>
 class num_punct_win : public std::numpunct<CharType> {
 public:
     typedef std::basic_string<CharType> string_type;
-    num_punct_win(winlocale const &lc,size_t refs = 0) : 
+    num_punct_win(winlocale const &lc,size_t refs = 0) :
         std::numpunct<CharType>(refs)
     {
         numeric_info np = wcsnumformat_l(lc) ;
@@ -135,7 +135,7 @@ BOOST_LOCALE_END_CONST_CONDITION
         if(decimal_point_.size() > 1)
             decimal_point_ = CharType('.');
     }
-    
+
     void to_str(std::wstring &s1,std::wstring &s2)
     {
         s2.swap(s1);
@@ -209,7 +209,7 @@ std::locale create_formatting(  std::locale const &in,
                                 character_facet_type type)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             return create_formatting_impl<char>(in,lc);
         case wchar_t_facet:
             return create_formatting_impl<wchar_t>(in,lc);
@@ -223,7 +223,7 @@ std::locale create_parsing( std::locale const &in,
                             character_facet_type type)
 {
         switch(type) {
-        case char_facet: 
+        case char_facet:
             return create_parsing_impl<char>(in,lc);
         case wchar_t_facet:
             return create_parsing_impl<wchar_t>(in,lc);
@@ -235,7 +235,7 @@ std::locale create_parsing( std::locale const &in,
 
 
 } // impl_std
-} // locale 
+} // locale
 } //boost
 
 

--- a/src/win32/win_backend.cpp
+++ b/src/win32/win_backend.cpp
@@ -21,16 +21,16 @@
 
 namespace boost {
 namespace locale {
-namespace impl_win { 
-    
+namespace impl_win {
+
     class winapi_localization_backend : public localization_backend {
     public:
-        winapi_localization_backend() : 
+        winapi_localization_backend() :
             invalid_(true)
         {
         }
         winapi_localization_backend(winapi_localization_backend const &other) :
-            localization_backend(), 
+            localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
             locale_id_(other.locale_id_),
@@ -42,7 +42,7 @@ namespace impl_win {
             return new winapi_localization_backend(*this);
         }
 
-        void set_option(std::string const &name,std::string const &value) 
+        void set_option(std::string const &name,std::string const &value)
         {
             invalid_ = true;
             if(name=="locale")
@@ -77,11 +77,11 @@ namespace impl_win {
             util::locale_data d;
             d.parse(real_id_);
             if(!d.utf8) {
-                lc_ = winlocale(); 
+                lc_ = winlocale();
                 // Make it C as non-UTF8 locales are not supported
             }
         }
-        
+
         std::locale install(std::locale const &base,
                                     locale_category_type category,
                                     character_facet_type type = nochar_facet) BOOST_OVERRIDE
@@ -142,7 +142,7 @@ namespace impl_win {
         bool invalid_;
         winlocale lc_;
     };
-    
+
     localization_backend *create_localization_backend()
     {
         return new winapi_localization_backend();
@@ -151,4 +151,4 @@ namespace impl_win {
 }  // impl win
 }  // locale
 }  // boost
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/src/win32/win_backend.hpp
+++ b/src/win32/win_backend.hpp
@@ -10,11 +10,11 @@
 namespace boost {
     namespace locale {
         class localization_backend;
-        namespace impl_win { 
+        namespace impl_win {
             localization_backend *create_localization_backend();
         } // impl_win
-    } // locale 
+    } // locale
 } // boost
 #endif
-// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ function(boost_locale_add_test name)
     set(ARG_SRC ${name}.cpp)
   endif()
   set(name ${PROJECT_NAME}-${name})
-  
+
   add_executable(${name} ${ARG_SRC})
   add_dependencies(tests ${name})
   target_link_libraries(${name} PRIVATE Boost::locale)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,8 +1,8 @@
 #
-# Copyright 2011 Artyom Beilis 
+# Copyright 2011 Artyom Beilis
 #
-# Distributed under the Boost Software License, Version 1.0. 
-# (See accompanying file LICENSE_1_0.txt or copy at 
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt.
 
 

--- a/test/cmake_test/main.cpp
+++ b/test/cmake_test/main.cpp
@@ -33,6 +33,6 @@ int main()
     {
         std::cout << "Failed creation..." << std::endl;
     }
-    
+
     return cvt.get() ? 0 : 1;
 }

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -50,7 +50,7 @@ void test_word_container(Iterator begin,Iterator end,
     )
 {
     for(int sm=(bt == lb::word ? 31 : 3 ) ;sm>=0;sm--) {
-        unsigned mask = 
+        unsigned mask =
               ((sm & 1 ) != 0) * 0xF
             + ((sm & 2 ) != 0) * 0xF0
             + ((sm & 4 ) != 0) * 0xF00
@@ -96,7 +96,7 @@ void test_word_container(Iterator begin,Iterator end,
 
             map.rule(mask);
 
-            {        
+            {
                 unsigned i=0;
                 iter_type p;
                 map.full_select(false);
@@ -104,7 +104,7 @@ void test_word_container(Iterator begin,Iterator end,
                     TEST(p->str()==chunks[i]);
                     TEST(p->rule() == unsigned(masks[i]));
                 }
-                
+
                 TEST(chunks.size() == i);
                 for(;;) {
                     if(p==map.begin()) {
@@ -136,7 +136,7 @@ void test_word_container(Iterator begin,Iterator end,
                 }
 
                 TEST(chunks.size() == i);
-                
+
                 for(;;) {
                     if(p==map.begin()) {
                         TEST(i==0);
@@ -152,7 +152,7 @@ void test_word_container(Iterator begin,Iterator end,
                         TEST(p->rule() == unsigned(masks[i]));
                     }
                 }
-                
+
                 for(i=0,p=map.end();i<chunks.size();i++){
                     --p;
                     unsigned index = chunks.size() - i - 1;
@@ -161,8 +161,8 @@ void test_word_container(Iterator begin,Iterator end,
                 }
                 TEST(p==map.begin());
             }
-            
-            {            
+
+            {
                 iter_type p;
                 unsigned chunk_ptr=0;
                 unsigned i=0;
@@ -181,7 +181,7 @@ void test_word_container(Iterator begin,Iterator end,
                     }
                 }
             }
-            {            
+            {
                 iter_type p;
                 unsigned chunk_ptr=0;
                 unsigned i=0;
@@ -208,7 +208,7 @@ void test_word_container(Iterator begin,Iterator end,
             typedef typename lb::boundary_point_index<Iterator>::iterator iter_type;
 
             map.rule(mask);
-        
+
             unsigned i=0;
             iter_type p;
             for(p=map.begin();p!=map.end();++p,i++) {
@@ -232,7 +232,7 @@ void test_word_container(Iterator begin,Iterator end,
                 if(iters.at(iters_ptr)==optr)
                     iters_ptr++;
             }
-        
+
         } // break iterator tests
 
         { // copy test
@@ -348,8 +348,8 @@ void run_word(std::string *original,int *none,int *num,int *word,int *kana,int *
         pos.push_back(test_string.size());
         masks.push_back(
               ( none ? none[i]*15 : 0)
-            | ( num  ? ((num[i]*15)  << 4) : 0) 
-            | ( word ? ((word[i]*15) << 8) : 0) 
+            | ( num  ? ((num[i]*15)  << 4) : 0)
+            | ( word ? ((word[i]*15) << 8) : 0)
             | ( kana ? ((kana[i]*15) << 12) : 0)
             | ( ideo ? ((ideo[i]*15) << 16) : 0)
         );
@@ -402,11 +402,11 @@ void word_boundary()
     int         num1[]={ 1,   0,      0,  0,         1,   0,      0 ,        0 ,         0};
     int        word1[]={ 0,   0,      1,  0,         1,   0,      0 ,        0 ,         0};
 #if U_ICU_VERSION_MAJOR_NUM >= 50
-    int        kana1[]={ 0,   0,      0,  0,         0,   0,      0,         0 ,         0}; 
-    int        ideo1[]={ 0,   0,      0,  0,         0,   0,      1,         1 ,         1}; 
+    int        kana1[]={ 0,   0,      0,  0,         0,   0,      0,         0 ,         0};
+    int        ideo1[]={ 0,   0,      0,  0,         0,   0,      1,         1 ,         1};
 #else
-    int        kana1[]={ 0,   0,      0,  0,         0,   0,      0,         1 ,         1}; 
-    int        ideo1[]={ 0,   0,      0,  0,         0,   0,      1,         0 ,         0}; 
+    int        kana1[]={ 0,   0,      0,  0,         0,   0,      0,         1 ,         1};
+    int        ideo1[]={ 0,   0,      0,  0,         0,   0,      1,         0 ,         0};
 #endif
 
 
@@ -437,14 +437,14 @@ void word_boundary()
     run_word<char16_t>(all1,none1,num1,word1,kana1,ideo1,g("ja_JP.UTF-8"));
     run_word<char16_t>(all2,zero,zero,zero,zero,zero,g("en_US.UTF-8"));
     run_word<char16_t>(all3,none3,zero,word3,zero,zero,g("en_US.UTF-8"));
-    #endif 
+    #endif
 
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     std::cout << " char32_t"<<std::endl;
     run_word<char32_t>(all1,none1,num1,word1,kana1,ideo1,g("ja_JP.UTF-8"));
     run_word<char32_t>(all2,zero,zero,zero,zero,zero,g("en_US.UTF-8"));
     run_word<char32_t>(all3,none3,zero,word3,zero,zero,g("en_US.UTF-8"));
-    #endif 
+    #endif
 }
 void test_op_one_side(std::string const &sl,std::string const &sr,int val)
 {
@@ -465,7 +465,7 @@ void test_op_one_side(std::string const &sl,std::string const &sr,int val)
     TEST( (l< sr.c_str()) == (val<0));
     TEST( (l>=sr.c_str()) == (val>=0));
     TEST( (l> sr.c_str()) == (val>0));
-    
+
     TEST( (sl.c_str()==r) == (val==0));
     TEST( (sl.c_str()!=r) == (val!=0));
     TEST( (sl.c_str()<=r) == (val<=0));
@@ -481,7 +481,7 @@ void test_op_one_side(std::string const &sl,std::string const &sr,int val)
     TEST( (l< sr) == (val<0));
     TEST( (l>=sr) == (val>=0));
     TEST( (l> sr) == (val>0));
-    
+
     TEST( (sl==r) == (val==0));
     TEST( (sl!=r) == (val!=0));
     TEST( (sl<=r) == (val<=0));
@@ -535,4 +535,4 @@ int main()
 #endif // NOICU
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -48,17 +48,17 @@ void test_codecvt_in_n_m(cvt_type const &cvt,int n,int m)
             if(end > real_end)
                 end = real_end;
         }
-        
+
         wchar_t buf[128];
         wchar_t *to = buf;
         wchar_t *to_end = to + m;
         wchar_t *to_next = to;
-        
-        
+
+
         std::mbstate_t mb2 = mb;
         std::codecvt_base::result r = cvt.in(mb,from,end,from_next,to,to_end,to_next);
         //std::cout << "In from_size=" << (end-from) << " from move=" <<  (from_next - from) << " to move= " << to_next - to << " state = " << res(r) << std::endl;
-       
+
         int count = cvt.length(mb2,from,end,to_end - to);
         #ifndef BOOST_LOCALE_DO_LENGTH_MBSTATE_CONST
         TEST(memcmp(&mb,&mb2,sizeof(mb))==0);
@@ -70,7 +70,7 @@ void test_codecvt_in_n_m(cvt_type const &cvt,int n,int m)
         TEST(count == to_next - to);
         #endif
 
-        
+
         if(r == cvt_type::partial) {
             end+=n;
             if(end > real_end)
@@ -88,7 +88,7 @@ void test_codecvt_in_n_m(cvt_type const &cvt,int n,int m)
     }
     TEST(wptr == wide_name + wlen);
     TEST(from == real_end);
-    
+
 }
 
 void test_codecvt_out_n_m(cvt_type const &cvt,int n,int m)
@@ -96,18 +96,18 @@ void test_codecvt_out_n_m(cvt_type const &cvt,int n,int m)
     char const *nptr = utf8_name;
     const size_t wlen = wcslen(wide_name);
     const size_t u8len = strlen(utf8_name);
-    
+
     std::mbstate_t mb=std::mbstate_t();
-    
+
     wchar_t const *from_next = wide_name;
     wchar_t const *real_from_end = wide_name + wlen;
-    
+
     char buf[256];
     char *to = buf;
     char *to_next = to;
     char *to_end = to + n;
     char *real_to_end = buf + sizeof(buf);
-    
+
     while(from_next < real_from_end) {
         wchar_t const *from = from_next;
         wchar_t const *from_end = from + m;
@@ -116,7 +116,7 @@ void test_codecvt_out_n_m(cvt_type const &cvt,int n,int m)
         if(to_end == to) {
             to_end = to+n;
         }
-        
+
         std::codecvt_base::result r = cvt.out(mb,from,from_end,from_next,to,to_end,to_next);
         //std::cout << "In from_size=" << (end-from) << " from move=" <<  (from_next - from) << " to move= " << to_next - to << " state = " << res(r) << std::endl;
         if(r == cvt_type::partial) {
@@ -128,7 +128,7 @@ void test_codecvt_out_n_m(cvt_type const &cvt,int n,int m)
         else {
             TEST(r == cvt_type::ok);
         }
-        
+
         while(to!=to_next) {
             TEST(*nptr == *to);
             nptr++;
@@ -148,11 +148,11 @@ void test_codecvt_conv()
 {
     std::cout << "Conversions " << std::endl;
     std::locale l(std::locale::classic(),new boost::locale::utf8_codecvt<wchar_t>());
- 
+
     cvt_type const &cvt = std::use_facet<cvt_type>(l);
 
     TEST(cvt.max_length()==4);
-    
+
     for(int i=1;i<=(int)strlen(utf8_name)+1;i++) {
         for(int j=1;j<=(int)wcslen(wide_name)+1;j++) {
             try {
@@ -164,19 +164,19 @@ void test_codecvt_conv()
                 throw;
             }
         }
-    }    
+    }
 }
 
 void test_codecvt_err()
 {
     std::cout << "Errors " << std::endl;
     std::locale l(std::locale::classic(),new boost::locale::utf8_codecvt<wchar_t>());
- 
+
     cvt_type const &cvt = std::use_facet<cvt_type>(l);
 
     std::cout << "- UTF-8" << std::endl;
     {
-        
+
         wchar_t buf[2];
         wchar_t *to=buf;
         wchar_t *to_end = buf+2;
@@ -203,11 +203,11 @@ void test_codecvt_err()
             TEST(from_next == from);
             TEST(to_next == to);
         }
-    }    
-    
+    }
+
     std::cout << "- UTF-16/32" << std::endl;
     {
-        
+
         char buf[32];
         char *to=buf;
         char *to_end = buf+32;
@@ -235,8 +235,8 @@ void test_codecvt_err()
             TEST(from_next == from);
             TEST(to_next == to);
         }
-    }    
-    
+    }
+
 }
 
 
@@ -265,12 +265,12 @@ void test_char_char()
 }
 
 int main()
-{   
+{
     try {
         test_codecvt_conv();
         test_codecvt_err();
         test_char_char();
-        
+
     }
     catch(std::exception const &e) {
         std::cerr << "Failed : " << e.what() << std::endl;

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -63,7 +63,7 @@ void test_ok(std::string file,std::locale const &l,std::basic_string<Char> cmp=s
 
     stream_type f1("testi.txt",stream_type::in);
     f1.imbue(l);
-    TEST(read_file<Char>(f1) == cmp); 
+    TEST(read_file<Char>(f1) == cmp);
     f1.close();
 
     stream_type f2("testo.txt",stream_type::out);
@@ -139,7 +139,7 @@ void test_for_char()
     else {
         std::cout << "    UTF-8 Not supported " << std::endl;
     }
-    
+
     if(test_iso) {
         if(test_iso_8859_8) {
             std::cout << "    ISO8859-8" << std::endl;
@@ -160,7 +160,7 @@ void test_wide_io()
 {
     std::cout << "  wchar_t" << std::endl;
     test_for_char<wchar_t>();
-    
+
     #if defined BOOST_LOCALE_ENABLE_CHAR16_T && !defined(BOOST_NO_CHAR16_T_CODECVT)
     std::cout << "  char16_t" << std::endl;
     test_for_char<char16_t>();
@@ -180,7 +180,7 @@ void test_pos(std::string source,std::basic_string<Char> target,std::string enco
     TEST(to_utf<Char>(source,encoding)==target);
     TEST(to_utf<Char>(source.c_str(),encoding)==target);
     TEST(to_utf<Char>(source.c_str(),source.c_str()+source.size(),encoding)==target);
-    
+
     TEST(to_utf<Char>(source,l)==target);
     TEST(to_utf<Char>(source.c_str(),l)==target);
     TEST(to_utf<Char>(source.c_str(),source.c_str()+source.size(),l)==target);
@@ -188,7 +188,7 @@ void test_pos(std::string source,std::basic_string<Char> target,std::string enco
     TEST(from_utf<Char>(target,encoding)==source);
     TEST(from_utf<Char>(target.c_str(),encoding)==source);
     TEST(from_utf<Char>(target.c_str(),target.c_str()+target.size(),encoding)==source);
-    
+
     TEST(from_utf<Char>(target,l)==source);
     TEST(from_utf<Char>(target.c_str(),l)==source);
     TEST(from_utf<Char>(target.c_str(),target.c_str()+target.size(),l)==source);
@@ -273,8 +273,8 @@ struct utfutf<char,1> {
 template<>
 struct utfutf<wchar_t,2> {
     static wchar_t const *ok(){ return  L"\x67\x72\xfc\xdf\x65\x6e"; }
-    static wchar_t const *bad() { 
-        static wchar_t buf[256] = L"\x67\x72\xFF\xfc\xFE\xFD\xdf\x65\x6e"; 
+    static wchar_t const *bad() {
+        static wchar_t buf[256] = L"\x67\x72\xFF\xfc\xFE\xFD\xdf\x65\x6e";
         buf[2]=0xDC01; // second surrogate must not be
         buf[4]=0xD801; // First
         buf[5]=0xD801; // Must be surrogate trail
@@ -284,8 +284,8 @@ struct utfutf<wchar_t,2> {
 template<>
 struct utfutf<wchar_t,4> {
     static wchar_t const *ok(){ return  L"\x67\x72\xfc\xdf\x65\x6e"; }
-    static wchar_t const *bad() { 
-        static wchar_t buf[256] = L"\x67\x72\xFF\xfc\xdf\x65\x6e"; 
+    static wchar_t const *bad() {
+        static wchar_t buf[256] = L"\x67\x72\xFF\xfc\xdf\x65\x6e";
         buf[2]=static_cast<wchar_t>(0x1000000); // > 10FFFF
         return buf;
     }
@@ -324,10 +324,10 @@ void test_to()
         test_pos<Char>("\xf9\xec\xe5\xed",utf<Char>("שלום"),"ISO8859-8");
     test_pos<Char>("grüßen",utf<Char>("grüßen"),"UTF-8");
     test_pos<Char>("abc\"\xf0\xa0\x82\x8a\"",utf<Char>("abc\"\xf0\xa0\x82\x8a\""),"UTF-8");
-    
+
     test_to_neg<Char>("g\xFFrüßen",utf<Char>("grüßen"),"UTF-8");
     test_from_neg<Char>(utf<Char>("hello שלום"),"hello ","ISO8859-1");
- 
+
     test_with_0<Char>();
 }
 
@@ -399,16 +399,16 @@ int main()
         #endif
 
         test_simple_conversions();
-        
-        
+
+
         for(int type = 0; type < int(def.size()); type ++ ) {
             boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
             tmp_backend.select(def[type]);
             boost::locale::localization_backend_manager::global(tmp_backend);
-            
+
             std::string bname = def[type];
-            
-            if(bname=="std") { 
+
+            if(bname=="std") {
                 en_us_8bit = get_std_name("en_US.ISO8859-1");
                 he_il_8bit = get_std_name("he_IL.ISO8859-8");
                 ja_jp_shiftjis = get_std_name("ja_JP.SJIS");
@@ -477,11 +477,11 @@ int main()
             }
             #endif
 
-            if(def[type]=="std" && (get_std_name("en_US.UTF-8").empty() || get_std_name("he_IL.UTF-8").empty())) 
+            if(def[type]=="std" && (get_std_name("en_US.UTF-8").empty() || get_std_name("he_IL.UTF-8").empty()))
             {
                 test_utf = false;
             }
-            
+
             std::cout << "Testing wide I/O" << std::endl;
             test_wide_io();
             std::cout << "Testing charset to/from UTF conversion functions" << std::endl;
@@ -513,4 +513,4 @@ int main()
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -74,14 +74,14 @@ void test_shiftjis(boost::locale::util::base_converter* pcvt)
         TEST_FROM("\x82\xd0",0x3072); // Full width hiragana Hi ひ
 
         std::cout << "- Illegal/incomplete" << std::endl;
-        
+
         TEST_TO("\xa0",illegal);
         TEST_TO("\x82",incomplete);
         TEST_TO("\x83\xf0",illegal);
 
         TEST_INC(0x30d2,1); // Full width katakana Hi ヒ
         TEST_INC(0x3072,1); // Full width hiragana Hi ひ
-        
+
         TEST_FROM(0,0x5e9); // Hebrew ש not in ShiftJIS
 }
 
@@ -151,7 +151,7 @@ int main()
 
         TEST_TO(make4(0x110000),illegal);
         TEST_TO(make4(0x1fffff),illegal);
-        
+
         TEST_TO(make2(0),illegal);
         TEST_TO(make3(0),illegal);
         TEST_TO(make4(0),illegal);
@@ -166,9 +166,9 @@ int main()
 
         TEST_TO(make4(0x8000),illegal);
         TEST_TO(make4(0xffff),illegal);
-        
+
         std::cout << "-- Invalid surrogate" << std::endl;
-        
+
         TEST_TO(make3(0xD800),illegal);
         TEST_TO(make3(0xDBFF),illegal);
         TEST_TO(make3(0xDC00),illegal);
@@ -183,7 +183,7 @@ int main()
 
         TEST_TO("\x80",illegal);
         TEST_TO("\xC2",incomplete);
-        
+
         TEST_TO("\xdf",incomplete);
 
         TEST_TO("\xe0",incomplete);
@@ -217,16 +217,16 @@ int main()
         TEST_INC(0x10000,1);
         TEST_FROM("\xf0\x90\x80\x80",0x10000);
         TEST_FROM("\xf4\x8f\xbf\xbf",0x10FFFF);
-       
+
         std::cout << "-- Test no surrogate " << std::endl;
-         
+
         TEST_FROM(0,0xD800);
         TEST_FROM(0,0xDBFF);
         TEST_FROM(0,0xDC00);
         TEST_FROM(0,0xDFFF);
-        
+
         std::cout << "-- Test invalid " << std::endl;
-        
+
         TEST_FROM(0,0x110000);
         TEST_FROM(0,0x1FFFFF);
 
@@ -294,4 +294,4 @@ int main()
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_collate.cpp
+++ b/test/test_collate.cpp
@@ -35,7 +35,7 @@ void test_comp(std::locale l,std::basic_string<Char> left,std::basic_string<Char
         else if(expected == 0) {
             TEST(lt==rt);
         }
-        else 
+        else
             TEST(lt > rt);
         long lh=coll.hash(left.c_str(),left.c_str()+left.size());
         long rh=coll.hash(right.c_str(),right.c_str()+right.size());
@@ -53,7 +53,7 @@ void test_comp(std::locale l,std::basic_string<Char> left,std::basic_string<Char
         TEST(lt<rt);
     else if(expected == 0)
         TEST(lt==rt);
-    else 
+    else
         TEST(lt > rt);
     long lh=coll.hash(level,left.c_str(),left.c_str()+left.size());
     TEST(lh==coll.hash(level,left));
@@ -64,8 +64,8 @@ void test_comp(std::locale l,std::basic_string<Char> left,std::basic_string<Char
     else
         TEST(lh!=rh);
 
-}    
-        
+}
+
 #define TEST_COMP(c,_l,_r) test_comp<c>(l,_l,_r,level,expected)
 
 
@@ -136,4 +136,4 @@ int main()
 
 #endif // NOICU
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -7,7 +7,7 @@
 //
 
 #ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS 
+#define _CRT_SECURE_NO_WARNINGS
 #endif
 
 #include <boost/locale.hpp>
@@ -137,4 +137,4 @@ int main()
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -66,8 +66,8 @@ void test_norm(std::string orig,std::string normal,boost::locale::norm_type type
             TEST_V(to_upper,"i","İ");                        \
             TEST_V(to_lower,"İ","i");                        \
         }while(0)
-    
-    
+
+
 int main()
 {
     try {
@@ -84,7 +84,7 @@ int main()
 
         boost::locale::generator gen;
         bool eight_bit=true;
-        
+
         #define TEST_V(how,source_s,dest_s)                                    \
         do {                                                                \
             TEST_A(char,how,source_s,dest_s);                                \
@@ -95,7 +95,7 @@ int main()
                 std::locale::global(tmp);                                    \
             }                                                                \
         }while(0)
-        
+
         TEST_ALL_CASES;
         #undef TEST_V
 
@@ -126,4 +126,4 @@ int main()
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -21,7 +21,7 @@
 #endif
 
 #ifdef BOOST_MSVC
-#  pragma warning(disable : 4244) // loose data 
+#  pragma warning(disable : 4244) // loose data
 #endif
 
 #define RESET() do { time_point = base_time_point; ss.str(""); } while(0)
@@ -34,9 +34,9 @@ int main()
     try {
         using namespace boost::locale;
         using namespace boost::locale::period;
-        std::string def[] = { 
+        std::string def[] = {
         #ifdef BOOST_LOCALE_WITH_ICU
-            "icu" , 
+            "icu" ,
         #endif
         #ifndef BOOST_LOCALE_NO_STD_BACKEND
             "std" ,
@@ -55,16 +55,16 @@ int main()
             std::cout << "Testing for backend: " << def[type] << std::endl;
             std::string backend_name = def[type];
             {
- 
+
                 boost::locale::generator g;
 
                 std::locale loc=g("en_US.UTF-8");
 
                 std::locale::global(loc);
-                
+
                 std::string tz("GMT");
                 time_zone::global(tz);
-                calendar cal(loc,tz); 
+                calendar cal(loc,tz);
 
                 TEST(calendar() == cal);
                 TEST(calendar(loc) == cal);
@@ -86,15 +86,15 @@ int main()
                 std::ostringstream ss;
                 ss.imbue(loc);
                 ss<<boost::locale::as::time_zone(tz);
-                
+
                 date_time time_point;
-                
+
                 time_point=year(1970) + february() + day(5);
 
                 ss << as::ftime("%Y-%m-%d")<< time_point;
 
                 TEST(ss.str() == "1970-02-05");
-                time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second(); 
+                time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second();
                 ss.str("");
                 ss << as::ftime("%Y-%m-%d %H:%M:%S") << time_point;
                 TEST( ss.str() == "1970-02-05 15:33:13"); ss.str("");
@@ -121,7 +121,7 @@ int main()
                 TESTEQSR( time_point, "1970-02-05 15:32:13");
 
                 time_point <<= minute() * 30;
-                TESTEQSR( time_point, "1970-02-05 15:03:13"); 
+                TESTEQSR( time_point, "1970-02-05 15:03:13");
 
                 time_point >>= minute(40);
                 TESTEQSR( time_point, "1970-02-05 15:53:13");
@@ -143,9 +143,9 @@ int main()
                 TEST( (time_point + 2* month()- (time_point+month())) / day() == 31);
                 TEST( day(time_point + 2* month()- (time_point+month())) == 31);
 
-                TESTEQSR( time_point + hour(), "1970-02-05 16:33:13"); 
+                TESTEQSR( time_point + hour(), "1970-02-05 16:33:13");
                 TESTEQSR( time_point - hour(2), "1970-02-05 13:33:13");
-                TESTEQSR( time_point >> minute(), "1970-02-05 15:32:13"); 
+                TESTEQSR( time_point >> minute(), "1970-02-05 15:32:13");
                 TESTEQSR( time_point << second(), "1970-02-05 15:33:14");
 
                 TEST(time_point == time_point);
@@ -194,10 +194,10 @@ int main()
                 TEST(time_point.get(week_of_year()) == 2);
                 TEST(time_point.get(week_of_month()) == 2);
                 time_point = february() + day() * 2;
-                
+
 
                 TEST(time_point.get(week_of_year()) == 6);
-               
+
                 if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
                     TEST(time_point.get(week_of_month()) == 1);
                 }
@@ -207,16 +207,16 @@ int main()
                 }
 
                 time_point = year(2010) + january() + day() * 3;
-                
+
                 if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
                     TEST(time_point.get(week_of_year()) == 53);
                 }
                 else {
                     TEST(time_point.get(week_of_year()) == 1);
                 }
-                
+
                 time_point = year()*2010 + january() + day() * 4;
-                
+
                 if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
                     TEST(time_point.get(week_of_year()) == 1);
                 }
@@ -224,7 +224,7 @@ int main()
                     TEST(time_point.get(week_of_year()) == 2);
                 }
                 time_point = year()*2010 + january() + day() * 10;
-                
+
                 if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
                     TEST(time_point.get(week_of_year()) == 1);
                 }
@@ -249,7 +249,7 @@ int main()
                 TEST(date_time(year()* 1984 + february() + day()).get(week_of_year())==5);
                 TEST(time_point.get(week_of_month()) == 1);
                 RESET();
-                
+
                 // Make sure we don't get year() < 1970 so the test would
                 // work on windows where mktime supports positive time_t
                 // only
@@ -279,7 +279,7 @@ int main()
                 TEST(time_point.get(year()) == 2011);
                 TEST(time_point.get(month()) == 2); // march
                 TEST(time_point.get(day()) == 5);
-                
+
                 time_point = tmp_save;
 
                 time_point = year() * 2011 + february() + day() * 5;
@@ -299,4 +299,4 @@ int main()
 
 }
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -14,7 +14,7 @@ int main()
 #else
 
 #ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS 
+#define _CRT_SECURE_NO_WARNINGS
 // Disable this "security crap"
 #endif
 
@@ -118,7 +118,7 @@ do{                                                             \
         TEST_THROWS(ss >> v,std::ios_base::failure);            \
     }                                                           \
 }while(0)
- 
+
 #define TEST_PAR(manip,type,actual,expected) \
 do{ \
     type v; \
@@ -219,12 +219,12 @@ void test_manip(std::string e_charset="UTF-8")
 {
     boost::locale::generator g;
     std::locale loc=g("en_US."+e_charset);
-    
+
     TEST_FP1(as::posix,1200.1,"1200.1",double,1200.1);
     TEST_FP1(as::number,1200.1,"1,200.1",double,1200.1);
     TEST_FMT(as::number<<std::setfill(CharType('_'))<<std::setw(6),1534,"_1,534");
     TEST_FMT(as::number<<std::left<<std::setfill(CharType('_'))<<std::setw(6),1534,"1,534_");
-    
+
     // Ranges
     if(sizeof(short) == 2) {
         TEST_MIN_MAX(short,"-32,768","32,767");
@@ -267,7 +267,7 @@ void test_manip(std::string e_charset="UTF-8")
     TEST_FP3(as::number,std::left,std::setw(3),15,"15 ",int,15);
     TEST_FP3(as::number,std::right,std::setw(3),15," 15",int,15);
     TEST_FP3(as::number,std::setprecision(3),std::fixed,13.1,"13.100",double,13.1);
-    #if BOOST_ICU_VER < 5601 
+    #if BOOST_ICU_VER < 5601
     // bug #13276
     TEST_FP3(as::number,std::setprecision(3),std::scientific,13.1,"1.310E1",double,13.1);
     #endif
@@ -312,7 +312,7 @@ void test_manip(std::string e_charset="UTF-8")
     TEST_FP3(as::date,as::date_medium,as::gmt,a_datetime,"Feb 5, 1970",time_t,a_date);
     TEST_FP3(as::date,as::date_long  ,as::gmt,a_datetime,"February 5, 1970",time_t,a_date);
     TEST_FP3(as::date,as::date_full  ,as::gmt,a_datetime,"Thursday, February 5, 1970",time_t,a_date);
-    
+
     TEST_NOPAR(as::date>>as::date_short,"aa/bb/cc",double);
 
 #if BOOST_ICU_VER >= 5901
@@ -320,7 +320,7 @@ void test_manip(std::string e_charset="UTF-8")
 #else
 #define GMT_FULL "GMT"
 #endif
-    
+
     TEST_FP2(as::time,                as::gmt,a_datetime,"3:33:13 PM",time_t,a_time+a_timesec);
     TEST_FP3(as::time,as::time_short ,as::gmt,a_datetime,"3:33 PM",time_t,a_time);
     TEST_FP3(as::time,as::time_medium,as::gmt,a_datetime,"3:33:13 PM",time_t,a_time+a_timesec);
@@ -334,7 +334,7 @@ void test_manip(std::string e_charset="UTF-8")
     TEST_FP3(as::time,as::time_long  ,as::gmt,a_datetime,"3:33:13 PM GMT+00:00",time_t,a_time+a_timesec);
     TEST_FP3(as::time,as::time_full  ,as::gmt,a_datetime,"3:33:13 PM GMT+00:00",time_t,a_time+a_timesec);
     #endif
-    
+
     TEST_NOPAR(as::time,"AM",double);
 
     TEST_FP2(as::time,                as::time_zone("GMT+01:00"),a_datetime,"4:33:13 PM",time_t,a_time+a_timesec);
@@ -349,7 +349,7 @@ void test_manip(std::string e_charset="UTF-8")
 
 
 #if U_ICU_VERSION_MAJOR_NUM >= 50
-#define PERIOD "," 
+#define PERIOD ","
 #define ICUAT " at"
 #else
 #define PERIOD ""
@@ -386,8 +386,8 @@ void test_manip(std::string e_charset="UTF-8")
     TEST_FMT(as::ftime(format_string),now,local_time_str);
     TEST_FMT(as::ftime(format_string)<<as::gmt<<as::local_time,now,local_time_str);
 
-    std::string marks =  
-        "aAbB" 
+    std::string marks =
+        "aAbB"
         "cdeh"
         "HIjm"
         "Mnpr"
@@ -395,7 +395,7 @@ void test_manip(std::string e_charset="UTF-8")
         "xXyY"
         "Z%";
 
-    std::string result[]= { 
+    std::string result[]= {
         "Thu","Thursday","Feb","February",  // aAbB
         #if BOOST_ICU_VER >= 408
         "Thursday, February 5, 1970" ICUAT  " 3:33:13 PM " GMT_FULL, // c
@@ -425,7 +425,7 @@ void test_manip(std::string e_charset="UTF-8")
         "Now is %A, %H o'clo''ck ' or not ' ",
         "'test %H'",
         "%H'",
-        "'%H'" 
+        "'%H'"
     };
     std::string expected_f[] = {
         "Now is Thursday, 15 o'clo''ck ' or not ' ",
@@ -446,13 +446,13 @@ void test_format(std::string charset="UTF-8")
 {
     boost::locale::generator g;
     std::locale loc=g("en_US."+charset);
-    
+
     FORMAT("{3} {1} {2}", 1 % 2 % 3,"3 1 2");
     FORMAT("{1} {2}", "hello" % 2,"hello 2");
     FORMAT("{1}",1200.1,"1200.1");
     FORMAT("Test {1,num}",1200.1,"Test 1,200.1");
     FORMAT("{{}} {1,number}",1200.1,"{} 1,200.1");
-    #if BOOST_ICU_VER < 5601 
+    #if BOOST_ICU_VER < 5601
     // bug #13276
     FORMAT("{1,num=sci,p=3}",13.1,"1.310E1");
     FORMAT("{1,num=scientific,p=3}",13.1,"1.310E1");
@@ -570,4 +570,4 @@ int main()
 
 #endif // NOICU
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -74,7 +74,7 @@ int main()
         TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
 
         std::locale l_wt(std::locale::classic(),new test_facet);
-        
+
         TEST(std::has_facet<test_facet>(g.generate(l_wt,"en_US.UTF-8")));
         TEST(std::has_facet<test_facet>(g.generate(l_wt,"en_US.ISO8859-1")));
         TEST(!std::has_facet<test_facet>(g("en_US.UTF-8")));
@@ -97,4 +97,4 @@ int main()
 
 }
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_icu_vs_os_timezone.cpp
+++ b/test/test_icu_vs_os_timezone.cpp
@@ -15,7 +15,7 @@ int main()
 #else
 
 #ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS 
+#define _CRT_SECURE_NO_WARNINGS
 // Disable this "security crap"
 #endif
 
@@ -62,4 +62,4 @@ int main()
 #endif // NO ICU
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -80,4 +80,4 @@ int main()
 }
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_locale.hpp
+++ b/test/test_locale.hpp
@@ -36,7 +36,7 @@ do {                                                                            
         if(X) break;                                                    \
         std::cerr << "Error in line:"<<__LINE__ << " "#X  << std::endl; \
         THROW_IF_TOO_BIG(error_counter++);                              \
-    }while(0)    
+    }while(0)
 #endif
 
 #define TEST_THROWS(X,E)                                                \
@@ -45,7 +45,7 @@ do {                                                                            
         try { X; } catch(E const &/*e*/ ) {break;} catch(...){}         \
         std::cerr << "Error in line:"<<__LINE__ << " "#X  << std::endl; \
         THROW_IF_TOO_BIG(error_counter++);                              \
-    }while(0)    
+    }while(0)
 
 #define FINALIZE()                                                      \
     do {                                                                \
@@ -76,9 +76,9 @@ inline unsigned utf8_next(std::string const &s,unsigned &pos)
         l = 2;
     else
         l = 3;
-    
+
     c &= (1 << (6-l)) - 1;
-    
+
     switch(l) {
     case 3:
         c = (c << 6) | (((unsigned char)s[pos++]) & 0x3F);

--- a/test/test_locale_tools.hpp
+++ b/test/test_locale_tools.hpp
@@ -80,7 +80,7 @@ std::string get_std_name(std::string const &name,std::string *real_name = 0)
 
     if(name=="en_US.UTF-8" || name == "en_US.ISO8859-1") {
         if(has_std_locale("English_United States.1252")) {
-            if(real_name) 
+            if(real_name)
                 *real_name = "English_United States.1252";
             return utf8 ? name : "en_US.windows-1252";
         }
@@ -88,28 +88,28 @@ std::string get_std_name(std::string const &name,std::string *real_name = 0)
     }
     else if(name=="he_IL.UTF-8" || name == "he_IL.ISO8859-8")  {
         if(has_std_locale("Hebrew_Israel.1255")) {
-            if(real_name) 
+            if(real_name)
                 *real_name = "Hebrew_Israel.1255";
             return utf8 ? name : "he_IL.windows-1255";
         }
     }
     else if(name=="ru_RU.UTF-8")  {
         if(has_std_locale("Russian_Russia.1251")) {
-            if(real_name) 
+            if(real_name)
                 *real_name = "Russian_Russia.1251";
             return name;
         }
     }
     else if(name == "tr_TR.UTF-8") {
         if(has_std_locale("Turkish_Turkey.1254")) {
-            if(real_name) 
+            if(real_name)
                 *real_name = "Turkish_Turkey.1254";
             return name;
         }
     }
     if(name == "ja_JP.SJIS") {
         if(has_std_locale("Japanese_Japan.932")) {
-            if(real_name) 
+            if(real_name)
                 *real_name = "Japanese_Japan.932";
             return name;
         }

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -315,7 +315,7 @@ int main(int argc,char **argv)
     try {
         std::string def[] = {
         #ifdef BOOST_LOCALE_WITH_ICU
-            "icu" , 
+            "icu" ,
         #endif
         #ifndef BOOST_LOCALE_NO_STD_BACKEND
             "std" ,
@@ -331,9 +331,9 @@ int main(int argc,char **argv)
             boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
             tmp_backend.select(def[type]);
             boost::locale::localization_backend_manager::global(tmp_backend);
-            
+
             backend = def[type];
-            
+
             std::cout << "Testing for backend --------- " << def[type] << std::endl;
 
             boost::locale::generator g;
@@ -346,12 +346,12 @@ int main(int argc,char **argv)
                 g.add_messages_path("./");
             g.set_default_messages_domain("default");
 
-            
+
             std::string locales[] = { "he_IL.UTF-8", "he_IL.ISO8859-8" };
 
             for(unsigned i=0;i<sizeof(locales)/sizeof(locales[0]);i++){
                 std::locale l;
-                
+
                 if(i==1) {
                     try {
                         l = g(locales[i]);
@@ -365,7 +365,7 @@ int main(int argc,char **argv)
                 else {
                         l = g(locales[i]);
                 }
-                
+
                 std::cout << "  Testing "<<locales[i]<<std::endl;
                 std::cout << "    single forms" << std::endl;
 
@@ -387,7 +387,7 @@ int main(int argc,char **argv)
                     test_ntranslate("x day","x days",2,"יומיים",l,"default");
                     test_ntranslate("x day","x days",3,"x ימים",l,"default");
                     test_ntranslate("x day","x days",20,"x יום",l,"default");
-                    
+
                     test_ntranslate("x day","x days",0,"x days",l,"undefined");
                     test_ntranslate("x day","x days",1,"x day",l,"undefined");
                     test_ntranslate("x day","x days",2,"x days",l,"undefined");
@@ -395,15 +395,15 @@ int main(int argc,char **argv)
                 }
                 std::cout << "    plural forms with context" << std::endl;
                 {
-                    std::string inp = "context"; 
-                    std::string out = "בהקשר "; 
+                    std::string inp = "context";
+                    std::string out = "בהקשר ";
 
                     test_cntranslate(inp,"x day","x days",0,out+"x ימים",l,"default");
                     test_cntranslate(inp,"x day","x days",1,out+"יום x",l,"default");
                     test_cntranslate(inp,"x day","x days",2,out+"יומיים",l,"default");
                     test_cntranslate(inp,"x day","x days",3,out+"x ימים",l,"default");
                     test_cntranslate(inp,"x day","x days",20,out+"x יום",l,"default");
-                    
+
                     test_cntranslate(inp,"x day","x days",0,"x days",l,"undefined");
                     test_cntranslate(inp,"x day","x days",1,"x day",l,"undefined");
                     test_cntranslate(inp,"x day","x days",2,"x days",l,"undefined");
@@ -413,26 +413,26 @@ int main(int argc,char **argv)
             std::cout << "  Testing fallbacks" <<std::endl;
             test_translate("test","he_IL",g("he_IL.UTF-8"),"full");
             test_translate("test","he",g("he_IL.UTF-8"),"fall");
-            
+
             std::cout << "  Testing automatic conversions " << std::endl;
             std::locale::global(g("he_IL.UTF-8"));
 
 
             TEST(same_s(bl::translate("hello"))=="שלום");
             TEST(same_w(bl::translate(to<wchar_t>("hello")))==to<wchar_t>("שלום"));
-            
+
             #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
             if(backend=="icu" || backend=="std")
                 TEST(same_u16(bl::translate(to<char16_t>("hello")))==to<char16_t>("שלום"));
             #endif
-            
+
             #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             if(backend=="icu" || backend=="std")
                 TEST(same_u32(bl::translate(to<char32_t>("hello")))==to<char32_t>("שלום"));
             #endif
 
         }
-        
+
         std::cout << "Testing custom file system support" << std::endl;
         {
             boost::locale::gnu_gettext::messages_info info;
@@ -453,12 +453,12 @@ int main(int argc,char **argv)
         }
         if(iso_8859_8_not_supported)
         {
-            std::cout << "ISO 8859-8 not supported so skipping non-US-ASCII keys" << std::endl; 
+            std::cout << "ISO 8859-8 not supported so skipping non-US-ASCII keys" << std::endl;
         }
-        else 
+        else
         {
-            std::cout << "Testing non-US-ASCII keys" << std::endl; 
-            std::cout << "  UTF-8 keys" << std::endl; 
+            std::cout << "Testing non-US-ASCII keys" << std::endl;
+            std::cout << "  UTF-8 keys" << std::endl;
             {
                 boost::locale::generator g;
                 g.add_messages_domain("default");
@@ -466,13 +466,13 @@ int main(int argc,char **argv)
                     g.add_messages_path(argv[1]);
                 else
                     g.add_messages_path("./");
-                
+
                 std::locale l = g("he_IL.UTF-8");
 
                 // narrow
                 TEST(bl::gettext("בדיקה",l)=="test");
                 TEST(bl::gettext("לא קיים",l)=="לא קיים");
-                
+
                 // wide
                 std::wstring wtest = bl::conv::to_utf<wchar_t>("בדיקה","UTF-8");
                 std::wstring wmiss = bl::conv::to_utf<wchar_t>("לא קיים","UTF-8");
@@ -484,8 +484,8 @@ int main(int argc,char **argv)
                 // conversion with substitution
                 TEST(bl::gettext("test-あにま-בדיקה",l)==bl::conv::from_utf("test--בדיקה","ISO-8859-8"));
             }
-            
-            std::cout << "  `ANSI' keys" << std::endl; 
+
+            std::cout << "  `ANSI' keys" << std::endl;
 
             {
                 boost::locale::generator g;
@@ -494,7 +494,7 @@ int main(int argc,char **argv)
                     g.add_messages_path(argv[1]);
                 else
                     g.add_messages_path("./");
-                
+
                 std::locale l = g("he_IL.UTF-8");
 
                 // narrow non-UTF-8 keys
@@ -523,7 +523,7 @@ int main(int argc,char **argv)
             bl::dnpgettext("","","","",1);
             bl::dnpgettext("",L"",L"",L"",1);
         }
-        
+
     }
     catch(std::exception const &e) {
         std::cerr << "Failed " << e.what() << std::endl;
@@ -533,4 +533,4 @@ int main(int argc,char **argv)
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_posix_collate.cpp
+++ b/test/test_posix_collate.cpp
@@ -49,7 +49,7 @@ void test_one(std::locale const &l,std::string ia,std::string ib,int diff)
         TEST(!l(a,b));
         TEST(l(b,a));
     }
-    
+
     std::collate<CharType> const &col = std::use_facet<std::collate<CharType> >(l);
 
     TEST(diff == col.compare(a.c_str(),a.c_str()+a.size(),b.c_str(),b.c_str()+b.size()));
@@ -63,7 +63,7 @@ template<typename CharType>
 void test_char()
 {
     boost::locale::generator gen;
-    
+
     std::cout << "- Testing at least C" << std::endl;
 
     std::locale l = gen("en_US.UTF-8");
@@ -117,4 +117,4 @@ int main()
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_posix_convert.cpp
+++ b/test/test_posix_convert.cpp
@@ -67,12 +67,12 @@ void test_char()
     else {
         std::cout << "- en_US.ISO8859-1 is not supported, skipping" << std::endl;
     }
-    
+
     name = "tr_TR.UTF-8";
     if(have_locale(name)) {
         std::cout << "Testing " << name << std::endl;
         locale_t cl = newlocale(LC_ALL_MASK,name.c_str(),0);
-        try { 
+        try {
             TEST(cl);
             if(towupper_l(L'i',cl) == 0x130) {
                 test_one<CharType>(gen(name),"i","i","İ");
@@ -86,9 +86,9 @@ void test_char()
             throw;
         }
         if(cl) freelocale(cl);
-        
+
     }
-    else 
+    else
     {
         std::cout << "- tr_TR.UTF-8 is not supported, skipping" << std::endl;
     }
@@ -119,4 +119,4 @@ int main()
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -129,13 +129,13 @@ void test_by_char(std::locale const &l,locale_t lreal)
         std::cout << "[" << boost::locale::conv::from_utf(buf,"UTF-8") << "]\n" ;
         #endif
     }
-    
-    
+
+
     {
         std::cout << "- Testing as::date/time" << std::endl;
         ss_type ss;
         ss.imbue(l);
-        
+
         time_t a_date = 3600*24*(31+4); // Feb 5th
         time_t a_time = 3600*15+60*33; // 15:33:05
         time_t a_timesec = 13;
@@ -185,9 +185,9 @@ int main()
                 lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
                 assert(lreal);
                 std::cout << "UTF-8" << std::endl;
-                
+
                 test_by_char<char,char>(l1,lreal);
-                
+
                 std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
                 test_by_char<wchar_t,char>(l1,lreal);
                 freelocale(lreal);
@@ -222,9 +222,9 @@ int main()
                 lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
                 assert(lreal);
                 std::cout << "UTF-8" << std::endl;
-                
+
                 test_by_char<char,char>(l1,lreal);
-                
+
                 std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
                 test_by_char<wchar_t,char>(l1,lreal);
                 freelocale(lreal);
@@ -278,4 +278,4 @@ int main()
 #endif // posix
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_std_collate.cpp
+++ b/test/test_std_collate.cpp
@@ -50,7 +50,7 @@ void test_one(std::locale const &l,std::string ia,std::string ib,int diff)
         TEST(!l(a,b));
         TEST(l(b,a));
     }
-    
+
     std::collate<CharType> const &col = std::use_facet<std::collate<CharType> >(l);
 
     TEST(diff == col.compare(a.c_str(),a.c_str()+a.size(),b.c_str(),b.c_str()+b.size()));
@@ -64,7 +64,7 @@ template<typename CharType>
 void test_char()
 {
     boost::locale::generator gen;
-    
+
     {
         std::cout << "- Testing at least C" << std::endl;
         std::locale l = gen("en_US.UTF-8");
@@ -127,4 +127,4 @@ int main()
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_std_convert.cpp
+++ b/test/test_std_convert.cpp
@@ -76,7 +76,7 @@ void test_char()
             std::cout << "Standard library does not support this locale's case conversion correctly" << std::endl;
         }
     }
-    else 
+    else
     {
         std::cout << "- tr_TR.UTF-8 is not supported, skipping" << std::endl;
     }
@@ -115,4 +115,4 @@ int main()
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -165,13 +165,13 @@ void test_by_char(std::locale const &l,std::locale const &lreal)
         std::cout << "[" << boost::locale::conv::from_utf(ss_ref.str(),"UTF-8") << "]\n" ;
         #endif
     }
-    
-    
+
+
     {
         std::cout << "- Testing as::date/time" << std::endl;
         ss_type ss;
         ss.imbue(l);
-        
+
         time_t a_date = 3600*24*(31+4); // Feb 5th
         time_t a_time = 3600*15+60*33; // 15:33:05
         time_t a_timesec = 13;
@@ -223,11 +223,11 @@ int main()
             else {
                 std::locale l1=gen(name),l2(real_name.c_str());
                 std::cout << "UTF-8" << std::endl;
-                if(name==real_name) 
+                if(name==real_name)
                     test_by_char<char,char>(l1,l2);
                 else
                     test_by_char<char,wchar_t>(l1,l2);
-                
+
                 std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
                 test_by_char<wchar_t,wchar_t>(l1,l2);
 
@@ -274,11 +274,11 @@ int main()
             else {
                 std::locale l1=gen(name),l2(real_name.c_str());
                 std::cout << "UTF-8" << std::endl;
-                if(name==real_name) 
+                if(name==real_name)
                     test_by_char<char,char>(l1,l2);
                 else
                     test_by_char<char,wchar_t>(l1,l2);
-                
+
                 std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
                 test_by_char<wchar_t,wchar_t>(l1,l2);
 
@@ -338,7 +338,7 @@ int main()
                 catch(...) {
                     fails = true;
                 }
-                
+
                 if(!fails) {
                     std::cout << "- No invalid UTF. No need to check"<<std::endl;
                 }
@@ -365,4 +365,4 @@ int main()
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -75,7 +75,7 @@ void test_from_utf(CharType const * const s,unsigned codepoint)
     CharType const * const end = str_end(s);
 
     typedef utf_traits<CharType> tr;
-    
+
     BOOST_STATIC_ASSERT(tr::max_width == 4 / sizeof(CharType));
 
     TEST(tr::template decode<CharType const *>(cur,end) == codepoint);
@@ -296,4 +296,4 @@ int main()
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_winapi_collate.cpp
+++ b/test/test_winapi_collate.cpp
@@ -36,7 +36,7 @@ void test_comp(std::locale l,std::basic_string<Char> left,std::basic_string<Char
         else if(expected == 0) {
             TEST(lt==rt);
         }
-        else 
+        else
             TEST(lt > rt);
         long lh=coll.hash(left.c_str(),left.c_str()+left.size());
         long rh=coll.hash(right.c_str(),right.c_str()+right.size());
@@ -54,7 +54,7 @@ void test_comp(std::locale l,std::basic_string<Char> left,std::basic_string<Char
         TEST(lt<rt);
     else if(expected == 0)
         TEST(lt==rt);
-    else 
+    else
         TEST(lt > rt);
     long lh=coll.hash(level,left.c_str(),left.c_str()+left.size());
     TEST(lh==coll.hash(level,left));
@@ -65,8 +65,8 @@ void test_comp(std::locale l,std::basic_string<Char> left,std::basic_string<Char
     else
         TEST(lh!=rh);
 
-}    
-        
+}
+
 #define TEST_COMP(c,_l,_r) test_comp<c>(l,_l,_r,level,expected)
 
 
@@ -130,4 +130,4 @@ int main()
 }
 #endif // NO WINAPI
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_winapi_convert.cpp
+++ b/test/test_winapi_convert.cpp
@@ -47,8 +47,8 @@ void test_char()
     std::cout << "- Testing " << name << std::endl;
     l=gen(name);
     test_one<CharType>(l,"Façade","façade","FAÇADE");
-    
-    
+
+
     name = "tr_TR.UTF-8";
     std::cout << "Testing " << name << std::endl;
     test_one<CharType>(gen(name),"i","i","İ");
@@ -82,7 +82,7 @@ int main()
         test_char<char>();
         std::cout << "Testing wchar_t" << std::endl;
         test_char<wchar_t>();
-        
+
         std::cout << "Testing Unicode normalization" << std::endl;
         test_norm("\xEF\xAC\x81","\xEF\xAC\x81",boost::locale::norm_nfd); /// ligature fi
         test_norm("\xEF\xAC\x81","\xEF\xAC\x81",boost::locale::norm_nfc);
@@ -105,4 +105,4 @@ int main()
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
 
-// boostinspect:noascii 
+// boostinspect:noascii

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -142,10 +142,10 @@ BOOST_LOCALE_END_CONST_CONDITION
         ss << as::currency;
         ss << 1043.34;
         TEST(ss);
-        
+
         wchar_t buf[256];
         GetCurrencyFormatW(lcid,0,L"1043.34",0,buf,256);
-        
+
         TEST(equal(ss.str(),buf));
     }
 
@@ -153,7 +153,7 @@ BOOST_LOCALE_END_CONST_CONDITION
         std::cout << "--- Testing as::date/time" << std::endl;
         ss_type ss;
         ss.imbue(l);
-        
+
         time_t a_date = 3600*24*(31+4); // Feb 5th
         time_t a_time = 3600*15+60*33; // 15:33:13
         time_t a_timesec = 13;
@@ -171,7 +171,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 
         wchar_t time_buf[256];
         wchar_t date_buf[256];
-        
+
         SYSTEMTIME st= { 1970, 2,5, 5,15,33,13,0 };
         GetTimeFormatW(lcid,0,&st,0,time_buf,256);
         GetDateFormatW(lcid,0,&st,0,date_buf,256);
@@ -264,4 +264,4 @@ int main()
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 
-// boostinspect:noascii 
+// boostinspect:noascii


### PR DESCRIPTION
The `__linux` define may not be set. `__linux__` or `linux` mayb be used.
So use Boost.Predef `BOOST_OS_LINUX` instead.
Closes https://github.com/boostorg/locale/pull/49

Removing the trailing spaces in a single commit avoids having git highlight them as possible issues on every commit.