### PR TITLE
Deprecate support for C++03, to be removed in Boost 1.81

### DIFF
--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -47,6 +47,27 @@
 #define BOOST_LOCALE_USE_AUTO_PTR 1
 #endif
 
+// Check for C++11 features that will be used in Boost 1.81
+// If you are using Boost.Locale and REALLY require it to keep
+// supporting C++03/C++98 please comment with a detailed description
+// of your use case and reasoning why using C++11 is not possible in
+// https://github.com/boostorg/locale/issues/90
+#if !defined(BOOST_LOCALE_DISABLE_DEPRECATED_03_WARNING) && ( \
+     defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || \
+     defined(BOOST_NO_CXX11_DEFAULTED_MOVES) || \
+     defined(BOOST_NO_CXX11_HDR_FUNCTIONAL) || \
+     defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS) || \
+     defined(BOOST_NO_CXX11_NOEXCEPT) || \
+     defined(BOOST_NO_CXX11_OVERRIDE) || \
+     defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || \
+     defined(BOOST_NO_CXX11_SMART_PTR) || \
+     defined(BOOST_NO_CXX11_STATIC_ASSERT) \
+    )
+        #include <boost/config/pragma_message.hpp>
+        BOOST_PRAGMA_MESSAGE("CAUTION: Boost.Locale support for C++03 is deprecated. C++11 will be required from Boost 1.81 onwards.")
+        BOOST_PRAGMA_MESSAGE("CAUTION: Define BOOST_LOCALE_DISABLE_DEPRECATED_03_WARNING to suppress this message.")
+#endif
+
 #ifdef BOOST_MSVC
 // Denote a constant condition, e.g. for if(sizeof(...
 #define BOOST_LOCALE_START_CONST_CONDITION __pragma(warning(push)) __pragma(warning(disable : 4127))


### PR DESCRIPTION
Make users aware of the pending removal for pre-C++11 support of Boost.Locale in Boost 1.81.

If there are concerns and/or strong interest in keeping C++03 support users should comment on #90