### PR TITLE
Disable running example/collate and some reformatting

### DIFF
--- a/doc/boundary_analysys.txt
+++ b/doc/boundary_analysys.txt
@@ -88,7 +88,7 @@ std::string text="To be or not to be, that is the question."
 ssegment_index map(word,text.begin(),text.end(),gen("en_US.UTF-8"));
 // Print all "words" -- chunks of word boundary
 for(ssegment_index::iterator it=map.begin(),e=map.end();it!=e;++it)
-    std::cout <<"\""<< * it << "\", ";
+    std::cout  << "\""<< * it << "\", ";
 std::cout << std::endl;
 \endcode
 

--- a/doc/messages_formatting.txt
+++ b/doc/messages_formatting.txt
@@ -101,7 +101,6 @@ This is an example of our first fully localized program:
 #include <boost/locale.hpp>
 #include <iostream>
 
-using namespace std;
 using namespace boost::locale;
 
 int main()
@@ -113,11 +112,11 @@ int main()
     gen.add_messages_domain("hello");
 
     // Generate locales and imbue them to iostream
-    locale::global(gen(""));
-    cout.imbue(locale());
+    std::locale::global(gen(""));
+    std::cout.imbue(std::locale());
 
     // Display a message using current system locale
-    cout << translate("Hello World") << endl;
+    std::cout << translate("Hello World") << std::endl;
 }
 \endcode
 
@@ -494,7 +493,6 @@ domain name for the application.
 #include <boost/locale.hpp>
 #include <iostream>
 
-using namespace std;
 using namespace boost::locale;
 
 int main()
@@ -507,8 +505,8 @@ int main()
     gen.add_messages_domain("copyrighted/windows-1255");
 
     // Generate locales and imbue them to iostream
-    locale::global(gen(""));
-    cout.imbue(locale());
+    std::locale::global(gen(""));
+    std::cout.imbue(std::locale());
 
     // In Windows 1255 (C) symbol is encoded as 0xA9
     cout << translate("© 2001 All Rights Reserved") << endl;

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -27,7 +27,7 @@ endfunction()
 
 boost_locale_add_example(boundary)
 boost_locale_add_example(calendar)
-boost_locale_add_example(collate)
+boost_locale_add_example(collate COMPILE_ONLY)
 boost_locale_add_example(conversions)
 boost_locale_add_example(hello)
 boost_locale_add_example(wboundary)

--- a/examples/boundary.cpp
+++ b/examples/boundary.cpp
@@ -20,7 +20,7 @@ int main()
     // We need the boundary facet, currently only available via ICU
     if(!std::has_facet<boundary::boundary_indexing<char>>(loc))
     {
-        std::cout << "boundary detection not implemented in this environment" << std::endl;
+        std::cout << "boundary detection not implemented in this environment\n";
         return 0;
     }
     std::locale::global(loc);

--- a/examples/boundary.cpp
+++ b/examples/boundary.cpp
@@ -13,7 +13,6 @@
 int main()
 {
     using namespace boost::locale;
-    using namespace std;
 
     generator gen;
     // Make system default locale global
@@ -21,55 +20,55 @@ int main()
     // We need the boundary facet, currently only available via ICU
     if(!std::has_facet<boundary::boundary_indexing<char>>(loc))
     {
-        cout << "boundary detection not implemented in this environment" << endl;
+        std::cout << "boundary detection not implemented in this environment" << std::endl;
         return 0;
     }
-    locale::global(loc);
-    cout.imbue(loc);
+    std::locale::global(loc);
+    std::cout.imbue(loc);
 
 
-    string text="Hello World! あにま! Linux2.6 and Windows7 is word and number. שָלוֹם עוֹלָם!";
+    std::string text="Hello World! あにま! Linux2.6 and Windows7 is word and number. שָלוֹם עוֹלָם!";
 
-    cout<<text<<endl;
+    std::cout << text << std::endl;
 
     boundary::ssegment_index index(boundary::word,text.begin(),text.end());
     boundary::ssegment_index::iterator p,e;
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        cout<<"Part ["<<*p<<"] has ";
+        std::cout << "Part [" << *p << "] has ";
         if(p->rule() & boundary::word_number)
-            cout<<"number(s) ";
+            std::cout << "number(s) ";
         if(p->rule() & boundary::word_letter)
-            cout<<"letter(s) ";
+            std::cout << "letter(s) ";
         if(p->rule() & boundary::word_kana)
-            cout<<"kana character(s) ";
+            std::cout << "kana character(s) ";
         if(p->rule() & boundary::word_ideo)
-            cout<<"ideographic character(s) ";
+            std::cout << "ideographic character(s) ";
         if(p->rule() & boundary::word_none)
-            cout<<"no word characters";
-        cout<<endl;
+            std::cout << "no word characters";
+        std::cout << std::endl;
     }
 
     index.map(boundary::character,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        cout<<"|" <<*p ;
+        std::cout << "|" << *p ;
     }
-    cout<<"|\n\n";
+    std::cout << "|\n\n";
 
     index.map(boundary::line,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        cout<<"|" <<*p ;
+        std::cout << "|" << *p ;
     }
-    cout<<"|\n\n";
+    std::cout << "|\n\n";
 
     index.map(boundary::sentence,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        cout<<"|" <<*p ;
+        std::cout << "|" << *p ;
     }
-    cout<<"|\n\n";
+    std::cout << "|\n\n";
 
 }
 

--- a/examples/calendar.cpp
+++ b/examples/calendar.cpp
@@ -40,7 +40,7 @@ int main()
 
         // Print heading of month
         if(calendar().is_gregorian())
-            std::cout << format("{1,ftime='%B'}") % now <<std::endl;
+            std::cout << format("{1,ftime='%B'}") % now << std::endl;
         else
             std::cout << format("{1,ftime='%B'} ({1,ftime='%Y-%m-%d',locale=en} - {2,locale=en,ftime='%Y-%m-%d'})")
                 % now

--- a/examples/collate.cpp
+++ b/examples/collate.cpp
@@ -11,7 +11,6 @@
 
 #include <boost/locale.hpp>
 
-using namespace std;
 using namespace boost::locale;
 
 int main()
@@ -26,14 +25,14 @@ int main()
      set_type all_strings;
 
      /// Read all strings into the set
-     while(!cin.eof()) {
+     while(!std::cin.eof()) {
           std::string tmp;
-          getline(cin,tmp);
+          std::getline(std::cin,tmp);
           all_strings.insert(tmp);
      }
      /// Print them out
      for(set_type::iterator p=all_strings.begin();p!=all_strings.end();++p) {
-          cout<<*p<<endl;
+          std::cout << *p << std::endl;
      }
 
 }

--- a/examples/conversions.cpp
+++ b/examples/conversions.cpp
@@ -23,21 +23,20 @@ int main()
     std::cout.imbue(loc);
 
 
-    std::cout << "Correct case conversion can't be done by simple, character by character conversion" << std::endl;
-    std::cout << "because case conversion is context sensitive and not 1-to-1 conversion" << std::endl;
-    std::cout << "For example:" << std::endl;
+    std::cout << "Correct case conversion can't be done by simple, character by character conversion\n";
+    std::cout << "because case conversion is context sensitive and not 1-to-1 conversion\n";
+    std::cout << "For example:\n";
     std::cout << "   German grüßen correctly converted to "
               << to_upper("grüßen") << ", instead of incorrect "
               << boost::to_upper_copy(std::string("grüßen")) << std::endl;
-    std::cout << "     where ß is replaced with SS" << std::endl;
+    std::cout << "     where ß is replaced with SS\n";
     std::cout << "   Greek ὈΔΥΣΣΕΎΣ is correctly converted to "
               << to_lower("ὈΔΥΣΣΕΎΣ") << ", instead of incorrect "
               << boost::to_lower_copy(std::string("ὈΔΥΣΣΕΎΣ")) << std::endl;
-    std::cout << "     where Σ is converted to σ or to ς, according to position in the word" << std::endl;
-    std::cout << "Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is " << endl;
-    std::cout << "not even applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct " << endl;
-    std::cout << "behavior to unicode subset BMP or ASCII only" << std::endl;
-
+    std::cout << "     where Σ is converted to σ or to ς, according to position in the word\n";
+    std::cout << "Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is\n";
+    std::cout << "not even applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct\n";
+    std::cout << "behavior to unicode subset BMP or ASCII only\n";
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/examples/conversions.cpp
+++ b/examples/conversions.cpp
@@ -16,26 +16,27 @@
 int main()
 {
     using namespace boost::locale;
-    using namespace std;
     // Create system default locale
     generator gen;
-    locale loc=gen("");
-    locale::global(loc);
-    cout.imbue(loc);
+    std::locale loc=gen("");
+    std::locale::global(loc);
+    std::cout.imbue(loc);
 
 
-    cout<<"Correct case conversion can't be done by simple, character by character conversion"<<endl;
-    cout<<"because case conversion is context sensitive and not 1-to-1 conversion"<<endl;
-    cout<<"For example:"<<endl;
-    cout<<"   German grüßen correctly converted to "<<to_upper("grüßen")<<", instead of incorrect "
-                    <<boost::to_upper_copy(std::string("grüßen"))<<endl;
-    cout<<"     where ß is replaced with SS"<<endl;
-    cout<<"   Greek ὈΔΥΣΣΕΎΣ is correctly converted to "<<to_lower("ὈΔΥΣΣΕΎΣ")<<", instead of incorrect "
-                    <<boost::to_lower_copy(std::string("ὈΔΥΣΣΕΎΣ"))<<endl;
-    cout<<"     where Σ is converted to σ or to ς, according to position in the word"<<endl;
-    cout<<"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is "<<endl;
-    cout<<"not even applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct "<<endl;
-    cout<<"behavior to unicode subset BMP or ASCII only"<<endl;
+    std::cout << "Correct case conversion can't be done by simple, character by character conversion" << std::endl;
+    std::cout << "because case conversion is context sensitive and not 1-to-1 conversion" << std::endl;
+    std::cout << "For example:" << std::endl;
+    std::cout << "   German grüßen correctly converted to "
+              << to_upper("grüßen") << ", instead of incorrect "
+              << boost::to_upper_copy(std::string("grüßen")) << std::endl;
+    std::cout << "     where ß is replaced with SS" << std::endl;
+    std::cout << "   Greek ὈΔΥΣΣΕΎΣ is correctly converted to "
+              << to_lower("ὈΔΥΣΣΕΎΣ") << ", instead of incorrect "
+              << boost::to_lower_copy(std::string("ὈΔΥΣΣΕΎΣ")) << std::endl;
+    std::cout << "     where Σ is converted to σ or to ς, according to position in the word" << std::endl;
+    std::cout << "Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is " << endl;
+    std::cout << "not even applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct " << endl;
+    std::cout << "behavior to unicode subset BMP or ASCII only" << std::endl;
 
 }
 

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -13,28 +13,27 @@
 int main()
 {
     using namespace boost::locale;
-    using namespace std;
     generator gen;
-    locale loc=gen("");
+    std::locale loc=gen("");
     // Create system default locale
 
-    locale::global(loc);
+    std::locale::global(loc);
     // Make it system global
 
-    cout.imbue(loc);
+    std::cout.imbue(loc);
     // Set as default locale for output
 
-    cout <<format("Today {1,date} at {1,time} we had run our first localization example") % time(0)
-          <<endl;
+    std::cout << format("Today {1,date} at {1,time} we had run our first localization example") % time(0)
+              << std::endl;
 
-    cout<<"This is how we show numbers in this locale "<<as::number << 103.34 <<endl;
-    cout<<"This is how we show currency in this locale "<<as::currency << 103.34 <<endl;
-    cout<<"This is typical date in the locale "<<as::date << std::time(0) <<endl;
-    cout<<"This is typical time in the locale "<<as::time << std::time(0) <<endl;
-    cout<<"This is upper case "<<to_upper("Hello World!")<<endl;
-    cout<<"This is lower case "<<to_lower("Hello World!")<<endl;
-    cout<<"This is title case "<<to_title("Hello World!")<<endl;
-    cout<<"This is fold case "<<fold_case("Hello World!")<<endl;
+    std::cout << "This is how we show numbers in this locale " << as::number << 103.34 << std::endl;
+    std::cout << "This is how we show currency in this locale " << as::currency << 103.34 << std::endl;
+    std::cout << "This is typical date in the locale " << as::date << std::time(0) << std::endl;
+    std::cout << "This is typical time in the locale " << as::time << std::time(0) << std::endl;
+    std::cout << "This is upper case " << to_upper("Hello World!") << std::endl;
+    std::cout << "This is lower case " << to_lower("Hello World!") << std::endl;
+    std::cout << "This is title case " << to_title("Hello World!") << std::endl;
+    std::cout << "This is fold case " << fold_case("Hello World!") << std::endl;
 
 }
 

--- a/examples/performance/perf_collate.cpp
+++ b/examples/performance/perf_collate.cpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 using namespace boost::locale;
 
 int main(int argc,char **argv)
@@ -33,9 +32,9 @@ int main(int argc,char **argv)
     set_type all_strings;
 
     /// Read all strings into the set
-    while(!cin.eof()) {
+    while(!std::cin.eof()) {
         std::string tmp;
-        getline(cin,tmp);
+        std::getline(std::cin,tmp);
         all.push_back(tmp);
     }
     for(int i=0;i<10000;i++) {

--- a/examples/performance/perf_collate.cpp
+++ b/examples/performance/perf_collate.cpp
@@ -16,7 +16,7 @@ using namespace boost::locale;
 int main(int argc,char **argv)
 {
     if(argc!=2) {
-        std::cerr << "Usage backend locale" << std::endl;
+        std::cerr << "Usage backend locale\n";
         return 1;
     }
     boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();

--- a/examples/performance/perf_convert.cpp
+++ b/examples/performance/perf_convert.cpp
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 using namespace boost::locale;
 
 int main(int argc,char **argv)

--- a/examples/performance/perf_convert.cpp
+++ b/examples/performance/perf_convert.cpp
@@ -17,7 +17,7 @@ using namespace boost::locale;
 int main(int argc,char **argv)
 {
     if(argc!=2) {
-        std::cerr << "Usage backend locale" << std::endl;
+        std::cerr << "Usage backend locale\n";
         return 1;
     }
     /// Set global locale to requested
@@ -29,9 +29,9 @@ int main(int argc,char **argv)
     set_type all_strings;
 
     /// Read all strings into the set
-    while(!cin.eof()) {
+    while(!std::cin.eof()) {
         std::string tmp;
-        getline(cin,tmp);
+        getline(std::cin,tmp);
         all.push_back(tmp);
     }
 

--- a/examples/performance/perf_format.cpp
+++ b/examples/performance/perf_format.cpp
@@ -11,7 +11,6 @@
 #include <ctime>
 #include <boost/locale.hpp>
 
-using namespace std;
 using namespace boost::locale;
 
 int main(int argc,char **argv)
@@ -29,7 +28,7 @@ int main(int argc,char **argv)
     for(int i=0;i<100000;i++) {
         std::ostringstream ss;
         for(int j=0;j<5;j++) {
-            ss << boost::locale::as::datetime << std::time(0) <<" "<< boost::locale::as::number << 13456.345 <<"\n";
+            ss << boost::locale::as::datetime << std::time(0) << " " << boost::locale::as::number << 13456.345 << "\n";
         }
         if(i==0)
             std::cout << ss.str() << std::endl;

--- a/examples/performance/perf_format.cpp
+++ b/examples/performance/perf_format.cpp
@@ -16,7 +16,7 @@ using namespace boost::locale;
 int main(int argc,char **argv)
 {
     if(argc!=2) {
-        std::cerr << "Usage backend locale" << std::endl;
+        std::cerr << "Usage backend locale\n";
         return 1;
     }
     boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();

--- a/examples/wboundary.cpp
+++ b/examples/wboundary.cpp
@@ -45,7 +45,7 @@ int main()
     // We need the boundary facet, currently only available via ICU
     if(!std::has_facet<boundary::boundary_indexing<wchar_t>>(loc))
     {
-        std::cout << "boundary detection not implemented in this environment" << std::endl;
+        std::cout << "boundary detection not implemented in this environment\n";
         return 0;
     }
     std::locale::global(loc);
@@ -96,7 +96,7 @@ int main()
     index.map(boundary::sentence,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        std::wcout << L"|"  
+        std::wcout << L"|" << *p;
     }
     std::wcout << "|\n\n";
 

--- a/examples/wboundary.cpp
+++ b/examples/wboundary.cpp
@@ -38,19 +38,18 @@
 int main()
 {
     using namespace boost::locale;
-    using namespace std;
 
     // Create system default locale
     generator gen;
-    locale loc=gen("");
+    std::locale loc=gen("");
     // We need the boundary facet, currently only available via ICU
     if(!std::has_facet<boundary::boundary_indexing<wchar_t>>(loc))
     {
-        cout << "boundary detection not implemented in this environment" << endl;
+        std::cout << "boundary detection not implemented in this environment" << std::endl;
         return 0;
     }
-    locale::global(loc);
-    wcout.imbue(loc);
+    std::locale::global(loc);
+    std::wcout.imbue(loc);
 
     // This is needed to prevent C library to
     // convert strings to narrow
@@ -58,48 +57,48 @@ int main()
     std::ios_base::sync_with_stdio(false);
 
 
-    wstring text=L"Hello World! あにま! Linux2.6 and Windows7 is word and number. שָלוֹם עוֹלָם!";
+    std::wstring text=L"Hello World! あにま! Linux2.6 and Windows7 is word and number. שָלוֹם עוֹלָם!";
 
-    wcout<<text<<endl;
+    std::wcout << text << std::endl;
 
     boundary::wssegment_index index(boundary::word,text.begin(),text.end());
     boundary::wssegment_index::iterator p,e;
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        wcout<<L"Part ["<<*p<<L"] has ";
+        std::wcout << L"Part [" << *p << L"] has ";
         if(p->rule() & boundary::word_number)
-            wcout<<L"number(s) ";
+            std::wcout << L"number(s) ";
         if(p->rule() & boundary::word_letter)
-            wcout<<L"letter(s) ";
+            std::wcout << L"letter(s) ";
         if(p->rule() & boundary::word_kana)
-            wcout<<L"kana character(s) ";
+            std::wcout << L"kana character(s) ";
         if(p->rule() & boundary::word_ideo)
-            wcout<<L"ideographic character(s) ";
+            std::wcout << L"ideographic character(s) ";
         if(p->rule() & boundary::word_none)
-            wcout<<L"no word characters";
-        wcout<<endl;
+            std::wcout << L"no word characters";
+        std::wcout << std::endl;
     }
 
     index.map(boundary::character,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        wcout<<L"|" <<*p ;
+        std::wcout << L"|" << *p ;
     }
-    wcout<<L"|\n\n";
+    std::wcout << L"|\n\n";
 
     index.map(boundary::line,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        wcout<<L"|" <<*p ;
+        std::wcout << L"|" << *p ;
     }
-    wcout<<L"|\n\n";
+    std::wcout << L"|\n\n";
 
     index.map(boundary::sentence,text.begin(),text.end());
 
     for(p=index.begin(),e=index.end();p!=e;++p) {
-        wcout<<L"|" <<*p ;
+        std::wcout << L"|"  
     }
-    wcout<<"|\n\n";
+    std::wcout << "|\n\n";
 
 }
 

--- a/examples/wconversions.cpp
+++ b/examples/wconversions.cpp
@@ -40,12 +40,11 @@
 int main()
 {
     using namespace boost::locale;
-    using namespace std;
     // Create system default locale
     generator gen;
-    locale loc=gen("");
-    locale::global(loc);
-    wcout.imbue(loc);
+    std::locale loc=gen("");
+    std::locale::global(loc);
+    std::wcout.imbue(loc);
 
     // This is needed to prevent C library to
     // convert strings to narrow
@@ -53,18 +52,20 @@ int main()
     std::ios_base::sync_with_stdio(false);
 
 
-    wcout<<L"Correct case conversion can't be done by simple, character by character conversion"<<endl;
-    wcout<<L"because case conversion is context sensitive and not 1-to-1 conversion"<<endl;
-    wcout<<L"For example:"<<endl;
-    wcout<<L"   German grüßen correctly converted to "<<to_upper(L"grüßen")<<L", instead of incorrect "
-                    <<boost::to_upper_copy(std::wstring(L"grüßen"))<<endl;
-    wcout<<L"     where ß is replaced with SS"<<endl;
-    wcout<<L"   Greek ὈΔΥΣΣΕΎΣ is correctly converted to "<<to_lower(L"ὈΔΥΣΣΕΎΣ")<<L", instead of incorrect "
-                    <<boost::to_lower_copy(std::wstring(L"ὈΔΥΣΣΕΎΣ"))<<endl;
-    wcout<<L"     where Σ is converted to σ or to ς, according to position in the word"<<endl;
-    wcout<<L"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is "<<endl;
-    wcout<<L"not fully applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct "<<endl;
-    wcout<<L"behavoir to BMP or ASCII only"<<endl;
+    std::wcout << L"Correct case conversion can't be done by simple, character by character conversion" << std::endl;
+    std::wcout << L"because case conversion is context sensitive and not 1-to-1 conversion" << std::endl;
+    std::wcout << L"For example:" << std::endl;
+    std::wcout << L"   German grüßen correctly converted to "
+               << to_upper(L"grüßen") << L", instead of incorrect "
+               << boost::to_upper_copy(std::wstring(L"grüßen")) << std::endl;
+    std::wcout << L"     where ß is replaced with SS" << std::endl;
+    std::wcout << L"   Greek ὈΔΥΣΣΕΎΣ is correctly converted to "
+               << to_lower(L"ὈΔΥΣΣΕΎΣ") << L", instead of incorrect "
+               << boost::to_lower_copy(std::wstring(L"ὈΔΥΣΣΕΎΣ")) << std::endl;
+    std::wcout << L"     where Σ is converted to σ or to ς, according to position in the word" << std::endl;
+    std::wcout << L"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is " << std::endl;
+    std::wcout << L"not fully applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct " << std::endl;
+    std::wcout << L"behavoir to BMP or ASCII only" << std::endl;
 
 }
 

--- a/examples/wconversions.cpp
+++ b/examples/wconversions.cpp
@@ -52,20 +52,20 @@ int main()
     std::ios_base::sync_with_stdio(false);
 
 
-    std::wcout << L"Correct case conversion can't be done by simple, character by character conversion" << std::endl;
-    std::wcout << L"because case conversion is context sensitive and not 1-to-1 conversion" << std::endl;
-    std::wcout << L"For example:" << std::endl;
+    std::wcout << L"Correct case conversion can't be done by simple, character by character conversion\n";
+    std::wcout << L"because case conversion is context sensitive and not 1-to-1 conversion\n";
+    std::wcout << L"For example:\n";
     std::wcout << L"   German grüßen correctly converted to "
                << to_upper(L"grüßen") << L", instead of incorrect "
                << boost::to_upper_copy(std::wstring(L"grüßen")) << std::endl;
-    std::wcout << L"     where ß is replaced with SS" << std::endl;
+    std::wcout << L"     where ß is replaced with SS\n";
     std::wcout << L"   Greek ὈΔΥΣΣΕΎΣ is correctly converted to "
                << to_lower(L"ὈΔΥΣΣΕΎΣ") << L", instead of incorrect "
                << boost::to_lower_copy(std::wstring(L"ὈΔΥΣΣΕΎΣ")) << std::endl;
-    std::wcout << L"     where Σ is converted to σ or to ς, according to position in the word" << std::endl;
-    std::wcout << L"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is " << std::endl;
-    std::wcout << L"not fully applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct " << std::endl;
-    std::wcout << L"behavoir to BMP or ASCII only" << std::endl;
+    std::wcout << L"     where Σ is converted to σ or to ς, according to position in the word\n";
+    std::wcout << L"Such type of conversion just can't be done using std::toupper that work on character base, also std::toupper is \n";
+    std::wcout << L"not fully applicable when working with variable character length like in UTF-8 or UTF-16 limiting the correct \n";
+    std::wcout << L"behavoir to BMP or ASCII only\n";
 
 }
 

--- a/examples/whello.cpp
+++ b/examples/whello.cpp
@@ -13,13 +13,12 @@
 int main()
 {
     using namespace boost::locale;
-    using namespace std;
 
     // Create system default locale
     generator gen;
-    locale loc=gen("");
-    locale::global(loc);
-    wcout.imbue(loc);
+    std::locale loc=gen("");
+    std::locale::global(loc);
+    std::wcout.imbue(loc);
 
     // This is needed to prevent C library to
     // convert strings to narrow
@@ -27,17 +26,17 @@ int main()
     std::ios_base::sync_with_stdio(false);
 
 
-    wcout <<wformat(L"Today {1,date} at {1,time} we had run our first localization example") % time(0)
-          <<endl;
+    std::wcout << wformat(L"Today {1,date} at {1,time} we had run our first localization example") % time(0)
+               << std::endl;
 
-    wcout<<L"This is how we show numbers in this locale "<<as::number << 103.34 <<endl;
-    wcout<<L"This is how we show currency in this locale "<<as::currency << 103.34 <<endl;
-    wcout<<L"This is typical date in the locale "<<as::date << std::time(0) <<endl;
-    wcout<<L"This is typical time in the locale "<<as::time << std::time(0) <<endl;
-    wcout<<L"This is upper case "<<to_upper(L"Hello World!")<<endl;
-    wcout<<L"This is lower case "<<to_lower(L"Hello World!")<<endl;
-    wcout<<L"This is title case "<<to_title(L"Hello World!")<<endl;
-    wcout<<L"This is fold case "<<fold_case(L"Hello World!")<<endl;
+    std::wcout << L"This is how we show numbers in this locale " << as::number << 103.34 << std::endl;
+    std::wcout << L"This is how we show currency in this locale " << as::currency << 103.34 << std::endl;
+    std::wcout << L"This is typical date in the locale " << as::date << std::time(0) << std::endl;
+    std::wcout << L"This is typical time in the locale " << as::time << std::time(0) << std::endl;
+    std::wcout << L"This is upper case " << to_upper(L"Hello World!") << std::endl;
+    std::wcout << L"This is lower case " << to_lower(L"Hello World!") << std::endl;
+    std::wcout << L"This is title case " << to_title(L"Hello World!") << std::endl;
+    std::wcout << L"This is fold case " << fold_case(L"Hello World!") << std::endl;
 
 }
 

--- a/include/boost/locale/boundary/index.hpp
+++ b/include/boost/locale/boundary/index.hpp
@@ -571,7 +571,7 @@ namespace boost {
                 ///     segment_index<some_iterator>::iterator p=index.begin();
                 ///     segment<some_iterator> &t = *p;
                 ///     ++p;
-                ///     cout << t.str() << endl;
+                ///     std::cout << t.str() << std::endl;
                 ///     \endcode
                 ///
                 typedef unspecified_iterator_type iterator;

--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -863,7 +863,7 @@ namespace boost {
         /// For example:
         /// \code
         ///  date_time now(time(0),hebrew_calendar)
-        ///  cout << "Year: " << period::year(now) << " Full Date:" << now;
+        ///  std::cout << "Year: " << period::year(now) << " Full Date:" << now;
         /// \endcode
         ///
         /// The output may be Year:5770 Full Date:Jan 1, 2010

--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -693,7 +693,7 @@ namespace boost {
             ///
             date_time operator<<(period::period_type f) const
             {
-                return *this<<date_time_period(f);
+                return *this << date_time_period(f);
             }
 
             ///
@@ -709,14 +709,14 @@ namespace boost {
             ///
             date_time const &operator<<=(period::period_type f)
             {
-                return *this<<=date_time_period(f);
+                return *this <<= date_time_period(f);
             }
             ///
             /// roll backward a date by single period f.
             ///
             date_time const &operator>>=(period::period_type f)
             {
-                return *this>>=date_time_period(f);
+                return *this >>= date_time_period(f);
             }
 
             ///
@@ -863,7 +863,7 @@ namespace boost {
         /// For example:
         /// \code
         ///  date_time now(time(0),hebrew_calendar)
-        ///  cout << "Year: " << period::year(now) <<" Full Date:"<< now;
+        ///  cout << "Year: " << period::year(now) << " Full Date:" << now;
         /// \endcode
         ///
         /// The output may be Year:5770 Full Date:Jan 1, 2010

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -137,7 +137,7 @@ namespace boost {
         ///
         /// For example
         /// \code
-        ///  cout << format("Hello {1}, you are {2} years old") % name % age << endl;
+        ///  std::cout << format("Hello {1}, you are {2} years old") % name % age << std::endl;
         /// \endcode
         ///
         /// Formatting is enclosed between curly brackets \c { \c } and defined by a comma separated list of flags in the format key[=value]
@@ -150,7 +150,7 @@ namespace boost {
         /// For example:
         ///
         /// \code
-        ///   cout << format("The height of water at {1,time} is {2,num=fixed,precision=3}") % time % height;
+        ///   std::cout << format("The height of water at {1,time} is {2,num=fixed,precision=3}") % time % height;
         /// \endcode
         ///
         /// The special key -- a number without a value defines the position of an input parameter.
@@ -185,16 +185,16 @@ namespace boost {
         /// -  \c locale -- with parameter -- switch locale for current operation. This command generates locale
         ///     with formatting facets giving more fine grained control of formatting. For example:
         ///    \code
-        ///    cout << format("Today {1,date} ({1,date,locale=he_IL.UTF-8@calendar=hebrew,date} Hebrew Date)") % date;
+        ///    std::cout << format("Today {1,date} ({1,date,locale=he_IL.UTF-8@calendar=hebrew,date} Hebrew Date)") % date;
         ///    \endcode
         /// -  \c timezone or \c tz -- the name of the timezone to display the time in. For example:\n
         ///    \code
-        ///    cout << format("Time is: Local {1,time}, ({1,time,tz=EET} Eastern European Time)") % date;
+        ///    std::cout << format("Time is: Local {1,time}, ({1,time,tz=EET} Eastern European Time)") % date;
         ///    \endcode
         /// -  \c local - display the time in local time
         /// -  \c gmt - display the time in UTC time scale
         ///    \code
-        ///    cout << format("Local time is: {1,time,local}, universal time is {1,time,gmt}") % time;
+        ///    std::cout << format("Local time is: {1,time,local}, universal time is {1,time,gmt}") % time;
         ///    \endcode
         ///
         ///

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -84,7 +84,7 @@ namespace boost {
                 static void void_write(stream_type &output,void const * /*ptr*/)
                 {
                     CharType empty_string[1]={0};
-                    output<<empty_string;
+                    output << empty_string;
                 }
 
                 template<typename Type>
@@ -319,7 +319,7 @@ namespace boost {
                             pos+=2;
                         }
                         else {
-                            out<<format[pos];
+                            out << format[pos];
                             pos++;
                         }
                         continue;

--- a/include/boost/locale/generic_codecvt.hpp
+++ b/include/boost/locale/generic_codecvt.hpp
@@ -256,7 +256,7 @@ protected:
         while(to < to_end && from < from_end)
         {
 #ifdef DEBUG_CODECVT
-            std::cout << "Entering IN--------------" << std::endl;
+            std::cout << "Entering IN--------------\n";
             std::cout << "State " << std::hex << state << std::endl;
             std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
@@ -310,16 +310,16 @@ protected:
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
-            std::cout << "ok" << std::endl;
+            std::cout << "ok\n";
             break;
         case std::codecvt_base::partial:
-            std::cout << "partial" << std::endl;
+            std::cout << "partial\n";
             break;
         case std::codecvt_base::error:
-            std::cout << "error" << std::endl;
+            std::cout << "error\n";
             break;
         default:
-            std::cout << "other" << std::endl;
+            std::cout << "other\n";
             break;
         }
         std::cout << "State " << std::hex << state << std::endl;
@@ -350,7 +350,7 @@ protected:
         while(to < to_end && from < from_end)
         {
 #ifdef DEBUG_CODECVT
-        std::cout << "Entering OUT --------------" << std::endl;
+        std::cout << "Entering OUT --------------\n";
         std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
@@ -419,16 +419,16 @@ protected:
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
-            std::cout << "ok" << std::endl;
+            std::cout << "ok\n";
             break;
         case std::codecvt_base::partial:
-            std::cout << "partial" << std::endl;
+            std::cout << "partial\n";
             break;
         case std::codecvt_base::error:
-            std::cout << "error" << std::endl;
+            std::cout << "error\n";
             break;
         default:
-            std::cout << "other" << std::endl;
+            std::cout << "other\n";
             break;
         }
         std::cout << "State " << std::hex << state << std::endl;
@@ -535,7 +535,7 @@ protected:
         while(to < to_end && from < from_end)
         {
 #ifdef DEBUG_CODECVT
-            std::cout << "Entering IN--------------" << std::endl;
+            std::cout << "Entering IN--------------\n";
             std::cout << "State " << std::hex << state << std::endl;
             std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
@@ -563,16 +563,16 @@ protected:
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
-            std::cout << "ok" << std::endl;
+            std::cout << "ok\n";
             break;
         case std::codecvt_base::partial:
-            std::cout << "partial" << std::endl;
+            std::cout << "partial\n";
             break;
         case std::codecvt_base::error:
-            std::cout << "error" << std::endl;
+            std::cout << "error\n";
             break;
         default:
-            std::cout << "other" << std::endl;
+            std::cout << "other\n";
             break;
         }
         std::cout << "State " << std::hex << state << std::endl;
@@ -596,7 +596,7 @@ protected:
         while(to < to_end && from < from_end)
         {
 #ifdef DEBUG_CODECVT
-        std::cout << "Entering OUT --------------" << std::endl;
+        std::cout << "Entering OUT --------------\n";
         std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
@@ -626,16 +626,16 @@ protected:
         std::cout << "Returning ";
         switch(r) {
         case std::codecvt_base::ok:
-            std::cout << "ok" << std::endl;
+            std::cout << "ok\n";
             break;
         case std::codecvt_base::partial:
-            std::cout << "partial" << std::endl;
+            std::cout << "partial\n";
             break;
         case std::codecvt_base::error:
-            std::cout << "error" << std::endl;
+            std::cout << "error\n";
             break;
         default:
-            std::cout << "other" << std::endl;
+            std::cout << "other\n";
             break;
         }
         std::cout << "State " << std::hex << state << std::endl;

--- a/include/boost/locale/generic_codecvt.hpp
+++ b/include/boost/locale/generic_codecvt.hpp
@@ -257,7 +257,7 @@ protected:
         {
 #ifdef DEBUG_CODECVT
             std::cout << "Entering IN--------------" << std::endl;
-            std::cout << "State " << std::hex << state <<std::endl;
+            std::cout << "State " << std::hex << state << std::endl;
             std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
             char const *from_saved = from;
@@ -322,7 +322,7 @@ protected:
             std::cout << "other" << std::endl;
             break;
         }
-        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
         return r;
@@ -351,7 +351,7 @@ protected:
         {
 #ifdef DEBUG_CODECVT
         std::cout << "Entering OUT --------------" << std::endl;
-        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
             boost::uint32_t ch=0;
@@ -431,7 +431,7 @@ protected:
             std::cout << "other" << std::endl;
             break;
         }
-        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
         return r;
@@ -536,7 +536,7 @@ protected:
         {
 #ifdef DEBUG_CODECVT
             std::cout << "Entering IN--------------" << std::endl;
-            std::cout << "State " << std::hex << state <<std::endl;
+            std::cout << "State " << std::hex << state << std::endl;
             std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
             char const *from_saved = from;
@@ -575,7 +575,7 @@ protected:
             std::cout << "other" << std::endl;
             break;
         }
-        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
         return r;
@@ -597,7 +597,7 @@ protected:
         {
 #ifdef DEBUG_CODECVT
         std::cout << "Entering OUT --------------" << std::endl;
-        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
             boost::uint32_t ch=0;
@@ -638,7 +638,7 @@ protected:
             std::cout << "other" << std::endl;
             break;
         }
-        std::cout << "State " << std::hex << state <<std::endl;
+        std::cout << "State " << std::hex << state << std::endl;
         std::cout << "Left in " << std::dec << from_end - from << " out " << to_end -to << std::endl;
 #endif
         return r;

--- a/include/boost/locale/utf.hpp
+++ b/include/boost/locale/utf.hpp
@@ -51,7 +51,7 @@ namespace utf {
     {
         if(v>0x10FFFF)
             return false;
-        if(0xD800 <=v && v<= 0xDFFF) // surragates
+        if(0xD800 <=v && v<= 0xDFFF) // surrogates
             return false;
         return true;
     }

--- a/include/boost/locale/utf.hpp
+++ b/include/boost/locale/utf.hpp
@@ -211,7 +211,7 @@ namespace utf {
             if(trail_size == 0)
                 return lead;
 
-            code_point c = lead & ((1<<(6-trail_size))-1);
+            code_point c = lead & ((1 << (6-trail_size))-1);
 
             // Read the rest
             unsigned char tmp;
@@ -270,7 +270,7 @@ namespace utf {
             else
                 trail_size = 3;
 
-            code_point c = lead & ((1<<(6-trail_size))-1);
+            code_point c = lead & ((1 << (6-trail_size))-1);
 
             switch(trail_size) {
             case 3:

--- a/src/icu/codecvt.cpp
+++ b/src/icu/codecvt.cpp
@@ -85,7 +85,7 @@ namespace impl_icu {
             UChar code_point[2]={0};
             int len;
             if(u<=0xFFFF) {
-                if(0xD800 <=u && u<= 0xDFFF) // No surragates
+                if(0xD800 <=u && u<= 0xDFFF) // No surrogates
                     return illegal;
                 code_point[0]=u;
                 len=1;

--- a/src/icu/formatter.hpp
+++ b/src/icu/formatter.hpp
@@ -80,7 +80,7 @@ namespace impl_icu {
         /// \code
         ///     std::cout << as::spellout;
         ///     for(int i=1;i<=10;i++)
-        ///         std::cout << i <<std::endl;
+        ///         std::cout << i << std::endl;
         /// \endcode
         ///
         /// Would create a new spelling formatter only once.

--- a/src/shared/date_time.cpp
+++ b/src/shared/date_time.cpp
@@ -244,14 +244,14 @@ date_time date_time::operator-(date_time_period const &v) const
 date_time date_time::operator<<(date_time_period const &v) const
 {
     date_time tmp(*this);
-    tmp<<=v;
+    tmp <<= v;
     return tmp;
 }
 
 date_time date_time::operator>>(date_time_period const &v) const
 {
     date_time tmp(*this);
-    tmp>>=v;
+    tmp >>= v;
     return tmp;
 }
 
@@ -297,14 +297,14 @@ date_time date_time::operator-(date_time_period_set const &v) const
 date_time date_time::operator<<(date_time_period_set const &v) const
 {
     date_time tmp(*this);
-    tmp<<=v;
+    tmp <<= v;
     return tmp;
 }
 
 date_time date_time::operator>>(date_time_period_set const &v) const
 {
     date_time tmp(*this);
-    tmp>>=v;
+    tmp >>= v;
     return tmp;
 }
 
@@ -327,7 +327,7 @@ date_time const &date_time::operator-=(date_time_period_set const &v)
 date_time const &date_time::operator<<=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
-        *this<<=v[i];
+        *this <<= v[i];
     }
     return *this;
 }
@@ -335,7 +335,7 @@ date_time const &date_time::operator<<=(date_time_period_set const &v)
 date_time const &date_time::operator>>=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
-        *this>>=v[i];
+        *this >>= v[i];
     }
     return *this;
 }

--- a/src/shared/localization_backend.cpp
+++ b/src/shared/localization_backend.cpp
@@ -134,7 +134,7 @@ namespace boost {
                 {
                     int id;
                     unsigned v;
-                    for(v=1,id=0;v!=0;v<<=1,id++) {
+                    for(v=1,id=0;v!=0;v <<= 1,id++) {
                         if(category == v)
                             break;
                     }

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -511,25 +511,18 @@ void segment_operator()
     test_op("aa","ab",-1);
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        std::cout << "Testing segment operators" << std::endl;
-        segment_operator();
-        std::cout << "Testing word boundary" << std::endl;
-        word_boundary();
-        std::cout << "Testing character boundary" << std::endl;
-        test_boundaries(character,nones,0,lb::character);
-        std::cout << "Testing sentence boundary" << std::endl;
-        test_boundaries(sentence1,sentence1a,sentence1b,lb::sentence);
-        std::cout << "Testing line boundary" << std::endl;
-        test_boundaries(line1,line1a,line1b,lb::line);
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
+    std::cout << "Testing segment operators" << std::endl;
+    segment_operator();
+    std::cout << "Testing word boundary" << std::endl;
+    word_boundary();
+    std::cout << "Testing character boundary" << std::endl;
+    test_boundaries(character,nones,0,lb::character);
+    std::cout << "Testing sentence boundary" << std::endl;
+    test_boundaries(sentence1,sentence1a,sentence1b,lb::sentence);
+    std::cout << "Testing line boundary" << std::endl;
+    test_boundaries(line1,line1a,line1b,lb::line);
 }
 
 #endif // NOICU

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "ICU is not build... Skipping" << std::endl;
+        std::cout << "ICU is not build... Skipping\n";
 }
 #else
 
@@ -34,7 +34,7 @@ void print_str(std::basic_string<Char> const &/*s*/)
 template<>
 void print_str<char>(std::basic_string<char> const &s)
 {
-    std::cout << "[" << s << "]" << std::endl;
+    std::cout << "[" << s << "]\n";
 }
 
 

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -34,7 +34,7 @@ void print_str(std::basic_string<Char> const &/*s*/)
 template<>
 void print_str<char>(std::basic_string<char> const &s)
 {
-    std::cout << "[" << s <<"]" << std::endl;
+    std::cout << "[" << s << "]" << std::endl;
 }
 
 
@@ -379,14 +379,14 @@ void test_boundaries(std::string *all,int *first,int *second,lb::boundary_type t
     run_word<char>(all,first,second,0,0,0,g("he_IL.UTF-8"),t);
     std::cout << " char CP1255" << std::endl;
     run_word<char>(all,first,second,0,0,0,g("he_IL.cp1255"),t);
-    std::cout << " wchar_t"<<std::endl;
+    std::cout << " wchar_t" << std::endl;
     run_word<wchar_t>(all,first,second,0,0,0,g("he_IL.UTF-8"),t);
     #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    std::cout << " char16_t"<<std::endl;
+    std::cout << " char16_t" << std::endl;
     run_word<char16_t>(all,first,second,0,0,0,g("he_IL.UTF-8"),t);
     #endif
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-    std::cout << " char32_t"<<std::endl;
+    std::cout << " char32_t" << std::endl;
     run_word<char32_t>(all,first,second,0,0,0,g("he_IL.UTF-8"),t);
     #endif
 
@@ -427,20 +427,20 @@ void word_boundary()
     run_word<char>(all2,zero,zero,zero,zero,zero,g("ja_JP.Shift-JIS"));
     run_word<char>(all3,none3,zero,word3,zero,zero,g("ja_JP.Shift-JIS"));
 
-    std::cout << " wchar_t"<<std::endl;
+    std::cout << " wchar_t" << std::endl;
     run_word<wchar_t>(all1,none1,num1,word1,kana1,ideo1,g("ja_JP.UTF-8"));
     run_word<wchar_t>(all2,zero,zero,zero,zero,zero,g("en_US.UTF-8"));
     run_word<wchar_t>(all3,none3,zero,word3,zero,zero,g("en_US.UTF-8"));
 
     #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    std::cout << " char16_t"<<std::endl;
+    std::cout << " char16_t" << std::endl;
     run_word<char16_t>(all1,none1,num1,word1,kana1,ideo1,g("ja_JP.UTF-8"));
     run_word<char16_t>(all2,zero,zero,zero,zero,zero,g("en_US.UTF-8"));
     run_word<char16_t>(all3,none3,zero,word3,zero,zero,g("en_US.UTF-8"));
     #endif
 
     #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-    std::cout << " char32_t"<<std::endl;
+    std::cout << " char32_t" << std::endl;
     run_word<char32_t>(all1,none1,num1,word1,kana1,ideo1,g("ja_JP.UTF-8"));
     run_word<char32_t>(all2,zero,zero,zero,zero,zero,g("en_US.UTF-8"));
     run_word<char32_t>(all3,none3,zero,word3,zero,zero,g("en_US.UTF-8"));

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -242,7 +242,7 @@ void test_codecvt_err()
 
 void test_char_char()
 {
-    std::cout << "Char-char specialization"<<std::endl;
+    std::cout << "Char-char specialization" << std::endl;
     std::locale l(std::locale::classic(),new boost::locale::utf8_codecvt<char>());
     std::codecvt<char,char,std::mbstate_t> const &cvt=std::use_facet<std::codecvt<char,char,std::mbstate_t> >(l);
     std::mbstate_t mb=std::mbstate_t();

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -264,20 +264,11 @@ void test_char_char()
     TEST(cvt.max_length()==1);
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        test_codecvt_conv();
-        test_codecvt_err();
-        test_char_char();
-
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed : " << e.what() << std::endl;
-        return 1;
-    }
-    std::cout << "Ok\n";
-    return 0;
+    test_codecvt_conv();
+    test_codecvt_err();
+    test_char_char();
 }
 ///
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -276,7 +276,7 @@ int main()
         std::cerr << "Failed : " << e.what() << std::endl;
         return 1;
     }
-    std::cout << "Ok" << std::endl;
+    std::cout << "Ok\n";
     return 0;
 }
 ///

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -137,7 +137,7 @@ void test_for_char()
         test_ok<Char>(res.c_str(),g("en_US.UTF-8")); // U+2008A
     }
     else {
-        std::cout << "    UTF-8 Not supported " << std::endl;
+        std::cout << "    UTF-8 Not supported \n";
     }
 
     if(test_iso) {
@@ -305,7 +305,7 @@ void test_combinations()
 
 void test_all_combinations()
 {
-    std::cout << "Testing utf_to_utf" << std::endl;
+    std::cout << "Testing utf_to_utf\n";
     std::cout << "  char<-char" << std::endl;
     test_combinations<char,char>();
     std::cout << "  char<-wchar" << std::endl;
@@ -353,7 +353,7 @@ void test_skip(char const *enc,char const *utf,char const *name,char const *opt=
 void test_simple_conversions()
 {
     namespace blc=boost::locale::conv;
-    std::cout << "- Testing correct invalid bytes skipping" << std::endl;
+    std::cout << "- Testing correct invalid bytes skipping\n";
     try {
         std::cout << "-- ISO-8859-8" << std::endl;
         test_skip("test \xE0\xE1\xFB-","test \xd7\x90\xd7\x91-","ISO-8859-8");
@@ -362,7 +362,7 @@ void test_simple_conversions()
         test_skip("\xFB-","-","ISO-8859-8");
     }
     catch(blc::invalid_charset_error const &) {
-        std::cout << "--- not supported" << std::endl;
+        std::cout << "--- not supported\n";
     }
     try {
         std::cout << "-- cp932" << std::endl;
@@ -372,7 +372,7 @@ void test_simple_conversions()
         test_skip("\x83\xF8-","-","cp932","");
     }
     catch(blc::invalid_charset_error const &) {
-        std::cout << "--- not supported" << std::endl;
+        std::cout << "--- not supported\n";
     }
 }
 
@@ -484,7 +484,7 @@ int main()
 
             std::cout << "Testing wide I/O" << std::endl;
             test_wide_io();
-            std::cout << "Testing charset to/from UTF conversion functions" << std::endl;
+            std::cout << "Testing charset to/from UTF conversion functions\n";
             std::cout << "  char" << std::endl;
             test_to<char>();
             std::cout << "  wchar_t" << std::endl;

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -108,11 +108,11 @@ void test_wfail(std::string file,std::locale const &l,int pos)
     int i;
     for(i=0;i<pos;i++) {
         f1 << out.at(i);
-        f1<<std::flush;
+        f1 << std::flush;
         TEST(f1.good());
     }
     f1 << out.at(i);
-    TEST(f1.fail() || (f1<<std::flush).fail());
+    TEST(f1.fail() || (f1 << std::flush).fail());
 }
 
 
@@ -306,13 +306,13 @@ void test_combinations()
 void test_all_combinations()
 {
     std::cout << "Testing utf_to_utf" << std::endl;
-    std::cout <<"  char<-char"<<std::endl;
+    std::cout << "  char<-char" << std::endl;
     test_combinations<char,char>();
-    std::cout <<"  char<-wchar"<<std::endl;
+    std::cout << "  char<-wchar" << std::endl;
     test_combinations<char,wchar_t>();
-    std::cout <<"  wchar<-char"<<std::endl;
+    std::cout << "  wchar<-char" << std::endl;
     test_combinations<wchar_t,char>();
-    std::cout <<"  wchar<-wchar"<<std::endl;
+    std::cout << "  wchar<-wchar" << std::endl;
     test_combinations<wchar_t,wchar_t>();
 }
 
@@ -362,7 +362,7 @@ void test_simple_conversions()
         test_skip("\xFB-","-","ISO-8859-8");
     }
     catch(blc::invalid_charset_error const &) {
-        std::cout <<"--- not supported" << std::endl;
+        std::cout << "--- not supported" << std::endl;
     }
     try {
         std::cout << "-- cp932" << std::endl;
@@ -372,7 +372,7 @@ void test_simple_conversions()
         test_skip("\x83\xF8-","-","cp932","");
     }
     catch(blc::invalid_charset_error const &) {
-        std::cout <<"--- not supported" << std::endl;
+        std::cout << "--- not supported" << std::endl;
     }
 }
 

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -179,7 +179,7 @@ int main()
         TEST_TO(make4(0xDC00),illegal);
         TEST_TO(make4(0xDFFF),illegal);
 
-        std::cout <<"-- Incomplete" << std::endl;
+        std::cout << "-- Incomplete" << std::endl;
 
         TEST_TO("\x80",illegal);
         TEST_TO("\xC2",incomplete);

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -91,7 +91,7 @@ int main()
     try {
         using namespace boost::locale::util;
 
-        std::cout << "Test UTF-8" << std::endl;
+        std::cout << "Test UTF-8\n";
         std::cout << "- From UTF-8" << std::endl;
 
 
@@ -200,7 +200,7 @@ int main()
         TEST_TO("\xf4\x8f",incomplete);
         TEST_TO("\xf4",incomplete);
 
-        std::cout << "- To UTF-8" << std::endl;
+        std::cout << "- To UTF-8\n";
 
         std::cout << "-- Test correct" << std::endl;
 

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -86,211 +86,203 @@ void test_shiftjis(boost::locale::util::base_converter* pcvt)
 }
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        using namespace boost::locale::util;
+    using namespace boost::locale::util;
 
-        std::cout << "Test UTF-8\n";
-        std::cout << "- From UTF-8" << std::endl;
-
-
-        #ifndef BOOST_NO_CXX11_SMART_PTR
-        std::unique_ptr<base_converter> cvt = create_utf8_converter_unique_ptr();
-        #elif BOOST_LOCALE_USE_AUTO_PTR
-        std::auto_ptr<base_converter> cvt = create_utf8_converter();
-        #else
-        boost::locale::hold_ptr<base_converter> cvt(create_utf8_converter_new_ptr());
-        #endif
-
-        TEST(cvt.get());
-        TEST(cvt->is_thread_safe());
-        TEST(cvt->max_len() == 4);
-
-        std::cout << "-- Correct" << std::endl;
-
-        TEST_TO("\x7f",0x7f);
-        TEST_TO("\xC2\x80",0x80);
-        TEST_TO("\xdf\xBF",0x7FF);
-        TEST_TO("\xe0\xa0\x80",0x800);
-        TEST_TO("\xef\xbf\xbf",0xFFFF);
-        TEST_TO("\xf0\x90\x80\x80",0x10000);
-        TEST_TO("\xf4\x8f\xbf\xbf",0x10FFFF);
-
-        std::cout << "-- Too big" << std::endl;
-        TEST_TO("\xf4\x9f\x80\x80",illegal); //  11 0000
-        TEST_TO("\xfb\xbf\xbf\xbf",illegal); // 3FF FFFF
-        TEST_TO("\xf8\x90\x80\x80\x80",illegal);  // 400 0000
-        TEST_TO("\xfd\xbf\xbf\xbf\xbf\xbf",illegal);  // 7fff ffff
-
-        std::cout << "-- Invalid trail" << std::endl;
-        TEST_TO("\xC2\x7F",illegal);
-        TEST_TO("\xdf\x7F",illegal);
-        TEST_TO("\xe0\x7F\x80",illegal);
-        TEST_TO("\xef\xbf\x7F",illegal);
-        TEST_TO("\xe0\x7F\x80",illegal);
-        TEST_TO("\xef\xbf\x7F",illegal);
-        TEST_TO("\xf0\x7F\x80\x80",illegal);
-        TEST_TO("\xf4\x7f\xbf\xbf",illegal);
-        TEST_TO("\xf0\x90\x7F\x80",illegal);
-        TEST_TO("\xf4\x8f\x7F\xbf",illegal);
-        TEST_TO("\xf0\x90\x80\x7F",illegal);
-        TEST_TO("\xf4\x8f\xbf\x7F",illegal);
-
-        std::cout << "-- Invalid length" << std::endl;
-
-        /// Test that this actually works
-        TEST_TO(make2(0x80),0x80);
-        TEST_TO(make2(0x7ff),0x7ff);
-
-        TEST_TO(make3(0x800),0x800);
-        TEST_TO(make3(0xffff),0xffff);
-
-        TEST_TO(make4(0x10000),0x10000);
-        TEST_TO(make4(0x10ffff),0x10ffff);
-
-        TEST_TO(make4(0x110000),illegal);
-        TEST_TO(make4(0x1fffff),illegal);
-
-        TEST_TO(make2(0),illegal);
-        TEST_TO(make3(0),illegal);
-        TEST_TO(make4(0),illegal);
-        TEST_TO(make2(0x7f),illegal);
-        TEST_TO(make3(0x7f),illegal);
-        TEST_TO(make4(0x7f),illegal);
-
-        TEST_TO(make3(0x80),illegal);
-        TEST_TO(make4(0x80),illegal);
-        TEST_TO(make3(0x7ff),illegal);
-        TEST_TO(make4(0x7ff),illegal);
-
-        TEST_TO(make4(0x8000),illegal);
-        TEST_TO(make4(0xffff),illegal);
-
-        std::cout << "-- Invalid surrogate" << std::endl;
-
-        TEST_TO(make3(0xD800),illegal);
-        TEST_TO(make3(0xDBFF),illegal);
-        TEST_TO(make3(0xDC00),illegal);
-        TEST_TO(make3(0xDFFF),illegal);
-
-        TEST_TO(make4(0xD800),illegal);
-        TEST_TO(make4(0xDBFF),illegal);
-        TEST_TO(make4(0xDC00),illegal);
-        TEST_TO(make4(0xDFFF),illegal);
-
-        std::cout << "-- Incomplete" << std::endl;
-
-        TEST_TO("\x80",illegal);
-        TEST_TO("\xC2",incomplete);
-
-        TEST_TO("\xdf",incomplete);
-
-        TEST_TO("\xe0",incomplete);
-        TEST_TO("\xe0\xa0",incomplete);
-
-        TEST_TO("\xef\xbf",incomplete);
-        TEST_TO("\xef",incomplete);
-
-        TEST_TO("\xf0\x90\x80",incomplete);
-        TEST_TO("\xf0\x90",incomplete);
-        TEST_TO("\xf0",incomplete);
-
-        TEST_TO("\xf4\x8f\xbf",incomplete);
-        TEST_TO("\xf4\x8f",incomplete);
-        TEST_TO("\xf4",incomplete);
-
-        std::cout << "- To UTF-8\n";
-
-        std::cout << "-- Test correct" << std::endl;
-
-        TEST_FROM("\x7f",0x7f);
-        TEST_FROM("\xC2\x80",0x80);
-        TEST_FROM("\xdf\xBF",0x7FF);
-        TEST_INC(0x7FF,1);
-        TEST_FROM("\xe0\xa0\x80",0x800);
-        TEST_INC(0x800,2);
-        TEST_INC(0x800,1);
-        TEST_FROM("\xef\xbf\xbf",0xFFFF);
-        TEST_INC(0x10000,3);
-        TEST_INC(0x10000,2);
-        TEST_INC(0x10000,1);
-        TEST_FROM("\xf0\x90\x80\x80",0x10000);
-        TEST_FROM("\xf4\x8f\xbf\xbf",0x10FFFF);
-
-        std::cout << "-- Test no surrogate " << std::endl;
-
-        TEST_FROM(0,0xD800);
-        TEST_FROM(0,0xDBFF);
-        TEST_FROM(0,0xDC00);
-        TEST_FROM(0,0xDFFF);
-
-        std::cout << "-- Test invalid " << std::endl;
-
-        TEST_FROM(0,0x110000);
-        TEST_FROM(0,0x1FFFFF);
+    std::cout << "Test UTF-8\n";
+    std::cout << "- From UTF-8" << std::endl;
 
 
-        std::cout << "Test windows-1255" << std::endl;
+    #ifndef BOOST_NO_CXX11_SMART_PTR
+    std::unique_ptr<base_converter> cvt = create_utf8_converter_unique_ptr();
+    #elif BOOST_LOCALE_USE_AUTO_PTR
+    std::auto_ptr<base_converter> cvt = create_utf8_converter();
+    #else
+    boost::locale::hold_ptr<base_converter> cvt(create_utf8_converter_new_ptr());
+    #endif
 
-        #ifndef BOOST_NO_CXX11_SMART_PTR
-        cvt = create_simple_converter_unique_ptr("windows-1255");
-        #elif BOOST_LOCALE_USE_AUTO_PTR
-        cvt = create_simple_converter("windows-1255");
-        #else
-        cvt.reset(create_simple_converter_new_ptr("windows-1255"));
-        #endif
+    TEST(cvt.get());
+    TEST(cvt->is_thread_safe());
+    TEST(cvt->max_len() == 4);
 
-        TEST(cvt.get());
-        TEST(cvt->is_thread_safe());
-        TEST(cvt->max_len() == 1);
+    std::cout << "-- Correct" << std::endl;
 
-        std::cout << "- From 1255" << std::endl;
+    TEST_TO("\x7f",0x7f);
+    TEST_TO("\xC2\x80",0x80);
+    TEST_TO("\xdf\xBF",0x7FF);
+    TEST_TO("\xe0\xa0\x80",0x800);
+    TEST_TO("\xef\xbf\xbf",0xFFFF);
+    TEST_TO("\xf0\x90\x80\x80",0x10000);
+    TEST_TO("\xf4\x8f\xbf\xbf",0x10FFFF);
 
-        TEST_TO("\xa4",0x20aa);
-        TEST_TO("\xe0",0x05d0);
-        TEST_TO("\xc4",0x5b4);
-        TEST_TO("\xfb",illegal);
-        TEST_TO("\xdd",illegal);
-        TEST_TO("\xff",illegal);
-        TEST_TO("\xfe",0x200f);
+    std::cout << "-- Too big" << std::endl;
+    TEST_TO("\xf4\x9f\x80\x80",illegal); //  11 0000
+    TEST_TO("\xfb\xbf\xbf\xbf",illegal); // 3FF FFFF
+    TEST_TO("\xf8\x90\x80\x80\x80",illegal);  // 400 0000
+    TEST_TO("\xfd\xbf\xbf\xbf\xbf\xbf",illegal);  // 7fff ffff
 
-        std::cout << "- To 1255" << std::endl;
+    std::cout << "-- Invalid trail" << std::endl;
+    TEST_TO("\xC2\x7F",illegal);
+    TEST_TO("\xdf\x7F",illegal);
+    TEST_TO("\xe0\x7F\x80",illegal);
+    TEST_TO("\xef\xbf\x7F",illegal);
+    TEST_TO("\xe0\x7F\x80",illegal);
+    TEST_TO("\xef\xbf\x7F",illegal);
+    TEST_TO("\xf0\x7F\x80\x80",illegal);
+    TEST_TO("\xf4\x7f\xbf\xbf",illegal);
+    TEST_TO("\xf0\x90\x7F\x80",illegal);
+    TEST_TO("\xf4\x8f\x7F\xbf",illegal);
+    TEST_TO("\xf0\x90\x80\x7F",illegal);
+    TEST_TO("\xf4\x8f\xbf\x7F",illegal);
 
-        TEST_FROM("\xa4",0x20aa);
-        TEST_FROM("\xe0",0x05d0);
-        TEST_FROM("\xc4",0x5b4);
-        TEST_FROM("\xfe",0x200f);
+    std::cout << "-- Invalid length" << std::endl;
 
-        TEST_FROM(0,0xe4);
-        TEST_FROM(0,0xd0);
+    /// Test that this actually works
+    TEST_TO(make2(0x80),0x80);
+    TEST_TO(make2(0x7ff),0x7ff);
 
-        #ifdef BOOST_LOCALE_WITH_ICU
-        std::cout << "Testing Shift-JIS using ICU/uconv" << std::endl;
+    TEST_TO(make3(0x800),0x800);
+    TEST_TO(make3(0xffff),0xffff);
 
-        cvt.reset(boost::locale::impl_icu::create_uconv_converter("Shift-JIS"));
-        TEST(cvt.get());
+    TEST_TO(make4(0x10000),0x10000);
+    TEST_TO(make4(0x10ffff),0x10ffff);
+
+    TEST_TO(make4(0x110000),illegal);
+    TEST_TO(make4(0x1fffff),illegal);
+
+    TEST_TO(make2(0),illegal);
+    TEST_TO(make3(0),illegal);
+    TEST_TO(make4(0),illegal);
+    TEST_TO(make2(0x7f),illegal);
+    TEST_TO(make3(0x7f),illegal);
+    TEST_TO(make4(0x7f),illegal);
+
+    TEST_TO(make3(0x80),illegal);
+    TEST_TO(make4(0x80),illegal);
+    TEST_TO(make3(0x7ff),illegal);
+    TEST_TO(make4(0x7ff),illegal);
+
+    TEST_TO(make4(0x8000),illegal);
+    TEST_TO(make4(0xffff),illegal);
+
+    std::cout << "-- Invalid surrogate" << std::endl;
+
+    TEST_TO(make3(0xD800),illegal);
+    TEST_TO(make3(0xDBFF),illegal);
+    TEST_TO(make3(0xDC00),illegal);
+    TEST_TO(make3(0xDFFF),illegal);
+
+    TEST_TO(make4(0xD800),illegal);
+    TEST_TO(make4(0xDBFF),illegal);
+    TEST_TO(make4(0xDC00),illegal);
+    TEST_TO(make4(0xDFFF),illegal);
+
+    std::cout << "-- Incomplete" << std::endl;
+
+    TEST_TO("\x80",illegal);
+    TEST_TO("\xC2",incomplete);
+
+    TEST_TO("\xdf",incomplete);
+
+    TEST_TO("\xe0",incomplete);
+    TEST_TO("\xe0\xa0",incomplete);
+
+    TEST_TO("\xef\xbf",incomplete);
+    TEST_TO("\xef",incomplete);
+
+    TEST_TO("\xf0\x90\x80",incomplete);
+    TEST_TO("\xf0\x90",incomplete);
+    TEST_TO("\xf0",incomplete);
+
+    TEST_TO("\xf4\x8f\xbf",incomplete);
+    TEST_TO("\xf4\x8f",incomplete);
+    TEST_TO("\xf4",incomplete);
+
+    std::cout << "- To UTF-8\n";
+
+    std::cout << "-- Test correct" << std::endl;
+
+    TEST_FROM("\x7f",0x7f);
+    TEST_FROM("\xC2\x80",0x80);
+    TEST_FROM("\xdf\xBF",0x7FF);
+    TEST_INC(0x7FF,1);
+    TEST_FROM("\xe0\xa0\x80",0x800);
+    TEST_INC(0x800,2);
+    TEST_INC(0x800,1);
+    TEST_FROM("\xef\xbf\xbf",0xFFFF);
+    TEST_INC(0x10000,3);
+    TEST_INC(0x10000,2);
+    TEST_INC(0x10000,1);
+    TEST_FROM("\xf0\x90\x80\x80",0x10000);
+    TEST_FROM("\xf4\x8f\xbf\xbf",0x10FFFF);
+
+    std::cout << "-- Test no surrogate " << std::endl;
+
+    TEST_FROM(0,0xD800);
+    TEST_FROM(0,0xDBFF);
+    TEST_FROM(0,0xDC00);
+    TEST_FROM(0,0xDFFF);
+
+    std::cout << "-- Test invalid " << std::endl;
+
+    TEST_FROM(0,0x110000);
+    TEST_FROM(0,0x1FFFFF);
+
+
+    std::cout << "Test windows-1255" << std::endl;
+
+    #ifndef BOOST_NO_CXX11_SMART_PTR
+    cvt = create_simple_converter_unique_ptr("windows-1255");
+    #elif BOOST_LOCALE_USE_AUTO_PTR
+    cvt = create_simple_converter("windows-1255");
+    #else
+    cvt.reset(create_simple_converter_new_ptr("windows-1255"));
+    #endif
+
+    TEST(cvt.get());
+    TEST(cvt->is_thread_safe());
+    TEST(cvt->max_len() == 1);
+
+    std::cout << "- From 1255" << std::endl;
+
+    TEST_TO("\xa4",0x20aa);
+    TEST_TO("\xe0",0x05d0);
+    TEST_TO("\xc4",0x5b4);
+    TEST_TO("\xfb",illegal);
+    TEST_TO("\xdd",illegal);
+    TEST_TO("\xff",illegal);
+    TEST_TO("\xfe",0x200f);
+
+    std::cout << "- To 1255" << std::endl;
+
+    TEST_FROM("\xa4",0x20aa);
+    TEST_FROM("\xe0",0x05d0);
+    TEST_FROM("\xc4",0x5b4);
+    TEST_FROM("\xfe",0x200f);
+
+    TEST_FROM(0,0xe4);
+    TEST_FROM(0,0xd0);
+
+    #ifdef BOOST_LOCALE_WITH_ICU
+    std::cout << "Testing Shift-JIS using ICU/uconv" << std::endl;
+
+    cvt.reset(boost::locale::impl_icu::create_uconv_converter("Shift-JIS"));
+    TEST(cvt.get());
+    test_shiftjis(cvt.release());
+    #endif
+
+    #if defined(BOOST_LOCALE_WITH_ICONV) && !defined(BOOST_LOCALE_NO_POSIX_BACKEND)
+    std::cout << "Testing Shift-JIS using POSIX/iconv" << std::endl;
+
+    cvt.reset(boost::locale::impl_posix::create_iconv_converter("Shift-JIS"));
+    if(cvt.get()) {
         test_shiftjis(cvt.release());
-        #endif
-
-        #if defined(BOOST_LOCALE_WITH_ICONV) && !defined(BOOST_LOCALE_NO_POSIX_BACKEND)
-        std::cout << "Testing Shift-JIS using POSIX/iconv" << std::endl;
-
-        cvt.reset(boost::locale::impl_posix::create_iconv_converter("Shift-JIS"));
-        if(cvt.get()) {
-            test_shiftjis(cvt.release());
-        }
-        else {
-            std::cout<< "- Shift-JIS is not supported!" << std::endl;
-        }
-        #endif
-
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
+    else {
+        std::cout<< "- Shift-JIS is not supported!" << std::endl;
     }
-    FINALIZE();
+    #endif
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_collate.cpp
+++ b/test/test_collate.cpp
@@ -121,17 +121,9 @@ void test_collate()
 
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        test_collate();
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    test_collate();
 }
 
 #endif // NOICU

--- a/test/test_collate.cpp
+++ b/test/test_collate.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "ICU is not build... Skipping" << std::endl;
+        std::cout << "ICU is not build... Skipping\n";
 }
 #else
 

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -78,15 +78,15 @@ int main()
     std::cout << "- Without iconv" << std::endl;
     #endif
     std::cout << "- Environment " << std::endl;
-    std::cout << "  LANG="<< env("LANG") << std::endl;
-    std::cout << "  LC_ALL="<< env("LC_ALL") << std::endl;
-    std::cout << "  LC_CTYPE="<< env("LC_CTYPE") << std::endl;
-    std::cout << "  TZ="<< env("TZ") << std::endl;
+    std::cout << "  LANG=" << env("LANG") << std::endl;
+    std::cout << "  LC_ALL=" << env("LC_ALL") << std::endl;
+    std::cout << "  LC_CTYPE=" << env("LC_CTYPE") << std::endl;
+    std::cout << "  TZ=" << env("TZ") << std::endl;
 
     char const *clocale=setlocale(LC_ALL,"");
     if(!clocale)
         clocale= "undetected";
-    std::cout <<"- C locale: " << clocale << std::endl;
+    std::cout << "- C locale: " << clocale << std::endl;
 
     try {
         std::locale loc("");

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -85,7 +85,7 @@ int main()
 
     char const *clocale=setlocale(LC_ALL,"");
     if(!clocale)
-        clocale= "undetected";
+        clocale= "undetected"; // LCOV_EXCL_LINE
     std::cout << "- C locale: " << clocale << std::endl;
 
     try {
@@ -97,7 +97,7 @@ int main()
 #endif
     }
     catch(std::exception const &) {
-        std::cout << "- C++ locale: is not supported\n";
+        std::cout << "- C++ locale: is not supported\n"; // LCOV_EXCL_LINE
     }
 
     char const *locales_to_check[] = {
@@ -129,11 +129,10 @@ int main()
         std::cout << std::use_facet<boost::locale::info>(l).name() << std::endl;
     }
     catch(std::exception const &) {
-        std::cout << " undetected\n";
-        return EXIT_FAILURE;
+        std::cout << " undetected\n"; // LCOV_EXCL_LINE
+        return EXIT_FAILURE;          // LCOV_EXCL_LINE
     }
     return EXIT_SUCCESS;
-
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -35,7 +35,7 @@ char const *env(char const *s)
 
 void check_locale(char const **names)
 {
-    std::cout << "  " << std::setw(32) << "locale" << std::setw(4) << "C" << std::setw(4) << "C++" << std::endl;
+    std::cout << "  " << std::setw(32) << "locale" << std::setw(4) << "C" << std::setw(4) << "C++\n";
     while(*names) {
         char const *name = *names;
         std::cout << "  " << std::setw(32) << name << std::setw(4);
@@ -73,11 +73,11 @@ int main()
     #endif
     std::cout << std::endl;
     #ifdef BOOST_LOCALE_WITH_ICONV
-    std::cout << "- With iconv" << std::endl;
+    std::cout << "- With iconv\n";
     #else
-    std::cout << "- Without iconv" << std::endl;
+    std::cout << "- Without iconv\n";
     #endif
-    std::cout << "- Environment " << std::endl;
+    std::cout << "- Environment \n";
     std::cout << "  LANG=" << env("LANG") << std::endl;
     std::cout << "  LC_ALL=" << env("LC_ALL") << std::endl;
     std::cout << "  LC_CTYPE=" << env("LC_CTYPE") << std::endl;
@@ -91,13 +91,13 @@ int main()
     try {
         std::locale loc("");
 #if defined(BOOST_CLANG) && BOOST_CLANG_VERSION < 30800
-        std::cout << "- C++ locale: n/a on Clang < 3.8" << std::endl;
+        std::cout << "- C++ locale: n/a on Clang < 3.8\n";
 #else
         std::cout << "- C++ locale: " << loc.name() << std::endl;
 #endif
     }
     catch(std::exception const &) {
-        std::cout << "- C++ locale: is not supported" << std::endl;
+        std::cout << "- C++ locale: is not supported\n";
     }
 
     char const *locales_to_check[] = {
@@ -129,7 +129,7 @@ int main()
         std::cout << std::use_facet<boost::locale::info>(l).name() << std::endl;
     }
     catch(std::exception const &) {
-        std::cout << " undetected" << std::endl;
+        std::cout << " undetected\n";
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "ICU is not build... Skipping" << std::endl;
+        std::cout << "ICU is not build... Skipping\n";
 }
 #else
 

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -68,59 +68,51 @@ void test_norm(std::string orig,std::string normal,boost::locale::norm_type type
         }while(0)
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        {
-            using namespace boost::locale;
-            std::cout << "Testing Unicode normalization" << std::endl;
-            test_norm("\xEF\xAC\x81","\xEF\xAC\x81",norm_nfd); /// ligature fi
-            test_norm("\xEF\xAC\x81","\xEF\xAC\x81",norm_nfc);
-            test_norm("\xEF\xAC\x81","fi",norm_nfkd);
-            test_norm("\xEF\xAC\x81","fi",norm_nfkc);
-            test_norm("ä","ä",norm_nfd); // ä to a and accent
-            test_norm("ä","ä",norm_nfc);
-        }
-
-        boost::locale::generator gen;
-        bool eight_bit=true;
-
-        #define TEST_V(how,source_s,dest_s)                                    \
-        do {                                                                \
-            TEST_A(char,how,source_s,dest_s);                                \
-            if(eight_bit) {                                                    \
-                std::locale tmp=std::locale();                                \
-                std::locale::global(gen("en_US.ISO8859-1"));                \
-                TEST_A(char,how,to<char>(source_s),to<char>(dest_s));        \
-                std::locale::global(tmp);                                    \
-            }                                                                \
-        }while(0)
-
-        TEST_ALL_CASES;
-        #undef TEST_V
-
-        #define TEST_V(how,source_s,dest_s) TEST_A(wchar_t,how,to<wchar_t>(source_s),to<wchar_t>(dest_s))
-        TEST_ALL_CASES;
-        #undef TEST_V
-
-        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        #define TEST_V(how,source_s,dest_s) TEST_A(char16_t,how,to<char16_t>(source_s),to<char16_t>(dest_s))
-        TEST_ALL_CASES;
-        #undef TEST_V
-        #endif
-
-        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        #define TEST_V(how,source_s,dest_s) TEST_A(char32_t,how,to<char32_t>(source_s),to<char32_t>(dest_s))
-        TEST_ALL_CASES;
-        #undef TEST_V
-        #endif
+    {
+        using namespace boost::locale;
+        std::cout << "Testing Unicode normalization" << std::endl;
+        test_norm("\xEF\xAC\x81","\xEF\xAC\x81",norm_nfd); /// ligature fi
+        test_norm("\xEF\xAC\x81","\xEF\xAC\x81",norm_nfc);
+        test_norm("\xEF\xAC\x81","fi",norm_nfkd);
+        test_norm("\xEF\xAC\x81","fi",norm_nfkc);
+        test_norm("ä","ä",norm_nfd); // ä to a and accent
+        test_norm("ä","ä",norm_nfc);
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
 
+    boost::locale::generator gen;
+    bool eight_bit=true;
+
+    #define TEST_V(how,source_s,dest_s)                            \
+    do {                                                           \
+        TEST_A(char,how,source_s,dest_s);                          \
+        if(eight_bit) {                                            \
+            std::locale tmp=std::locale();                         \
+            std::locale::global(gen("en_US.ISO8859-1"));           \
+            TEST_A(char,how,to<char>(source_s),to<char>(dest_s));  \
+            std::locale::global(tmp);                              \
+        }                                                          \
+    }while(0)
+
+    TEST_ALL_CASES;
+    #undef TEST_V
+
+    #define TEST_V(how,source_s,dest_s) TEST_A(wchar_t,how,to<wchar_t>(source_s),to<wchar_t>(dest_s))
+    TEST_ALL_CASES;
+    #undef TEST_V
+
+    #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    #define TEST_V(how,source_s,dest_s) TEST_A(char16_t,how,to<char16_t>(source_s),to<char16_t>(dest_s))
+    TEST_ALL_CASES;
+    #undef TEST_V
+    #endif
+
+    #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    #define TEST_V(how,source_s,dest_s) TEST_A(char32_t,how,to<char32_t>(source_s),to<char32_t>(dest_s))
+    TEST_ALL_CASES;
+    #undef TEST_V
+    #endif
 }
 #endif // NO ICU
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -42,29 +42,29 @@ void test_norm(std::string orig,std::string normal,boost::locale::norm_type type
 }
 
 #define TEST_A(Chr,how,source,dest)                                                            \
-    do {                                                                                    \
-        boost::locale::info const &inf=std::use_facet<boost::locale::info>(std::locale());    \
-        std::cout <<"Testing " #how " for " #Chr ", lang="<<inf.language();                    \
-        if(std::string("char")==#Chr) std::cout <<" charset="<<    inf.encoding();                \
+    do {                                                                                       \
+        boost::locale::info const &inf=std::use_facet<boost::locale::info>(std::locale());     \
+        std::cout << "Testing " #how " for " #Chr ", lang=" << inf.language();                 \
+        if(std::string("char")==#Chr) std::cout << " charset=" <<    inf.encoding();           \
         std::cout << std::endl;                                                                \
         std::basic_string<Chr> source_s=(source),dest_s=(dest);                                \
         TEST(boost::locale::how(source_s)==dest_s);                                            \
         TEST(boost::locale::how(source_s.c_str())==dest_s);                                    \
-        TEST(boost::locale::how(source_s.c_str(),source_s.c_str()+source_s.size())==dest_s);\
+        TEST(boost::locale::how(source_s.c_str(),source_s.c_str()+source_s.size())==dest_s);   \
     }while(0)
 
-#define TEST_ALL_CASES                                        \
+#define TEST_ALL_CASES                                      \
         do {                                                \
-            eight_bit=true;                                    \
+            eight_bit=true;                                 \
             std::locale::global(gen("en_US.UTF-8"));        \
             TEST_V(to_upper,"grüßen i","GRÜSSEN I");        \
-            TEST_V(to_lower,"Façade","façade");                \
-            TEST_V(to_title,"façadE world","Façade World");    \
-            TEST_V(fold_case,"Hello World","hello world");    \
+            TEST_V(to_lower,"Façade","façade");             \
+            TEST_V(to_title,"façadE world","Façade World"); \
+            TEST_V(fold_case,"Hello World","hello world");  \
             std::locale::global(gen("tr_TR.UTF-8"));        \
             eight_bit=false;                                \
-            TEST_V(to_upper,"i","İ");                        \
-            TEST_V(to_lower,"İ","i");                        \
+            TEST_V(to_upper,"i","İ");                       \
+            TEST_V(to_lower,"İ","i");                       \
         }while(0)
 
 

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -27,7 +27,14 @@
 #define RESET() do { time_point = base_time_point; ss.str(""); } while(0)
 #define TESTR(X) do { TEST(X); RESET(); } while(0)
 //#define TESTEQSR(t,X) do { ss << (t); TESTR(ss.str() == X); } while(0)
-#define TESTEQSR(t,X) do { ss << (t); if(ss.str()!=X) { std::cerr <<"[" << ss.str() <<"]!=[" <<X<<"]" << std::endl; } TESTR(ss.str() == X); } while(0)
+#define TESTEQSR(t,X)                                                        \
+    do {                                                                     \
+        ss << (t);                                                            \
+        if(ss.str()!=X) {                                                     \
+            std::cerr << "[" << ss.str() << "]!=[" << X << "]" << std::endl;  \
+        }                                                                     \
+        TESTR(ss.str() == X);                                                 \
+    } while(0)
 
 int main()
 {
@@ -85,7 +92,7 @@ int main()
 
                 std::ostringstream ss;
                 ss.imbue(loc);
-                ss<<boost::locale::as::time_zone(tz);
+                ss << boost::locale::as::time_zone(tz);
 
                 date_time time_point;
 

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -36,274 +36,265 @@
         TESTR(ss.str() == X);                                                 \
     } while(0)
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        using namespace boost::locale;
-        using namespace boost::locale::period;
-        std::string def[] = {
-        #ifdef BOOST_LOCALE_WITH_ICU
-            "icu" ,
-        #endif
-        #ifndef BOOST_LOCALE_NO_STD_BACKEND
-            "std" ,
-        #endif
-        #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-            "posix",
-        #endif
-        #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-            "winapi",
-        #endif
-        };
-        for(int type = 0 ; type < int(sizeof(def)/sizeof(def[0])) ; type ++ ) {
-            boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
-            tmp_backend.select(def[type]);
-            boost::locale::localization_backend_manager::global(tmp_backend);
-            std::cout << "Testing for backend: " << def[type] << std::endl;
-            std::string backend_name = def[type];
-            {
+    using namespace boost::locale;
+    using namespace boost::locale::period;
+    std::string def[] = {
+    #ifdef BOOST_LOCALE_WITH_ICU
+        "icu" ,
+    #endif
+    #ifndef BOOST_LOCALE_NO_STD_BACKEND
+        "std" ,
+    #endif
+    #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
+        "posix",
+    #endif
+    #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
+        "winapi",
+    #endif
+    };
+    for(int type = 0 ; type < int(sizeof(def)/sizeof(def[0])) ; type ++ ) {
+        boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
+        tmp_backend.select(def[type]);
+        boost::locale::localization_backend_manager::global(tmp_backend);
+        std::cout << "Testing for backend: " << def[type] << std::endl;
+        std::string backend_name = def[type];
+        {
 
-                boost::locale::generator g;
+            boost::locale::generator g;
 
-                std::locale loc=g("en_US.UTF-8");
+            std::locale loc=g("en_US.UTF-8");
 
-                std::locale::global(loc);
+            std::locale::global(loc);
 
-                std::string tz("GMT");
-                time_zone::global(tz);
-                calendar cal(loc,tz);
+            std::string tz("GMT");
+            time_zone::global(tz);
+            calendar cal(loc,tz);
 
-                TEST(calendar() == cal);
-                TEST(calendar(loc) == cal);
-                TEST(calendar(tz) == cal);
-                TEST(calendar(loc,"GMT+01:00") != cal);
-                TEST(calendar(g("ru_RU.UTF-8")) != cal);
+            TEST(calendar() == cal);
+            TEST(calendar(loc) == cal);
+            TEST(calendar(tz) == cal);
+            TEST(calendar(loc,"GMT+01:00") != cal);
+            TEST(calendar(g("ru_RU.UTF-8")) != cal);
 
-                TEST(cal.minimum(month())==0);
-                TEST(cal.maximum(month())==11);
-                TEST(cal.minimum(day())==1);
-                TEST(cal.greatest_minimum(day())==1);
-                TEST(cal.least_maximum(day())==28);
-                TEST(cal.maximum(day())==31);
+            TEST(cal.minimum(month())==0);
+            TEST(cal.maximum(month())==11);
+            TEST(cal.minimum(day())==1);
+            TEST(cal.greatest_minimum(day())==1);
+            TEST(cal.least_maximum(day())==28);
+            TEST(cal.maximum(day())==31);
 
-                TEST(calendar(g("ar_EG.UTF-8")).first_day_of_week() == 7);
-                TEST(calendar(g("he_IL.UTF-8")).first_day_of_week() == 1);
-                TEST(calendar(g("ru_RU.UTF-8")).first_day_of_week() == 2);
+            TEST(calendar(g("ar_EG.UTF-8")).first_day_of_week() == 7);
+            TEST(calendar(g("he_IL.UTF-8")).first_day_of_week() == 1);
+            TEST(calendar(g("ru_RU.UTF-8")).first_day_of_week() == 2);
 
-                std::ostringstream ss;
-                ss.imbue(loc);
-                ss << boost::locale::as::time_zone(tz);
+            std::ostringstream ss;
+            ss.imbue(loc);
+            ss << boost::locale::as::time_zone(tz);
 
-                date_time time_point;
+            date_time time_point;
 
-                time_point=year(1970) + february() + day(5);
+            time_point=year(1970) + february() + day(5);
 
-                ss << as::ftime("%Y-%m-%d")<< time_point;
+            ss << as::ftime("%Y-%m-%d")<< time_point;
 
-                TEST(ss.str() == "1970-02-05");
-                time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second();
-                ss.str("");
-                ss << as::ftime("%Y-%m-%d %H:%M:%S") << time_point;
-                TEST( ss.str() == "1970-02-05 15:33:13"); ss.str("");
+            TEST(ss.str() == "1970-02-05");
+            time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second();
+            ss.str("");
+            ss << as::ftime("%Y-%m-%d %H:%M:%S") << time_point;
+            TEST( ss.str() == "1970-02-05 15:33:13"); ss.str("");
 
-                time_t a_date = 3600*24*(31+4); // Feb 5th
-                time_t a_time = 3600*15+60*33; // 15:33:05
-                time_t a_timesec = 13;
-                time_t a_datetime = a_date + a_time + a_timesec;
+            time_t a_date = 3600*24*(31+4); // Feb 5th
+            time_t a_time = 3600*15+60*33; // 15:33:05
+            time_t a_timesec = 13;
+            time_t a_datetime = a_date + a_time + a_timesec;
 
-                date_time base_time_point=date_time(a_datetime);
+            date_time base_time_point=date_time(a_datetime);
 
-                RESET();
+            RESET();
 
-                time_point += hour();
-                TESTEQSR(time_point,"1970-02-05 16:33:13");
+            time_point += hour();
+            TESTEQSR(time_point,"1970-02-05 16:33:13");
 
-                TEST(time_point.minimum(day())==1);
-                TEST(time_point.maximum(day())==28);
+            TEST(time_point.minimum(day())==1);
+            TEST(time_point.maximum(day())==28);
 
-                time_point += year() * 2 + 1 *month();
-                TESTEQSR(time_point,"1972-03-05 15:33:13");
+            time_point += year() * 2 + 1 *month();
+            TESTEQSR(time_point,"1972-03-05 15:33:13");
 
-                time_point -= minute();
-                TESTEQSR( time_point, "1970-02-05 15:32:13");
+            time_point -= minute();
+            TESTEQSR( time_point, "1970-02-05 15:32:13");
 
-                time_point <<= minute() * 30;
-                TESTEQSR( time_point, "1970-02-05 15:03:13");
+            time_point <<= minute() * 30;
+            TESTEQSR( time_point, "1970-02-05 15:03:13");
 
-                time_point >>= minute(40);
-                TESTEQSR( time_point, "1970-02-05 15:53:13");
+            time_point >>= minute(40);
+            TESTEQSR( time_point, "1970-02-05 15:53:13");
 
-                TEST((time_point + month()) / month() == 2);
-                TEST(month(time_point + month(1)) == 2);
-                TEST(time_point / month() == 1);
-                TEST((time_point - month()) / month()== 0);
-                TEST(time_point / month() == 1);
-                TEST((time_point << month()) / month()== 2);
-                TEST(time_point / month()== 1);
-                TEST((time_point >> month()) / month()== 0);
-                TEST(time_point / month()== 1);
-
+            TEST((time_point + month()) / month() == 2);
+            TEST(month(time_point + month(1)) == 2);
+            TEST(time_point / month() == 1);
+            TEST((time_point - month()) / month()== 0);
+            TEST(time_point / month() == 1);
+            TEST((time_point << month()) / month()== 2);
+            TEST(time_point / month()== 1);
+            TEST((time_point >> month()) / month()== 0);
+            TEST(time_point / month()== 1);
 
 
-                TEST( (time_point + 2 * hour() - time_point) / minute() == 120);
-                TEST( (time_point + month()- time_point) / day() == 28);
-                TEST( (time_point + 2* month()- (time_point+month())) / day() == 31);
-                TEST( day(time_point + 2* month()- (time_point+month())) == 31);
 
-                TESTEQSR( time_point + hour(), "1970-02-05 16:33:13");
-                TESTEQSR( time_point - hour(2), "1970-02-05 13:33:13");
-                TESTEQSR( time_point >> minute(), "1970-02-05 15:32:13");
-                TESTEQSR( time_point << second(), "1970-02-05 15:33:14");
+            TEST( (time_point + 2 * hour() - time_point) / minute() == 120);
+            TEST( (time_point + month()- time_point) / day() == 28);
+            TEST( (time_point + 2* month()- (time_point+month())) / day() == 31);
+            TEST( day(time_point + 2* month()- (time_point+month())) == 31);
 
-                TEST(time_point == time_point);
-                TEST(!(time_point != time_point));
-                TEST(time_point.get(hour()) == 15);
-                TEST(time_point/hour() == 15);
-                TEST(time_point+year() != time_point);
-                TEST(time_point - minute() <= time_point);
-                TEST(time_point <= time_point);
-                TEST(time_point + minute() >= time_point);
-                TEST(time_point >= time_point);
+            TESTEQSR( time_point + hour(), "1970-02-05 16:33:13");
+            TESTEQSR( time_point - hour(2), "1970-02-05 13:33:13");
+            TESTEQSR( time_point >> minute(), "1970-02-05 15:32:13");
+            TESTEQSR( time_point << second(), "1970-02-05 15:33:14");
 
-                TEST(time_point < time_point + second());
-                TEST(!(time_point < time_point - second()));
-                TEST(time_point > time_point - second());
-                TEST(!(time_point > time_point + second()));
+            TEST(time_point == time_point);
+            TEST(!(time_point != time_point));
+            TEST(time_point.get(hour()) == 15);
+            TEST(time_point/hour() == 15);
+            TEST(time_point+year() != time_point);
+            TEST(time_point - minute() <= time_point);
+            TEST(time_point <= time_point);
+            TEST(time_point + minute() >= time_point);
+            TEST(time_point >= time_point);
 
-                TEST(time_point.get(day()) == 5);
-                TEST(time_point.get(year()) == 1970);
+            TEST(time_point < time_point + second());
+            TEST(!(time_point < time_point - second()));
+            TEST(time_point > time_point - second());
+            TEST(!(time_point > time_point + second()));
 
-                TEST(time_point.get(era()) == 1);
-                TEST(time_point.get(year()) == 1970);
-                TEST(time_point.get(extended_year()) == 1970);
-                if(backend_name == "icu") {
-                    time_point=extended_year(-3);
-                    TEST(time_point.get(era()) == 0);
-                    TEST(time_point.get(year()) == 4);
-                }
-                RESET();
-                TEST(time_point.get(month()) == 1);
-                TEST(time_point.get(day()) == 5);
-                TEST(time_point.get(day_of_year()) == 36);
-                TEST(time_point.get(day_of_week()) == 5);
-                TEST(time_point.get(day_of_week_in_month())==1);
-                time_point=date_time(a_datetime,calendar(g("ru_RU.UTF-8")));
-                TEST(time_point.get(day_of_week_local()) == 4);
-                time_point = year(2026) + january() + day(1);
-                TEST(time_point.get(day_of_week()) == 5);
-                TEST(time_point.get(week_of_year()) == 1);
+            TEST(time_point.get(day()) == 5);
+            TEST(time_point.get(year()) == 1970);
+
+            TEST(time_point.get(era()) == 1);
+            TEST(time_point.get(year()) == 1970);
+            TEST(time_point.get(extended_year()) == 1970);
+            if(backend_name == "icu") {
+                time_point=extended_year(-3);
+                TEST(time_point.get(era()) == 0);
+                TEST(time_point.get(year()) == 4);
+            }
+            RESET();
+            TEST(time_point.get(month()) == 1);
+            TEST(time_point.get(day()) == 5);
+            TEST(time_point.get(day_of_year()) == 36);
+            TEST(time_point.get(day_of_week()) == 5);
+            TEST(time_point.get(day_of_week_in_month())==1);
+            time_point=date_time(a_datetime,calendar(g("ru_RU.UTF-8")));
+            TEST(time_point.get(day_of_week_local()) == 4);
+            time_point = year(2026) + january() + day(1);
+            TEST(time_point.get(day_of_week()) == 5);
+            TEST(time_point.get(week_of_year()) == 1);
+            TEST(time_point.get(week_of_month()) == 1);
+            time_point = day_of_week() * 1;
+            TEST(time_point.get(day()) == 4);
+            TEST(time_point.get(week_of_year()) == 1);
+            TEST(time_point.get(week_of_month()) == 1);
+            time_point += day() * 1;
+            TEST(time_point.get(week_of_year()) == 2);
+            TEST(time_point.get(week_of_month()) == 2);
+            time_point = february() + day() * 2;
+
+
+            TEST(time_point.get(week_of_year()) == 6);
+
+            if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
                 TEST(time_point.get(week_of_month()) == 1);
-                time_point = day_of_week() * 1;
-                TEST(time_point.get(day()) == 4);
-                TEST(time_point.get(week_of_year()) == 1);
-                TEST(time_point.get(week_of_month()) == 1);
-                time_point += day() * 1;
-                TEST(time_point.get(week_of_year()) == 2);
+            }
+            else {
+                // cldr changes
                 TEST(time_point.get(week_of_month()) == 2);
-                time_point = february() + day() * 2;
+            }
 
+            time_point = year(2010) + january() + day() * 3;
 
-                TEST(time_point.get(week_of_year()) == 6);
+            if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
+                TEST(time_point.get(week_of_year()) == 53);
+            }
+            else {
+                TEST(time_point.get(week_of_year()) == 1);
+            }
 
-                if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
-                    TEST(time_point.get(week_of_month()) == 1);
-                }
-                else {
-                    // cldr changes
-                    TEST(time_point.get(week_of_month()) == 2);
-                }
+            time_point = year()*2010 + january() + day() * 4;
 
-                time_point = year(2010) + january() + day() * 3;
+            if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
+                TEST(time_point.get(week_of_year()) == 1);
+            }
+            else {
+                TEST(time_point.get(week_of_year()) == 2);
+            }
+            time_point = year()*2010 + january() + day() * 10;
 
-                if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
-                    TEST(time_point.get(week_of_year()) == 53);
-                }
-                else {
-                    TEST(time_point.get(week_of_year()) == 1);
-                }
+            if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
+                TEST(time_point.get(week_of_year()) == 1);
+            }
+            else {
+                TEST(time_point.get(week_of_year()) == 2);
+            }
 
-                time_point = year()*2010 + january() + day() * 4;
+            time_point = year()*2010 + january() + day() * 11;
+            if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
+                TEST(time_point.get(week_of_year()) == 2);
+            }
+            else {
+                TEST(time_point.get(week_of_year()) == 3);
+            }
+            RESET();
+            TEST(time_point.get(hour()) == 15);
+            TEST(date_time(a_datetime,calendar("GMT+01:00")).get(hour()) ==16);
+            TEST(time_point.get(hour_12()) == 3);
+            TEST(time_point.get(am_pm()) == 1);
+            TEST(time_point.get(minute()) == 33);
+            TEST(time_point.get(second()) == 13);
+            TEST(date_time(year()* 1984 + february() + day()).get(week_of_year())==5);
+            TEST(time_point.get(week_of_month()) == 1);
+            RESET();
 
-                if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
-                    TEST(time_point.get(week_of_year()) == 1);
-                }
-                else {
-                    TEST(time_point.get(week_of_year()) == 2);
-                }
-                time_point = year()*2010 + january() + day() * 10;
+            // Make sure we don't get year() < 1970 so the test would
+            // work on windows where mktime supports positive time_t
+            // only
+            time_point = year() * 2010;
 
-                if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
-                    TEST(time_point.get(week_of_year()) == 1);
-                }
-                else {
-                    TEST(time_point.get(week_of_year()) == 2);
-                }
+            TEST((time_point + year() *1 - hour() * 1 - time_point) / year() == 0);
+            TEST((time_point + year() *1 - time_point) / year() == 1);
+            TEST((time_point + year() *1 + hour() * 1 - time_point) / year() == 1);
+            TEST((time_point - year() *1 + hour() * 1 - time_point) / year() == 0);
+            TEST((time_point - year() *1 - time_point) / year() == -1);
+            TEST((time_point - year() *1 - hour() * 1 - time_point) / year() == -1);
 
-                time_point = year()*2010 + january() + day() * 11;
-                if(backend_name!="icu" || BOOST_ICU_VER<408 || BOOST_ICU_VER > 6000) {
-                    TEST(time_point.get(week_of_year()) == 2);
-                }
-                else {
-                    TEST(time_point.get(week_of_year()) == 3);
-                }
-                RESET();
-                TEST(time_point.get(hour()) == 15);
-                TEST(date_time(a_datetime,calendar("GMT+01:00")).get(hour()) ==16);
-                TEST(time_point.get(hour_12()) == 3);
-                TEST(time_point.get(am_pm()) == 1);
-                TEST(time_point.get(minute()) == 33);
-                TEST(time_point.get(second()) == 13);
-                TEST(date_time(year()* 1984 + february() + day()).get(week_of_year())==5);
-                TEST(time_point.get(week_of_month()) == 1);
-                RESET();
+            RESET();
 
-                // Make sure we don't get year() < 1970 so the test would
-                // work on windows where mktime supports positive time_t
-                // only
-                time_point = year() * 2010;
+            time_point.time(24*3600 * 2);
 
-                TEST((time_point + year() *1 - hour() * 1 - time_point) / year() == 0);
-                TEST((time_point + year() *1 - time_point) / year() == 1);
-                TEST((time_point + year() *1 + hour() * 1 - time_point) / year() == 1);
-                TEST((time_point - year() *1 + hour() * 1 - time_point) / year() == 0);
-                TEST((time_point - year() *1 - time_point) / year() == -1);
-                TEST((time_point - year() *1 - hour() * 1 - time_point) / year() == -1);
+            time_point = year() * 2011;
+            time_point = march();
+            time_point = day() * 29;
 
-                RESET();
+            date_time tmp_save = time_point;
 
-                time_point.time(24*3600 * 2);
+            time_point = year() * 2011;
+            time_point = february();
+            time_point = day() * 5;
 
-                time_point = year() * 2011;
-                time_point = march();
-                time_point = day() * 29;
+            TEST(time_point.get(year()) == 2011);
+            TEST(time_point.get(month()) == 2); // march
+            TEST(time_point.get(day()) == 5);
 
-                date_time tmp_save = time_point;
+            time_point = tmp_save;
 
-                time_point = year() * 2011;
-                time_point = february();
-                time_point = day() * 5;
+            time_point = year() * 2011 + february() + day() * 5;
+            TEST(time_point.get(year()) == 2011);
+            TEST(time_point.get(month()) == 1); // february
+            TEST(time_point.get(day()) == 5);
 
-                TEST(time_point.get(year()) == 2011);
-                TEST(time_point.get(month()) == 2); // march
-                TEST(time_point.get(day()) == 5);
-
-                time_point = tmp_save;
-
-                time_point = year() * 2011 + february() + day() * 5;
-                TEST(time_point.get(year()) == 2011);
-                TEST(time_point.get(month()) == 1); // february
-                TEST(time_point.get(day()) == 5);
-
-            } // test
-        }   // for loop
-
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+        } // test
+    }   // for loop
 }
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 // boostinspect:noascii

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -31,7 +31,7 @@
     do {                                                                     \
         ss << (t);                                                            \
         if(ss.str()!=X) {                                                     \
-            std::cerr << "[" << ss.str() << "]!=[" << X << "]" << std::endl;  \
+            std::cerr << "[" << ss.str() << "]!=[" << X << "]\n";  \
         }                                                                     \
         TESTR(ss.str() == X);                                                 \
     } while(0)

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -532,40 +532,31 @@ void test_format(std::string charset="UTF-8")
 }
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::time_zone::global("GMT+4:00");
-        std::cout << "Testing char, UTF-8" << std::endl;
-        test_manip<char>();
-        test_format<char>();
-        std::cout << "Testing char, ISO8859-1" << std::endl;
-        test_manip<char>("ISO8859-1");
-        test_format<char>("ISO8859-1");
+    boost::locale::time_zone::global("GMT+4:00");
+    std::cout << "Testing char, UTF-8" << std::endl;
+    test_manip<char>();
+    test_format<char>();
+    std::cout << "Testing char, ISO8859-1" << std::endl;
+    test_manip<char>("ISO8859-1");
+    test_format<char>("ISO8859-1");
 
-        std::cout << "Testing wchar_t" << std::endl;
-        test_manip<wchar_t>();
-        test_format<wchar_t>();
+    std::cout << "Testing wchar_t" << std::endl;
+    test_manip<wchar_t>();
+    test_format<wchar_t>();
 
-        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        std::cout << "Testing char16_t" << std::endl;
-        test_manip<char16_t>();
-        test_format<char16_t>();
-        #endif
+    #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    std::cout << "Testing char16_t" << std::endl;
+    test_manip<char16_t>();
+    test_format<char16_t>();
+    #endif
 
-        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        std::cout << "Testing char32_t" << std::endl;
-        test_manip<char32_t>();
-        test_format<char32_t>();
-        #endif
-
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    std::cout << "Testing char32_t" << std::endl;
+    test_manip<char32_t>();
+    test_format<char32_t>();
+    #endif
 }
 
 #endif // NOICU

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -46,7 +46,7 @@ template<>
 void print_diff(std::string const &l,std::string const &r,int line)
 {
     if(l!=r) {
-        std::cerr << "----[" << l <<"]!=\n----["<<r<<"] in " << line << std::endl;
+        std::cerr << "----[" << l << "]!=\n----[" << r << " ] in " << line << std::endl;
     }
 }
 
@@ -145,19 +145,19 @@ do { \
 
 #define TEST_FP2(m1,m2,value_in,str,type,value_out) \
 do { \
-    TEST_FMT(m1<<m2,value_in,str); \
+    TEST_FMT(m1 << m2,value_in,str); \
     TEST_PAR(m1>>m2,type,str,value_out);  \
 }while(0)
 
 #define TEST_FP3(m1,m2,m3,value_in,str,type,value_out) \
 do { \
-    TEST_FMT(m1<<m2<<m3,value_in,str); \
+    TEST_FMT(m1 << m2 << m3,value_in,str); \
     TEST_PAR(m1>>m2>>m3,type,str,value_out); \
 }while(0)
 
 #define TEST_FP4(m1,m2,m3,m4,value_in,str,type,value_out) \
 do { \
-    TEST_FMT(m1<<m2<<m3<<m4,value_in,str); \
+    TEST_FMT(m1 << m2 << m3 << m4,value_in,str); \
     TEST_PAR(m1>>m2>>m3>>m4,type,str,value_out); \
 }while(0)
 
@@ -222,8 +222,8 @@ void test_manip(std::string e_charset="UTF-8")
 
     TEST_FP1(as::posix,1200.1,"1200.1",double,1200.1);
     TEST_FP1(as::number,1200.1,"1,200.1",double,1200.1);
-    TEST_FMT(as::number<<std::setfill(CharType('_'))<<std::setw(6),1534,"_1,534");
-    TEST_FMT(as::number<<std::left<<std::setfill(CharType('_'))<<std::setw(6),1534,"1,534_");
+    TEST_FMT(as::number << std::setfill(CharType('_')) << std::setw(6),1534,"_1,534");
+    TEST_FMT(as::number << std::left << std::setfill(CharType('_')) << std::setw(6),1534,"1,534_");
 
     // Ranges
     if(sizeof(short) == 2) {
@@ -384,7 +384,7 @@ void test_manip(std::string e_charset="UTF-8")
     std::basic_string<CharType> format_string(format.begin(),format.end());
     strftime(local_time_str,sizeof(local_time_str),format.c_str(),gmtime(&lnow));
     TEST_FMT(as::ftime(format_string),now,local_time_str);
-    TEST_FMT(as::ftime(format_string)<<as::gmt<<as::local_time,now,local_time_str);
+    TEST_FMT(as::ftime(format_string) << as::gmt << as::local_time,now,local_time_str);
 
     std::string marks =
         "aAbB"
@@ -418,7 +418,7 @@ void test_manip(std::string e_charset="UTF-8")
         format_string.clear();
         format_string+=static_cast<CharType>('%');
         format_string+=static_cast<CharType>(marks[i]);
-        TEST_FMT(as::ftime(format_string)<<as::gmt,a_datetime,result[i]);
+        TEST_FMT(as::ftime(format_string) << as::gmt,a_datetime,result[i]);
     }
 
     std::string sample_f[]={
@@ -436,7 +436,7 @@ void test_manip(std::string e_charset="UTF-8")
 
     for(unsigned i=0;i<sizeof(sample_f)/sizeof(sample_f[0]);i++) {
         format_string.assign(sample_f[i].begin(),sample_f[i].end());
-        TEST_FMT(as::ftime(format_string)<<as::gmt,a_datetime,expected_f[i]);
+        TEST_FMT(as::ftime(format_string) << as::gmt,a_datetime,expected_f[i]);
     }
 
 }

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "ICU is not build... Skipping" << std::endl;
+        std::cout << "ICU is not build... Skipping\n";
 }
 #else
 
@@ -89,7 +89,7 @@ static bool parsing_fails()
         }
         checked=true;
         if(!fails) {
-            std::cerr << "!!! Warning: libc++ library does not throw an exception on failbit !!!" << std::endl;
+            std::cerr << "!!! Warning: libc++ library does not throw an exception on failbit !!!\n";
         }
     }
     return fails;

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -26,75 +26,66 @@ struct test_facet : public std::locale::facet {
 std::locale::id test_facet::id;
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::generator g;
-        std::locale l=g("en_US.UTF-8");
-        TEST(has_message(l));
+    boost::locale::generator g;
+    std::locale l=g("en_US.UTF-8");
+    TEST(has_message(l));
 
-        g.categories(g.categories() ^ boost::locale::message_facet);
-        g.locale_cache_enabled(true);
-        g("en_US.UTF-8");
-        g.categories(g.categories() | boost::locale::message_facet);
-        l=g("en_US.UTF-8");
-        TEST(!has_message(l));
-        g.clear_cache();
-        g.locale_cache_enabled(false);
-        l=g("en_US.UTF-8");
-        TEST(has_message(l));
-        g.characters(g.characters() ^ boost::locale::char_facet);
-        l=g("en_US.UTF-8");
-        TEST(!has_message(l));
-        g.characters(g.characters() | boost::locale::char_facet);
-        l=g("en_US.UTF-8");
-        TEST(has_message(l));
+    g.categories(g.categories() ^ boost::locale::message_facet);
+    g.locale_cache_enabled(true);
+    g("en_US.UTF-8");
+    g.categories(g.categories() | boost::locale::message_facet);
+    l=g("en_US.UTF-8");
+    TEST(!has_message(l));
+    g.clear_cache();
+    g.locale_cache_enabled(false);
+    l=g("en_US.UTF-8");
+    TEST(has_message(l));
+    g.characters(g.characters() ^ boost::locale::char_facet);
+    l=g("en_US.UTF-8");
+    TEST(!has_message(l));
+    g.characters(g.characters() | boost::locale::char_facet);
+    l=g("en_US.UTF-8");
+    TEST(has_message(l));
 
-        l=g("en_US.ISO8859-1");
-        TEST(std::use_facet<boost::locale::info>(l).language()=="en");
-        TEST(std::use_facet<boost::locale::info>(l).country()=="US");
-        TEST(!std::use_facet<boost::locale::info>(l).utf8());
-        TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
+    l=g("en_US.ISO8859-1");
+    TEST(std::use_facet<boost::locale::info>(l).language()=="en");
+    TEST(std::use_facet<boost::locale::info>(l).country()=="US");
+    TEST(!std::use_facet<boost::locale::info>(l).utf8());
+    TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
 
-        l=g("en_US.UTF-8");
-        TEST(std::use_facet<boost::locale::info>(l).language()=="en");
-        TEST(std::use_facet<boost::locale::info>(l).country()=="US");
-        TEST(std::use_facet<boost::locale::info>(l).utf8());
+    l=g("en_US.UTF-8");
+    TEST(std::use_facet<boost::locale::info>(l).language()=="en");
+    TEST(std::use_facet<boost::locale::info>(l).country()=="US");
+    TEST(std::use_facet<boost::locale::info>(l).utf8());
 
-        l=g("en_US.ISO8859-1");
-        TEST(std::use_facet<boost::locale::info>(l).language()=="en");
-        TEST(std::use_facet<boost::locale::info>(l).country()=="US");
-        TEST(!std::use_facet<boost::locale::info>(l).utf8());
-        TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
+    l=g("en_US.ISO8859-1");
+    TEST(std::use_facet<boost::locale::info>(l).language()=="en");
+    TEST(std::use_facet<boost::locale::info>(l).country()=="US");
+    TEST(!std::use_facet<boost::locale::info>(l).utf8());
+    TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
 
-        l=g("en_US.ISO8859-1");
-        TEST(std::use_facet<boost::locale::info>(l).language()=="en");
-        TEST(std::use_facet<boost::locale::info>(l).country()=="US");
-        TEST(!std::use_facet<boost::locale::info>(l).utf8());
-        TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
+    l=g("en_US.ISO8859-1");
+    TEST(std::use_facet<boost::locale::info>(l).language()=="en");
+    TEST(std::use_facet<boost::locale::info>(l).country()=="US");
+    TEST(!std::use_facet<boost::locale::info>(l).utf8());
+    TEST(std::use_facet<boost::locale::info>(l).encoding()=="iso8859-1");
 
-        std::locale l_wt(std::locale::classic(),new test_facet);
+    std::locale l_wt(std::locale::classic(),new test_facet);
 
-        TEST(std::has_facet<test_facet>(g.generate(l_wt,"en_US.UTF-8")));
-        TEST(std::has_facet<test_facet>(g.generate(l_wt,"en_US.ISO8859-1")));
-        TEST(!std::has_facet<test_facet>(g("en_US.UTF-8")));
-        TEST(!std::has_facet<test_facet>(g("en_US.ISO8859-1")));
+    TEST(std::has_facet<test_facet>(g.generate(l_wt,"en_US.UTF-8")));
+    TEST(std::has_facet<test_facet>(g.generate(l_wt,"en_US.ISO8859-1")));
+    TEST(!std::has_facet<test_facet>(g("en_US.UTF-8")));
+    TEST(!std::has_facet<test_facet>(g("en_US.ISO8859-1")));
 
-        g.locale_cache_enabled(true);
-        g.generate(l_wt,"en_US.UTF-8");
-        g.generate(l_wt,"en_US.ISO8859-1");
-        TEST(std::has_facet<test_facet>(g("en_US.UTF-8")));
-        TEST(std::has_facet<test_facet>(g("en_US.ISO8859-1")));
-        TEST(std::use_facet<boost::locale::info>(g("en_US.UTF-8")).utf8());
-        TEST(!std::use_facet<boost::locale::info>(g("en_US.ISO8859-1")).utf8());
-
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    g.locale_cache_enabled(true);
+    g.generate(l_wt,"en_US.UTF-8");
+    g.generate(l_wt,"en_US.ISO8859-1");
+    TEST(std::has_facet<test_facet>(g("en_US.UTF-8")));
+    TEST(std::has_facet<test_facet>(g("en_US.ISO8859-1")));
+    TEST(std::use_facet<boost::locale::info>(g("en_US.UTF-8")).utf8());
+    TEST(!std::use_facet<boost::locale::info>(g("en_US.ISO8859-1")).utf8());
 }
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 // boostinspect:noascii

--- a/test/test_icu_vs_os_timezone.cpp
+++ b/test/test_icu_vs_os_timezone.cpp
@@ -30,33 +30,24 @@ int main()
 #include "test_locale.hpp"
 #include "test_locale_tools.hpp"
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
+    time_t now=time(0);
+    boost::locale::generator gen;
+    std::locale::global(gen("en_US.UTF-8"));
 
-        time_t now=time(0);
-        boost::locale::generator gen;
-        std::locale::global(gen("en_US.UTF-8"));
+    for(int i=0;i<366;i++) {
+        time_t point = now + i * 24 * 3600;
+        std::stringstream ss;
+        ss << boost::locale::format("{1,ftime='%H %M %S'}") % point;
+        int icu_hour = 0,icu_min = 0,icu_sec = 0;
+        ss >> icu_hour >> icu_min >> icu_sec;
+        std::tm *tm=localtime(&point);
+        TEST(icu_hour == tm->tm_hour);
+        TEST(icu_min == tm->tm_min);
+        TEST(icu_sec == tm->tm_sec);
 
-        for(int i=0;i<366;i++) {
-            time_t point = now + i * 24 * 3600;
-            std::stringstream ss;
-            ss << boost::locale::format("{1,ftime='%H %M %S'}") % point;
-            int icu_hour = 0,icu_min = 0,icu_sec = 0;
-            ss >> icu_hour >> icu_min >> icu_sec;
-            std::tm *tm=localtime(&point);
-            TEST(icu_hour == tm->tm_hour);
-            TEST(icu_min == tm->tm_min);
-            TEST(icu_sec == tm->tm_sec);
-
-        }
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
 }
 
 #endif // NO ICU

--- a/test/test_icu_vs_os_timezone.cpp
+++ b/test/test_icu_vs_os_timezone.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "ICU is not build... Skipping" << std::endl;
+        std::cout << "ICU is not build... Skipping\n";
 }
 #else
 

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -30,53 +30,47 @@ struct init {
     init() { prop_type::global_init(); }
 };
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        {
-            std::stringstream ss;
-            TEST(!prop_type::has(ss));
-            TEST(prop_type::get(ss).x==-1);
-            TEST(prop_type::has(ss));
-            TEST(counter==1);
-        }
-        TEST(counter==0);
-        {
-            std::stringstream ss;
-            prop_type::set(propery(1),ss);
-            TEST(counter==1);
-            TEST(prop_type::get(ss).x==1);
-        }
-        TEST(counter==0);
-        {
-            std::stringstream ss;
-            prop_type::set(propery(1),ss);
-            TEST(counter==1);
-            TEST(prop_type::get(ss).x==1);
-        }
-        TEST(counter==0);
-        {
-            std::stringstream ss,ss2;
-            prop_type::set(propery(2),ss);
-            ss2.copyfmt(ss);
-            TEST(prop_type::get(ss).x==2);
-            TEST(prop_type::has(ss2));
-            TEST(prop_type::has(ss));
-            TEST(prop_type::get(ss2).x==2);
-            prop_type::get(ss2).x=3;
-            TEST(prop_type::get(ss2).x==3);
-            TEST(prop_type::get(ss).x==2);
-            TEST(counter==2);
-            TEST(imbued==0);
-            ss2.imbue(std::locale::classic());
-            TEST(imbued==1);
-        }
-        TEST(counter==0);
-    }catch(std::exception const &e) {
-        std::cerr << "Fail:" << e.what() << std::endl;
-        return EXIT_FAILURE;
+    {
+        std::stringstream ss;
+        TEST(!prop_type::has(ss));
+        TEST(prop_type::get(ss).x==-1);
+        TEST(prop_type::has(ss));
+        TEST(counter==1);
     }
-    FINALIZE();
+    TEST(counter==0);
+    {
+        std::stringstream ss;
+        prop_type::set(propery(1),ss);
+        TEST(counter==1);
+        TEST(prop_type::get(ss).x==1);
+    }
+    TEST(counter==0);
+    {
+        std::stringstream ss;
+        prop_type::set(propery(1),ss);
+        TEST(counter==1);
+        TEST(prop_type::get(ss).x==1);
+    }
+    TEST(counter==0);
+    {
+        std::stringstream ss,ss2;
+        prop_type::set(propery(2),ss);
+        ss2.copyfmt(ss);
+        TEST(prop_type::get(ss).x==2);
+        TEST(prop_type::has(ss2));
+        TEST(prop_type::has(ss));
+        TEST(prop_type::get(ss2).x==2);
+        prop_type::get(ss2).x=3;
+        TEST(prop_type::get(ss2).x==3);
+        TEST(prop_type::get(ss).x==2);
+        TEST(counter==2);
+        TEST(imbued==0);
+        ss2.imbue(std::locale::classic());
+        TEST(imbued==1);
+    }
+    TEST(counter==0);
 }
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/test/test_locale.hpp
+++ b/test/test_locale.hpp
@@ -51,13 +51,13 @@ do {                                                                            
     do {                                                                \
         int passed=test_counter - error_counter;                        \
         std::cout << std::endl;                                         \
-        std::cout << "Passed " << passed << " tests" << std::endl;          \
+        std::cout << "Passed " << passed << " tests\n";          \
         if(error_counter >0 ) {                                         \
-            std::cout << "Failed " << error_counter << " tests" << std::endl; \
+            std::cout << "Failed " << error_counter << " tests\n"; \
         }                                                               \
         std::cout << " " << std::fixed << std::setprecision(1)          \
                 << std::setw(5) << 100.0 * passed / test_counter <<     \
-                "% of tests completed sucsessefully" << std::endl;      \
+                "% of tests completed sucsessefully\n";      \
         return error_counter == 0 ? EXIT_SUCCESS : EXIT_FAILURE ;       \
     }while(0)
 

--- a/test/test_locale.hpp
+++ b/test/test_locale.hpp
@@ -47,20 +47,26 @@ do {                                                                            
         THROW_IF_TOO_BIG(error_counter++);                              \
     }while(0)
 
-#define FINALIZE()                                                      \
-    do {                                                                \
-        int passed=test_counter - error_counter;                        \
-        std::cout << std::endl;                                         \
-        std::cout << "Passed " << passed << " tests\n";          \
-        if(error_counter >0 ) {                                         \
-            std::cout << "Failed " << error_counter << " tests\n"; \
-        }                                                               \
-        std::cout << " " << std::fixed << std::setprecision(1)          \
-                << std::setw(5) << 100.0 * passed / test_counter <<     \
-                "% of tests completed sucsessefully\n";      \
-        return error_counter == 0 ? EXIT_SUCCESS : EXIT_FAILURE ;       \
-    }while(0)
+void test_main(int argc, char **argv);
 
+int main(int argc,char **argv) {
+    try {
+        test_main(argc, argv);
+    } catch(std::exception const &e) {
+        std::cerr << "Failed " << e.what() << std::endl; // LCOV_EXCL_LINE
+        return EXIT_FAILURE;                             // LCOV_EXCL_LINE
+    }
+    int passed = test_counter - error_counter; 
+    std::cout << std::endl;
+    std::cout << "Passed " << passed << " tests\n";
+    if(error_counter > 0 ) { 
+        std::cout << "Failed " << error_counter << " tests\n"; // LCOV_EXCL_LINE
+    }
+    std::cout << " " << std::fixed << std::setprecision(1)
+              << std::setw(5) << 100.0 * passed / test_counter <<
+              "% of tests completed sucsessefully\n";
+    return error_counter == 0 ? EXIT_SUCCESS : EXIT_FAILURE ;
+}
 
 inline unsigned utf8_next(std::string const &s,unsigned &pos)
 {
@@ -109,7 +115,7 @@ BOOST_LOCALE_START_CONST_CONDITION
                << ") to Latin1";
             throw std::runtime_error(ss.str());
         }
-        else if(sizeof(Char)==2 && point >0xFFFF) { // Deal with surragates
+        else if(sizeof(Char)==2 && point >0xFFFF) { // Deal with surrogates
             point-=0x10000;
             out+=static_cast<Char>(0xD800 | (point>>10));
             out+=static_cast<Char>(0xDC00 | (point & 0x3FF));

--- a/test/test_locale.hpp
+++ b/test/test_locale.hpp
@@ -34,7 +34,7 @@ do {                                                                            
     do {                                                                \
         test_counter++;                                                 \
         if(X) break;                                                    \
-        std::cerr << "Error in line:"<<__LINE__ << " "#X  << std::endl; \
+        std::cerr << "Error in line:" << __LINE__ << " "#X  << std::endl; \
         THROW_IF_TOO_BIG(error_counter++);                              \
     }while(0)
 #endif
@@ -43,7 +43,7 @@ do {                                                                            
     do {                                                                \
         test_counter++;                                                 \
         try { X; } catch(E const &/*e*/ ) {break;} catch(...){}         \
-        std::cerr << "Error in line:"<<__LINE__ << " "#X  << std::endl; \
+        std::cerr << "Error in line:" << __LINE__ << " "#X  << std::endl; \
         THROW_IF_TOO_BIG(error_counter++);                              \
     }while(0)
 
@@ -51,11 +51,11 @@ do {                                                                            
     do {                                                                \
         int passed=test_counter - error_counter;                        \
         std::cout << std::endl;                                         \
-        std::cout << "Passed "<<passed<<" tests" << std::endl;          \
+        std::cout << "Passed " << passed << " tests" << std::endl;          \
         if(error_counter >0 ) {                                         \
-            std::cout << "Failed "<<error_counter<<" tests"<<std::endl; \
+            std::cout << "Failed " << error_counter << " tests" << std::endl; \
         }                                                               \
-        std::cout <<" "<< std::fixed << std::setprecision(1)            \
+        std::cout << " " << std::fixed << std::setprecision(1)          \
                 << std::setw(5) << 100.0 * passed / test_counter <<     \
                 "% of tests completed sucsessefully" << std::endl;      \
         return error_counter == 0 ? EXIT_SUCCESS : EXIT_FAILURE ;       \
@@ -104,7 +104,9 @@ std::basic_string<Char> to(std::string const &utf8)
 BOOST_LOCALE_START_CONST_CONDITION
         if(sizeof(Char)==1 && point > 255) {
             std::ostringstream ss;
-            ss << "Can't convert codepoint U" << std::hex << point <<"(" <<std::string(utf8.begin()+prev,utf8.begin()+i)<<") to Latin1";
+            ss << "Can't convert codepoint U"
+               << std::hex << point << "(" << std::string(utf8.begin()+prev,utf8.begin()+i)
+               << ") to Latin1";
             throw std::runtime_error(ss.str());
         }
         else if(sizeof(Char)==2 && point >0xFFFF) { // Deal with surragates

--- a/test/test_locale_tools.hpp
+++ b/test/test_locale_tools.hpp
@@ -10,10 +10,11 @@
 #define BOOST_LOCLAE_TEST_LOCALE_TOOLS_HPP
 
 #include <boost/locale/encoding.hpp>
-
-#include <cstdio>
-#include <cstdlib>
 #include <fstream>
+
+#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
+#include "test_posix_tools.hpp"
+#endif
 
 template<typename Char>
 std::basic_string<Char> to_correct_string(std::string const &e,std::locale /*l*/)

--- a/test/test_locale_tools.hpp
+++ b/test/test_locale_tools.hpp
@@ -46,7 +46,7 @@ inline bool test_std_supports_SJIS_codecvt(std::string const &locale_name)
     // Japan in Shift JIS/cp932
         char const *japan_932 = "\x93\xfa\x96\x7b";
         std::ofstream f("test-siftjis.txt");
-        f<<japan_932;
+        f << japan_932;
         f.close();		
     }
     try {

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -366,7 +366,7 @@ int main(int argc,char **argv)
                         l = g(locales[i]);
                 }
 
-                std::cout << "  Testing "<<locales[i]<<std::endl;
+                std::cout << "  Testing " << locales[i] << std::endl;
                 std::cout << "    single forms" << std::endl;
 
                 test_translate("hello","שלום",l,"default");
@@ -410,7 +410,7 @@ int main(int argc,char **argv)
                     test_cntranslate(inp,"x day","x days",20,"x days",l,"undefined");
                 }
             }
-            std::cout << "  Testing fallbacks" <<std::endl;
+            std::cout << "  Testing fallbacks" << std::endl;
             test_translate("test","he_IL",g("he_IL.UTF-8"),"full");
             test_translate("test","he",g("he_IL.UTF-8"),"fall");
 

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -310,226 +310,218 @@ void test_translate(std::string original,std::string expected,std::locale const 
 bool iso_8859_8_not_supported = false;
 
 
-int main(int argc,char **argv)
+void test_main(int argc, char **argv)
 {
-    try {
-        std::string def[] = {
-        #ifdef BOOST_LOCALE_WITH_ICU
-            "icu" ,
-        #endif
-        #ifndef BOOST_LOCALE_NO_STD_BACKEND
-            "std" ,
-        #endif
-        #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-            "posix",
-        #endif
-        #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-            "winapi",
-        #endif
-        };
-        for(int type = 0 ; type < int(sizeof(def)/sizeof(def[0])) ; type ++ ) {
-            boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
-            tmp_backend.select(def[type]);
-            boost::locale::localization_backend_manager::global(tmp_backend);
+    std::string def[] = {
+    #ifdef BOOST_LOCALE_WITH_ICU
+        "icu" ,
+    #endif
+    #ifndef BOOST_LOCALE_NO_STD_BACKEND
+        "std" ,
+    #endif
+    #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
+        "posix",
+    #endif
+    #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
+        "winapi",
+    #endif
+    };
+    for(int type = 0 ; type < int(sizeof(def)/sizeof(def[0])) ; type ++ ) {
+        boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
+        tmp_backend.select(def[type]);
+        boost::locale::localization_backend_manager::global(tmp_backend);
 
-            backend = def[type];
+        backend = def[type];
 
-            std::cout << "Testing for backend --------- " << def[type] << std::endl;
+        std::cout << "Testing for backend --------- " << def[type] << std::endl;
 
+        boost::locale::generator g;
+        g.add_messages_domain("simple");
+        g.add_messages_domain("full");
+        g.add_messages_domain("fall");
+        if(argc==2)
+            g.add_messages_path(argv[1]);
+        else
+            g.add_messages_path("./");
+        g.set_default_messages_domain("default");
+
+
+        std::string locales[] = { "he_IL.UTF-8", "he_IL.ISO8859-8" };
+
+        for(unsigned i=0;i<sizeof(locales)/sizeof(locales[0]);i++){
+            std::locale l;
+
+            if(i==1) {
+                try {
+                    l = g(locales[i]);
+                }
+                catch(boost::locale::conv::invalid_charset_error const &) {
+                    std::cout << "Looks like ISO-8859-8 is not supported! skipping" << std::endl;
+                    iso_8859_8_not_supported = true;
+                    continue;
+                }
+            }
+            else {
+                    l = g(locales[i]);
+            }
+
+            std::cout << "  Testing " << locales[i] << std::endl;
+            std::cout << "    single forms" << std::endl;
+
+            test_translate("hello","שלום",l,"default");
+            test_translate("hello","היי",l,"simple");
+            test_translate("hello","hello",l,"undefined");
+            test_translate("untranslated","untranslated",l,"default");
+            // Check removal of old "context" information
+            test_translate("#untranslated","#untranslated",l,"default");
+            test_translate("##untranslated","##untranslated",l,"default");
+            test_ctranslate("context","hello","שלום בהקשר אחר",l,"default");
+            test_translate("#hello","#שלום",l,"default");
+
+            std::cout << "    plural forms" << std::endl;
+
+            {
+                test_ntranslate("x day","x days",0,"x ימים",l,"default");
+                test_ntranslate("x day","x days",1,"יום x",l,"default");
+                test_ntranslate("x day","x days",2,"יומיים",l,"default");
+                test_ntranslate("x day","x days",3,"x ימים",l,"default");
+                test_ntranslate("x day","x days",20,"x יום",l,"default");
+
+                test_ntranslate("x day","x days",0,"x days",l,"undefined");
+                test_ntranslate("x day","x days",1,"x day",l,"undefined");
+                test_ntranslate("x day","x days",2,"x days",l,"undefined");
+                test_ntranslate("x day","x days",20,"x days",l,"undefined");
+            }
+            std::cout << "    plural forms with context" << std::endl;
+            {
+                std::string inp = "context";
+                std::string out = "בהקשר ";
+
+                test_cntranslate(inp,"x day","x days",0,out+"x ימים",l,"default");
+                test_cntranslate(inp,"x day","x days",1,out+"יום x",l,"default");
+                test_cntranslate(inp,"x day","x days",2,out+"יומיים",l,"default");
+                test_cntranslate(inp,"x day","x days",3,out+"x ימים",l,"default");
+                test_cntranslate(inp,"x day","x days",20,out+"x יום",l,"default");
+
+                test_cntranslate(inp,"x day","x days",0,"x days",l,"undefined");
+                test_cntranslate(inp,"x day","x days",1,"x day",l,"undefined");
+                test_cntranslate(inp,"x day","x days",2,"x days",l,"undefined");
+                test_cntranslate(inp,"x day","x days",20,"x days",l,"undefined");
+            }
+        }
+        std::cout << "  Testing fallbacks" << std::endl;
+        test_translate("test","he_IL",g("he_IL.UTF-8"),"full");
+        test_translate("test","he",g("he_IL.UTF-8"),"fall");
+
+        std::cout << "  Testing automatic conversions " << std::endl;
+        std::locale::global(g("he_IL.UTF-8"));
+
+
+        TEST(same_s(bl::translate("hello"))=="שלום");
+        TEST(same_w(bl::translate(to<wchar_t>("hello")))==to<wchar_t>("שלום"));
+
+        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+        if(backend=="icu" || backend=="std")
+            TEST(same_u16(bl::translate(to<char16_t>("hello")))==to<char16_t>("שלום"));
+        #endif
+
+        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+        if(backend=="icu" || backend=="std")
+            TEST(same_u32(bl::translate(to<char32_t>("hello")))==to<char32_t>("שלום"));
+        #endif
+
+    }
+
+    std::cout << "Testing custom file system support" << std::endl;
+    {
+        boost::locale::gnu_gettext::messages_info info;
+        info.language = "he";
+        info.country = "IL";
+        info.encoding="UTF-8";
+        if(argc==2)
+            info.paths.push_back(argv[1]);
+        else
+            info.paths.push_back("./");
+
+        info.domains.push_back(bl::gnu_gettext::messages_info::domain("default"));
+        info.callback = file_loader();
+
+        std::locale l(std::locale::classic(),boost::locale::gnu_gettext::create_messages_facet<char>(info));
+        TEST(file_loader_is_actually_called);
+        TEST(bl::translate("hello").str(l)=="שלום");
+    }
+    if(iso_8859_8_not_supported)
+    {
+        std::cout << "ISO 8859-8 not supported so skipping non-US-ASCII keys" << std::endl;
+    }
+    else
+    {
+        std::cout << "Testing non-US-ASCII keys" << std::endl;
+        std::cout << "  UTF-8 keys" << std::endl;
+        {
             boost::locale::generator g;
-            g.add_messages_domain("simple");
-            g.add_messages_domain("full");
-            g.add_messages_domain("fall");
+            g.add_messages_domain("default");
             if(argc==2)
                 g.add_messages_path(argv[1]);
             else
                 g.add_messages_path("./");
-            g.set_default_messages_domain("default");
 
+            std::locale l = g("he_IL.UTF-8");
 
-            std::string locales[] = { "he_IL.UTF-8", "he_IL.ISO8859-8" };
+            // narrow
+            TEST(bl::gettext("בדיקה",l)=="test");
+            TEST(bl::gettext("לא קיים",l)=="לא קיים");
 
-            for(unsigned i=0;i<sizeof(locales)/sizeof(locales[0]);i++){
-                std::locale l;
+            // wide
+            std::wstring wtest = bl::conv::to_utf<wchar_t>("בדיקה","UTF-8");
+            std::wstring wmiss = bl::conv::to_utf<wchar_t>("לא קיים","UTF-8");
+            TEST(bl::gettext(wtest.c_str(),l)==L"test");
+            TEST(bl::gettext(wmiss.c_str(),l)==wmiss);
 
-                if(i==1) {
-                    try {
-                        l = g(locales[i]);
-                    }
-                    catch(boost::locale::conv::invalid_charset_error const &) {
-                        std::cout << "Looks like ISO-8859-8 is not supported! skipping" << std::endl;
-                        iso_8859_8_not_supported = true;
-                        continue;
-                    }
-                }
-                else {
-                        l = g(locales[i]);
-                }
+            l=g("he_IL.ISO-8859-8");
 
-                std::cout << "  Testing " << locales[i] << std::endl;
-                std::cout << "    single forms" << std::endl;
-
-                test_translate("hello","שלום",l,"default");
-                test_translate("hello","היי",l,"simple");
-                test_translate("hello","hello",l,"undefined");
-                test_translate("untranslated","untranslated",l,"default");
-                // Check removal of old "context" information
-                test_translate("#untranslated","#untranslated",l,"default");
-                test_translate("##untranslated","##untranslated",l,"default");
-                test_ctranslate("context","hello","שלום בהקשר אחר",l,"default");
-                test_translate("#hello","#שלום",l,"default");
-
-                std::cout << "    plural forms" << std::endl;
-
-                {
-                    test_ntranslate("x day","x days",0,"x ימים",l,"default");
-                    test_ntranslate("x day","x days",1,"יום x",l,"default");
-                    test_ntranslate("x day","x days",2,"יומיים",l,"default");
-                    test_ntranslate("x day","x days",3,"x ימים",l,"default");
-                    test_ntranslate("x day","x days",20,"x יום",l,"default");
-
-                    test_ntranslate("x day","x days",0,"x days",l,"undefined");
-                    test_ntranslate("x day","x days",1,"x day",l,"undefined");
-                    test_ntranslate("x day","x days",2,"x days",l,"undefined");
-                    test_ntranslate("x day","x days",20,"x days",l,"undefined");
-                }
-                std::cout << "    plural forms with context" << std::endl;
-                {
-                    std::string inp = "context";
-                    std::string out = "בהקשר ";
-
-                    test_cntranslate(inp,"x day","x days",0,out+"x ימים",l,"default");
-                    test_cntranslate(inp,"x day","x days",1,out+"יום x",l,"default");
-                    test_cntranslate(inp,"x day","x days",2,out+"יומיים",l,"default");
-                    test_cntranslate(inp,"x day","x days",3,out+"x ימים",l,"default");
-                    test_cntranslate(inp,"x day","x days",20,out+"x יום",l,"default");
-
-                    test_cntranslate(inp,"x day","x days",0,"x days",l,"undefined");
-                    test_cntranslate(inp,"x day","x days",1,"x day",l,"undefined");
-                    test_cntranslate(inp,"x day","x days",2,"x days",l,"undefined");
-                    test_cntranslate(inp,"x day","x days",20,"x days",l,"undefined");
-                }
-            }
-            std::cout << "  Testing fallbacks" << std::endl;
-            test_translate("test","he_IL",g("he_IL.UTF-8"),"full");
-            test_translate("test","he",g("he_IL.UTF-8"),"fall");
-
-            std::cout << "  Testing automatic conversions " << std::endl;
-            std::locale::global(g("he_IL.UTF-8"));
-
-
-            TEST(same_s(bl::translate("hello"))=="שלום");
-            TEST(same_w(bl::translate(to<wchar_t>("hello")))==to<wchar_t>("שלום"));
-
-            #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            if(backend=="icu" || backend=="std")
-                TEST(same_u16(bl::translate(to<char16_t>("hello")))==to<char16_t>("שלום"));
-            #endif
-
-            #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            if(backend=="icu" || backend=="std")
-                TEST(same_u32(bl::translate(to<char32_t>("hello")))==to<char32_t>("שלום"));
-            #endif
-
+            // conversion with substitution
+            TEST(bl::gettext("test-あにま-בדיקה",l)==bl::conv::from_utf("test--בדיקה","ISO-8859-8"));
         }
 
-        std::cout << "Testing custom file system support" << std::endl;
+        std::cout << "  `ANSI' keys" << std::endl;
+
         {
-            boost::locale::gnu_gettext::messages_info info;
-            info.language = "he";
-            info.country = "IL";
-            info.encoding="UTF-8";
+            boost::locale::generator g;
+            g.add_messages_domain("default/ISO-8859-8");
             if(argc==2)
-                info.paths.push_back(argv[1]);
+                g.add_messages_path(argv[1]);
             else
-                info.paths.push_back("./");
+                g.add_messages_path("./");
 
-            info.domains.push_back(bl::gnu_gettext::messages_info::domain("default"));
-            info.callback = file_loader();
+            std::locale l = g("he_IL.UTF-8");
 
-            std::locale l(std::locale::classic(),boost::locale::gnu_gettext::create_messages_facet<char>(info));
-            TEST(file_loader_is_actually_called);
-            TEST(bl::translate("hello").str(l)=="שלום");
+            // narrow non-UTF-8 keys
+            // match
+            TEST(bl::gettext(bl::conv::from_utf("בדיקה","ISO-8859-8").c_str(),l)=="test");
+            // conversion
+            TEST(bl::gettext(bl::conv::from_utf("לא קיים","ISO-8859-8").c_str(),l)=="לא קיים");
         }
-        if(iso_8859_8_not_supported)
-        {
-            std::cout << "ISO 8859-8 not supported so skipping non-US-ASCII keys" << std::endl;
-        }
-        else
-        {
-            std::cout << "Testing non-US-ASCII keys" << std::endl;
-            std::cout << "  UTF-8 keys" << std::endl;
-            {
-                boost::locale::generator g;
-                g.add_messages_domain("default");
-                if(argc==2)
-                    g.add_messages_path(argv[1]);
-                else
-                    g.add_messages_path("./");
-
-                std::locale l = g("he_IL.UTF-8");
-
-                // narrow
-                TEST(bl::gettext("בדיקה",l)=="test");
-                TEST(bl::gettext("לא קיים",l)=="לא קיים");
-
-                // wide
-                std::wstring wtest = bl::conv::to_utf<wchar_t>("בדיקה","UTF-8");
-                std::wstring wmiss = bl::conv::to_utf<wchar_t>("לא קיים","UTF-8");
-                TEST(bl::gettext(wtest.c_str(),l)==L"test");
-                TEST(bl::gettext(wmiss.c_str(),l)==wmiss);
-
-                l=g("he_IL.ISO-8859-8");
-
-                // conversion with substitution
-                TEST(bl::gettext("test-あにま-בדיקה",l)==bl::conv::from_utf("test--בדיקה","ISO-8859-8"));
-            }
-
-            std::cout << "  `ANSI' keys" << std::endl;
-
-            {
-                boost::locale::generator g;
-                g.add_messages_domain("default/ISO-8859-8");
-                if(argc==2)
-                    g.add_messages_path(argv[1]);
-                else
-                    g.add_messages_path("./");
-
-                std::locale l = g("he_IL.UTF-8");
-
-                // narrow non-UTF-8 keys
-                // match
-                TEST(bl::gettext(bl::conv::from_utf("בדיקה","ISO-8859-8").c_str(),l)=="test");
-                // conversion
-                TEST(bl::gettext(bl::conv::from_utf("לא קיים","ISO-8859-8").c_str(),l)=="לא קיים");
-            }
-        }
-        // Test compiles
-        {
-            bl::gettext("");
-            bl::gettext(L"");
-            bl::dgettext("","");
-            bl::dgettext("",L"");
-            bl::pgettext("","");
-            bl::pgettext(L"",L"");
-            bl::dpgettext("","","");
-            bl::dpgettext("",L"",L"");
-            bl::ngettext("","",1);
-            bl::ngettext(L"",L"",1);
-            bl::dngettext("","","",1);
-            bl::dngettext("",L"",L"",1);
-            bl::npgettext("","","",1);
-            bl::npgettext(L"",L"",L"",1);
-            bl::dnpgettext("","","","",1);
-            bl::dnpgettext("",L"",L"",L"",1);
-        }
-
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
+    // Test compiles
+    {
+        bl::gettext("");
+        bl::gettext(L"");
+        bl::dgettext("","");
+        bl::dgettext("",L"");
+        bl::pgettext("","");
+        bl::pgettext(L"",L"");
+        bl::dpgettext("","","");
+        bl::dpgettext("",L"",L"");
+        bl::ngettext("","",1);
+        bl::ngettext(L"",L"",1);
+        bl::dngettext("","","",1);
+        bl::dngettext("",L"",L"",1);
+        bl::npgettext("","","",1);
+        bl::npgettext(L"",L"",L"",1);
+        bl::dnpgettext("","","","",1);
+        bl::dnpgettext("",L"",L"",L"",1);
     }
-    FINALIZE();
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_posix_collate.cpp
+++ b/test/test_posix_collate.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "POSIX Backend is not build... Skipping" << std::endl;
+        std::cout << "POSIX Backend is not build... Skipping\n";
 }
 #else
 #include <boost/locale/config.hpp>
@@ -89,7 +89,7 @@ void test_char()
         }
     }
     #else
-    std::cout << "- Collation is broken on this OS C standard library, skipping" << std::endl;
+    std::cout << "- Collation is broken on this OS C standard library, skipping\n";
     #endif
 }
 

--- a/test/test_posix_collate.cpp
+++ b/test/test_posix_collate.cpp
@@ -20,7 +20,6 @@ int main()
 #include <iomanip>
 #include "test_locale.hpp"
 #include "test_locale_tools.hpp"
-#include "test_posix_tools.hpp"
 #include <iostream>
 
 int get_sign(int x)
@@ -94,24 +93,16 @@ void test_char()
 }
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("posix");
-        boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("posix");
+    boost::locale::localization_backend_manager::global(mgr);
 
-        std::cout << "Testing char" << std::endl;
-        test_char<char>();
-        std::cout << "Testing wchar_t" << std::endl;
-        test_char<wchar_t>();
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    std::cout << "Testing char" << std::endl;
+    test_char<char>();
+    std::cout << "Testing wchar_t" << std::endl;
+    test_char<wchar_t>();
 }
 #endif  // NO POSIX
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_posix_convert.cpp
+++ b/test/test_posix_convert.cpp
@@ -19,7 +19,6 @@ int main()
 #include <iomanip>
 #include "test_locale.hpp"
 #include "test_locale_tools.hpp"
-#include "test_posix_tools.hpp"
 #include <iostream>
 
 #include <wctype.h>
@@ -71,22 +70,12 @@ void test_char()
     name = "tr_TR.UTF-8";
     if(have_locale(name)) {
         std::cout << "Testing " << name << std::endl;
-        locale_t cl = newlocale(LC_ALL_MASK,name.c_str(),0);
-        try {
-            TEST(cl);
-            if(towupper_l(L'i',cl) == 0x130) {
-                test_one<CharType>(gen(name),"i","i","İ");
-            }
-            else {
-                std::cout << "  Turkish locale is not supported well" << std::endl;
-            }
-        }
-        catch(...) {
-            if(cl) freelocale(cl);
-            throw;
-        }
-        if(cl) freelocale(cl);
-
+        locale_holder cl(newlocale(LC_ALL_MASK,name.c_str(),0));
+        TEST(cl);
+        if(towupper_l(L'i',cl) == 0x130)
+            test_one<CharType>(gen(name),"i","i","İ");
+        else
+            std::cout << "  Turkish locale is not supported well" << std::endl; // LCOV_EXCL_LINE
     }
     else
     {
@@ -95,24 +84,16 @@ void test_char()
 }
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("posix");
-        boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("posix");
+    boost::locale::localization_backend_manager::global(mgr);
 
-        std::cout << "Testing char" << std::endl;
-        test_char<char>();
-        std::cout << "Testing wchar_t" << std::endl;
-        test_char<wchar_t>();
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    std::cout << "Testing char" << std::endl;
+    test_char<char>();
+    std::cout << "Testing wchar_t" << std::endl;
+    test_char<wchar_t>();
 }
 
 #endif // POSIX

--- a/test/test_posix_convert.cpp
+++ b/test/test_posix_convert.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "POSIX Backend is not build... Skipping" << std::endl;
+        std::cout << "POSIX Backend is not build... Skipping\n";
 }
 #else
 #include <boost/locale/conversion.hpp>

--- a/test/test_posix_convert.cpp
+++ b/test/test_posix_convert.cpp
@@ -78,7 +78,7 @@ void test_char()
                 test_one<CharType>(gen(name),"i","i","İ");
             }
             else {
-                std::cout <<"  Turkish locale is not supported well" << std::endl;
+                std::cout << "  Turkish locale is not supported well" << std::endl;
             }
         }
         catch(...) {

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -26,7 +26,6 @@ int main()
 
 #include "test_locale.hpp"
 #include "test_locale_tools.hpp"
-#include "test_posix_tools.hpp"
 
 //#define DEBUG_FMT
 
@@ -164,115 +163,97 @@ void test_by_char(std::locale const &l,locale_t lreal)
 
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    locale_t lreal = 0;
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("posix");
-        boost::locale::localization_backend_manager::global(mgr);
-        boost::locale::generator gen;
-        std::string name;
+    locale_holder lreal;
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("posix");
+    boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::generator gen;
+    std::string name;
 
-        {
-            std::cout << "en_US.UTF locale" << std::endl;
-            name="en_US.UTF-8";
-            if(!have_locale(name)) {
-                std::cout << "en_US.UTF-8 not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name);
-                lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
-                assert(lreal);
-                std::cout << "UTF-8" << std::endl;
-
-                test_by_char<char,char>(l1,lreal);
-
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,char>(l1,lreal);
-                freelocale(lreal);
-                lreal = 0;
-            }
+    {
+        std::cout << "en_US.UTF locale" << std::endl;
+        name="en_US.UTF-8";
+        if(!have_locale(name)) {
+            std::cout << "en_US.UTF-8 not supported" << std::endl;
         }
-        {
-            std::cout << "en_US.Latin-1 locale" << std::endl;
-            std::string name = "en_US.ISO8859-1";
-            if(!have_locale(name)) {
-                std::cout << "en_US.ISO8859-8 not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name);
-                lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
-                assert(lreal);
-                test_by_char<char,char>(l1,lreal);
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,char>(l1,lreal);
-                freelocale(lreal);
-                lreal = 0;
-            }
-        }
-        {
-            std::cout << "he_IL.UTF locale" << std::endl;
-            name="he_IL.UTF-8";
-            if(!have_locale(name)) {
-                std::cout << name << " not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name);
-                lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
-                assert(lreal);
-                std::cout << "UTF-8" << std::endl;
+        else {
+            std::locale l1=gen(name);
+            lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
+            assert(lreal);
+            std::cout << "UTF-8" << std::endl;
 
-                test_by_char<char,char>(l1,lreal);
+            test_by_char<char,char>(l1,lreal);
 
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,char>(l1,lreal);
-                freelocale(lreal);
-                lreal = 0;
-            }
-        }
-        {
-            std::cout << "he_IL.ISO locale" << std::endl;
-            std::string name = "he_IL.ISO8859-8";
-            if(!have_locale(name)) {
-                std::cout << name << " not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name);
-                lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
-                assert(lreal);
-                test_by_char<char,char>(l1,lreal);
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,char>(l1,lreal);
-                freelocale(lreal);
-                lreal = 0;
-            }
-        }
-        {
-            std::cout << "Testing UTF-8 punct issues" << std::endl;
-            std::string name = "ru_RU.UTF-8";
-            if(!have_locale(name)) {
-                std::cout << "- No russian locale" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name);
-                std::ostringstream ss;
-                ss.imbue(l1);
-                ss << std::setprecision(10) ;
-                ss << boost::locale::as::number << 12345.45;
-                std::string v=ss.str();
-                TEST(v == "12345,45" || v == "12 345,45" || v=="12.345,45");
-            }
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,char>(l1,lreal);
         }
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        if(lreal)
-            freelocale(lreal);
-        return EXIT_FAILURE;
+    {
+        std::cout << "en_US.Latin-1 locale" << std::endl;
+        std::string name = "en_US.ISO8859-1";
+        if(!have_locale(name)) {
+            std::cout << "en_US.ISO8859-8 not supported" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name);
+            lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
+            assert(lreal);
+            test_by_char<char,char>(l1,lreal);
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,char>(l1,lreal);
+        }
     }
-    FINALIZE();
+    {
+        std::cout << "he_IL.UTF locale" << std::endl;
+        name="he_IL.UTF-8";
+        if(!have_locale(name)) {
+            std::cout << name << " not supported" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name);
+            lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
+            assert(lreal);
+            std::cout << "UTF-8" << std::endl;
 
+            test_by_char<char,char>(l1,lreal);
+
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,char>(l1,lreal);
+        }
+    }
+    {
+        std::cout << "he_IL.ISO locale" << std::endl;
+        std::string name = "he_IL.ISO8859-8";
+        if(!have_locale(name)) {
+            std::cout << name << " not supported" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name);
+            lreal=newlocale(LC_ALL_MASK,name.c_str(),0);
+            assert(lreal);
+            test_by_char<char,char>(l1,lreal);
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,char>(l1,lreal);
+        }
+    }
+    {
+        std::cout << "Testing UTF-8 punct issues" << std::endl;
+        std::string name = "ru_RU.UTF-8";
+        if(!have_locale(name)) {
+            std::cout << "- No russian locale" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name);
+            std::ostringstream ss;
+            ss.imbue(l1);
+            ss << std::setprecision(10) ;
+            ss << boost::locale::as::number << 12345.45;
+            std::string v=ss.str();
+            TEST(v == "12345,45" || v == "12 345,45" || v=="12.345,45");
+        }
+    }
 }
 
 #endif // posix

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -235,7 +235,7 @@ int main()
             std::cout << "he_IL.ISO locale" << std::endl;
             std::string name = "he_IL.ISO8859-8";
             if(!have_locale(name)) {
-                std::cout << name <<" not supported" << std::endl;
+                std::cout << name << " not supported" << std::endl;
             }
             else {
                 std::locale l1=gen(name);

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "POSIX Backend is not build... Skipping" << std::endl;
+        std::cout << "POSIX Backend is not build... Skipping\n";
 }
 #else
 #include <boost/locale/formatting.hpp>

--- a/test/test_posix_tools.hpp
+++ b/test/test_posix_tools.hpp
@@ -26,6 +26,24 @@ inline bool have_locale(std::string const &name)
     return false;
 }
 
+class locale_holder
+{
+    locale_t l_;
+    locale_holder(const locale_holder&);
+    locale_holder& operator=(const locale_holder&);
+    void reset(const locale_t l = 0)
+    {
+        if(l_)
+            freelocale(l_);
+        l_ = l;
+    }
+public:
+    explicit locale_holder(locale_t l = 0): l_(l) {}
+    ~locale_holder() { reset(); }
+    operator locale_t() const { return l_; }
+    locale_holder& operator=(locale_t l) { reset(l); return *this; }
+};
+
 #endif
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/test/test_std_collate.cpp
+++ b/test/test_std_collate.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "STD Backend is not build... Skipping" << std::endl;
+        std::cout << "STD Backend is not build... Skipping\n";
 }
 #else
 
@@ -76,7 +76,7 @@ void test_char()
     std::string name;
 
     #if defined(_LIBCPP_VERSION) && (defined(__APPLE__) || defined(__FreeBSD__))
-    std::cout << "- Collation is broken on this OS's standard C++ library, skipping" << std::endl;
+    std::cout << "- Collation is broken on this OS's standard C++ library, skipping\n";
     #else
     std::string names[] = { "en_US.UTF-8", "en_US.ISO8859-1" };
     for(unsigned i=0;i<sizeof(names)/sizeof(names[0]);i++) {

--- a/test/test_std_collate.cpp
+++ b/test/test_std_collate.cpp
@@ -95,32 +95,24 @@ void test_char()
 }
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("std");
-        boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("std");
+    boost::locale::localization_backend_manager::global(mgr);
 
-        std::cout << "Testing char" << std::endl;
-        test_char<char>();
-        std::cout << "Testing wchar_t" << std::endl;
-        test_char<wchar_t>();
-        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        std::cout << "Testing char16_t" << std::endl;
-        test_char<char16_t>();
-        #endif
-        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        std::cout << "Testing char32_t" << std::endl;
-        test_char<char32_t>();
-        #endif
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    std::cout << "Testing char" << std::endl;
+    test_char<char>();
+    std::cout << "Testing wchar_t" << std::endl;
+    test_char<wchar_t>();
+    #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    std::cout << "Testing char16_t" << std::endl;
+    test_char<char16_t>();
+    #endif
+    #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    std::cout << "Testing char32_t" << std::endl;
+    test_char<char32_t>();
+    #endif
 }
 
 #endif // NO STD

--- a/test/test_std_convert.cpp
+++ b/test/test_std_convert.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "STD Backend is not build... Skipping" << std::endl;
+        std::cout << "STD Backend is not build... Skipping\n";
 }
 #else
 

--- a/test/test_std_convert.cpp
+++ b/test/test_std_convert.cpp
@@ -83,32 +83,24 @@ void test_char()
 }
 
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("std");
-        boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("std");
+    boost::locale::localization_backend_manager::global(mgr);
 
-        std::cout << "Testing char" << std::endl;
-        test_char<char>();
-        std::cout << "Testing wchar_t" << std::endl;
-        test_char<wchar_t>();
-        #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        std::cout << "Testing char16_t" << std::endl;
-        test_char<char16_t>();
-        #endif
-        #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        std::cout << "Testing char32_t" << std::endl;
-        test_char<char32_t>();
-        #endif
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    std::cout << "Testing char" << std::endl;
+    test_char<char>();
+    std::cout << "Testing wchar_t" << std::endl;
+    test_char<wchar_t>();
+    #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    std::cout << "Testing char16_t" << std::endl;
+    test_char<char16_t>();
+    #endif
+    #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    std::cout << "Testing char32_t" << std::endl;
+    test_char<char32_t>();
+    #endif
 }
 
 #endif // no std

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "STD Backend is not build... Skipping" << std::endl;
+        std::cout << "STD Backend is not build... Skipping\n";
 }
 #else
 

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -205,159 +205,151 @@ void test_by_char(std::locale const &l,std::locale const &lreal)
 
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("std");
-        boost::locale::localization_backend_manager::global(mgr);
-        boost::locale::generator gen;
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("std");
+    boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::generator gen;
 
-        {
-            std::cout << "en_US.UTF locale" << std::endl;
-            std::string real_name;
-            std::string name = get_std_name("en_US.UTF-8",&real_name);
-            if(name.empty()) {
-                std::cout << "en_US.UTF-8 not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name),l2(real_name.c_str());
-                std::cout << "UTF-8" << std::endl;
-                if(name==real_name)
-                    test_by_char<char,char>(l1,l2);
-                else
-                    test_by_char<char,wchar_t>(l1,l2);
-
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,wchar_t>(l1,l2);
-
-                #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                std::cout << "char16 UTF-16" << std::endl;
-                test_by_char<char16_t,char16_t>(l1,l2);
-                #endif
-                #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                std::cout << "char32 UTF-32" << std::endl;
-                test_by_char<char32_t,char32_t>(l1,l2);
-                #endif
-            }
+    {
+        std::cout << "en_US.UTF locale" << std::endl;
+        std::string real_name;
+        std::string name = get_std_name("en_US.UTF-8",&real_name);
+        if(name.empty()) {
+            std::cout << "en_US.UTF-8 not supported" << std::endl;
         }
-        {
-            std::cout << "en_US.Latin-1 locale" << std::endl;
-            std::string real_name;
-            std::string name = get_std_name("en_US.ISO8859-1",&real_name);
-            if(name.empty()) {
-                std::cout << "en_US.ISO8859-8 not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name),l2(real_name.c_str());
+        else {
+            std::locale l1=gen(name),l2(real_name.c_str());
+            std::cout << "UTF-8" << std::endl;
+            if(name==real_name)
                 test_by_char<char,char>(l1,l2);
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,wchar_t>(l1,l2);
+            else
+                test_by_char<char,wchar_t>(l1,l2);
 
-                #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                std::cout << "char16 UTF-16" << std::endl;
-                test_by_char<char16_t,char16_t>(l1,l2);
-                #endif
-                #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                std::cout << "char32 UTF-32" << std::endl;
-                test_by_char<char32_t,char32_t>(l1,l2);
-                #endif
-            }
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,wchar_t>(l1,l2);
+
+            #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            std::cout << "char16 UTF-16" << std::endl;
+            test_by_char<char16_t,char16_t>(l1,l2);
+            #endif
+            #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            std::cout << "char32 UTF-32" << std::endl;
+            test_by_char<char32_t,char32_t>(l1,l2);
+            #endif
         }
-        {
-            std::cout << "he_IL.UTF locale" << std::endl;
-            std::string real_name;
-            std::string name = get_std_name("he_IL.UTF-8",&real_name);
-            if(name.empty()) {
-                std::cout << "he_IL.UTF-8 not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name),l2(real_name.c_str());
-                std::cout << "UTF-8" << std::endl;
-                if(name==real_name)
-                    test_by_char<char,char>(l1,l2);
-                else
-                    test_by_char<char,wchar_t>(l1,l2);
-
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,wchar_t>(l1,l2);
-
-                #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                std::cout << "char16 UTF-16" << std::endl;
-                test_by_char<char16_t,char16_t>(l1,l2);
-                #endif
-                #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                std::cout << "char32 UTF-32" << std::endl;
-                test_by_char<char32_t,char32_t>(l1,l2);
-                #endif
-            }
+    }
+    {
+        std::cout << "en_US.Latin-1 locale" << std::endl;
+        std::string real_name;
+        std::string name = get_std_name("en_US.ISO8859-1",&real_name);
+        if(name.empty()) {
+            std::cout << "en_US.ISO8859-8 not supported" << std::endl;
         }
-        {
-            std::cout << "he_IL.ISO8859-8 locale" << std::endl;
-            std::string real_name;
-            std::string name = get_std_name("he_IL.ISO8859-8",&real_name);
-            if(name.empty()) {
-                std::cout << "he_IL.ISO8859-8 not supported" << std::endl;
-            }
-            else {
-                std::locale l1=gen(name),l2(real_name.c_str());
+        else {
+            std::locale l1=gen(name),l2(real_name.c_str());
+            test_by_char<char,char>(l1,l2);
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,wchar_t>(l1,l2);
+
+            #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            std::cout << "char16 UTF-16" << std::endl;
+            test_by_char<char16_t,char16_t>(l1,l2);
+            #endif
+            #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            std::cout << "char32 UTF-32" << std::endl;
+            test_by_char<char32_t,char32_t>(l1,l2);
+            #endif
+        }
+    }
+    {
+        std::cout << "he_IL.UTF locale" << std::endl;
+        std::string real_name;
+        std::string name = get_std_name("he_IL.UTF-8",&real_name);
+        if(name.empty()) {
+            std::cout << "he_IL.UTF-8 not supported" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name),l2(real_name.c_str());
+            std::cout << "UTF-8" << std::endl;
+            if(name==real_name)
                 test_by_char<char,char>(l1,l2);
-                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-                test_by_char<wchar_t,wchar_t>(l1,l2);
+            else
+                test_by_char<char,wchar_t>(l1,l2);
 
-                #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                std::cout << "char16 UTF-16" << std::endl;
-                test_by_char<char16_t,char16_t>(l1,l2);
-                #endif
-                #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                std::cout << "char32 UTF-32" << std::endl;
-                test_by_char<char32_t,char32_t>(l1,l2);
-                #endif
-            }
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,wchar_t>(l1,l2);
+
+            #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            std::cout << "char16 UTF-16" << std::endl;
+            test_by_char<char16_t,char16_t>(l1,l2);
+            #endif
+            #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            std::cout << "char32 UTF-32" << std::endl;
+            test_by_char<char32_t,char32_t>(l1,l2);
+            #endif
         }
-        {
-            std::cout << "Testing UTF-8 punct workaround" << std::endl;
-            std::string real_name;
-            std::string name = get_std_name("ru_RU.UTF-8",&real_name);
-            if(name.empty()) {
-                std::cout << "- No russian locale" << std::endl;
+    }
+    {
+        std::cout << "he_IL.ISO8859-8 locale" << std::endl;
+        std::string real_name;
+        std::string name = get_std_name("he_IL.ISO8859-8",&real_name);
+        if(name.empty()) {
+            std::cout << "he_IL.ISO8859-8 not supported" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name),l2(real_name.c_str());
+            test_by_char<char,char>(l1,l2);
+            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+            test_by_char<wchar_t,wchar_t>(l1,l2);
+
+            #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            std::cout << "char16 UTF-16" << std::endl;
+            test_by_char<char16_t,char16_t>(l1,l2);
+            #endif
+            #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            std::cout << "char32 UTF-32" << std::endl;
+            test_by_char<char32_t,char32_t>(l1,l2);
+            #endif
+        }
+    }
+    {
+        std::cout << "Testing UTF-8 punct workaround" << std::endl;
+        std::string real_name;
+        std::string name = get_std_name("ru_RU.UTF-8",&real_name);
+        if(name.empty()) {
+            std::cout << "- No russian locale" << std::endl;
+        }
+        else if(name != real_name) {
+            std::cout << "- Not having UTF-8 locale, no need for workaround" << std::endl;
+        }
+        else {
+            std::locale l1=gen(name),l2(real_name.c_str());
+            bool fails = false;
+            try {
+                std::ostringstream ss;
+                ss.imbue(l2);
+                ss << 12345.45;
+                boost::locale::conv::from_utf<char>(ss.str(),"windows-1251",boost::locale::conv::stop);
+                fails = false;
             }
-            else if(name != real_name) {
-                std::cout << "- Not having UTF-8 locale, no need for workaround" << std::endl;
+            catch(...) {
+                fails = true;
+            }
+
+            if(!fails) {
+                std::cout << "- No invalid UTF. No need to check" << std::endl;
             }
             else {
-                std::locale l1=gen(name),l2(real_name.c_str());
-                bool fails = false;
-                try {
-                    std::ostringstream ss;
-                    ss.imbue(l2);
-                    ss << 12345.45;
-                    boost::locale::conv::from_utf<char>(ss.str(),"windows-1251",boost::locale::conv::stop);
-                    fails = false;
-                }
-                catch(...) {
-                    fails = true;
-                }
-
-                if(!fails) {
-                    std::cout << "- No invalid UTF. No need to check" << std::endl;
-                }
-                else {
-                    std::ostringstream ss;
-                    ss.imbue(l1);
-                    ss << std::setprecision(10) ;
-                    ss << boost::locale::as::number << 12345.45;
-                    TEST(ss.str() == "12 345,45" || ss.str()=="12345,45");
-                }
+                std::ostringstream ss;
+                ss.imbue(l1);
+                ss << std::setprecision(10) ;
+                ss << boost::locale::as::number << 12345.45;
+                TEST(ss.str() == "12 345,45" || ss.str()=="12345,45");
             }
         }
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
 }
 
 #endif // no std

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -340,7 +340,7 @@ int main()
                 }
 
                 if(!fails) {
-                    std::cout << "- No invalid UTF. No need to check"<<std::endl;
+                    std::cout << "- No invalid UTF. No need to check" << std::endl;
                 }
                 else {
                     std::ostringstream ss;

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -281,18 +281,11 @@ void test_utf32()
 #endif
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        test_utf8();
-        test_utf16();
-        test_utf32();
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
+    test_utf8();
+    test_utf16();
+    test_utf32();
 }
 
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -126,7 +126,7 @@ void test_valid_utf(CharType const* str, unsigned codepoint)
 
 void test_utf8()
 {
-    std::cout << "- Test UTF-8" << std::endl;
+    std::cout << "- Test UTF-8\n";
 
     std::cout << "-- Correct" << std::endl;
     test_valid_utf("\x7f", 0x7f);
@@ -210,7 +210,7 @@ void test_utf8()
 
 void test_utf16()
 {
-    std::cout << "- Test UTF-16" << std::endl;
+    std::cout << "- Test UTF-16\n";
 
     std::cout << "-- Correct" << std::endl;
     test_valid_utf(u16_seq(0x10), 0x10);
@@ -245,7 +245,7 @@ void test_utf16()
 
 void test_utf32()
 {
-    std::cout << "- Test UTF-32" << std::endl;
+    std::cout << "- Test UTF-32\n";
 
     std::cout << "-- Correct" << std::endl;
     test_valid_utf(u32_seq(0x10), 0x10);

--- a/test/test_winapi_collate.cpp
+++ b/test/test_winapi_collate.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "WinAPI Backend is not build... Skipping" << std::endl;
+        std::cout << "WinAPI Backend is not build... Skipping\n";
 }
 #else
 

--- a/test/test_winapi_collate.cpp
+++ b/test/test_winapi_collate.cpp
@@ -109,24 +109,13 @@ void test_collate()
     compare("ä","a",identical,gt); //  a , ä
 }
 
-
-
-
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("winapi");
-        boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("winapi");
+    boost::locale::localization_backend_manager::global(mgr);
 
-        test_collate();
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    test_collate();
 }
 #endif // NO WINAPI
 // vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/test/test_winapi_convert.cpp
+++ b/test/test_winapi_convert.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "WinAPI Backend is not build... Skipping" << std::endl;
+        std::cout << "WinAPI Backend is not build... Skipping\n";
 }
 #else
 

--- a/test/test_winapi_convert.cpp
+++ b/test/test_winapi_convert.cpp
@@ -71,34 +71,26 @@ void test_norm(std::string orig,std::string normal,boost::locale::norm_type type
     test_normc<wchar_t>(to<wchar_t>(orig),to<wchar_t>(normal),type);
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("winapi");
-        boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("winapi");
+    boost::locale::localization_backend_manager::global(mgr);
 
-        std::cout << "Testing char" << std::endl;
-        test_char<char>();
-        std::cout << "Testing wchar_t" << std::endl;
-        test_char<wchar_t>();
+    std::cout << "Testing char" << std::endl;
+    test_char<char>();
+    std::cout << "Testing wchar_t" << std::endl;
+    test_char<wchar_t>();
 
-        std::cout << "Testing Unicode normalization" << std::endl;
-        test_norm("\xEF\xAC\x81","\xEF\xAC\x81",boost::locale::norm_nfd); /// ligature fi
-        test_norm("\xEF\xAC\x81","\xEF\xAC\x81",boost::locale::norm_nfc);
-        #if defined(_WIN32_NT) && _WIN32_NT >= 0x600
-        test_norm("\xEF\xAC\x81","fi",boost::locale::norm_nfkd);
-        test_norm("\xEF\xAC\x81","fi",boost::locale::norm_nfkc);
-        #endif
-        test_norm("ä","ä",boost::locale::norm_nfd); // ä to a and accent
-        test_norm("ä","ä",boost::locale::norm_nfc);
-    }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    std::cout << "Testing Unicode normalization" << std::endl;
+    test_norm("\xEF\xAC\x81","\xEF\xAC\x81",boost::locale::norm_nfd); /// ligature fi
+    test_norm("\xEF\xAC\x81","\xEF\xAC\x81",boost::locale::norm_nfc);
+    #if defined(_WIN32_NT) && _WIN32_NT >= 0x600
+    test_norm("\xEF\xAC\x81","fi",boost::locale::norm_nfkd);
+    test_norm("\xEF\xAC\x81","fi",boost::locale::norm_nfkc);
+    #endif
+    test_norm("ä","ä",boost::locale::norm_nfd); // ä to a and accent
+    test_norm("ä","ä",boost::locale::norm_nfc);
 }
 
 #endif // no winapi

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 int main()
 {
-        std::cout << "WinAPI Backend is not build... Skipping" << std::endl;
+        std::cout << "WinAPI Backend is not build... Skipping\n";
 }
 #else
 
@@ -40,7 +40,7 @@ bool equal(std::string const &s1,std::wstring const &s2)
     bool res = s1 == boost::locale::conv::from_utf(s2,"UTF-8");
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << s1 << "]!=[" << boost::locale::conv::from_utf(s2,"UTF-8") << "]" << std::endl;
+        std::cout << "[" << s1 << "]!=[" << boost::locale::conv::from_utf(s2,"UTF-8") << "]\n";
     #endif
     return res;
 }
@@ -50,7 +50,7 @@ bool equal(std::wstring const &s1,std::wstring const &s2)
     bool res = s1 == s2;
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=[" << boost::locale::conv::from_utf(s2,"UTF-8") << "]" << std::endl;
+        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=[" << boost::locale::conv::from_utf(s2,"UTF-8") << "]\n";
     #endif
     return res;
 }
@@ -61,7 +61,7 @@ bool equal(std::string const &s1,std::string const &s2)
     bool res = s1 == s2;
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << s1 << "]!=[" << s2 << "]" << std::endl;
+        std::cout << "[" << s1 << "]!=[" << s2 << "]\n";
     #endif
     return res;
 }
@@ -71,7 +71,7 @@ bool equal(std::wstring const &s1,std::string const &s2)
     bool res = s1 == boost::locale::conv::to_utf<wchar_t>(s2,"UTF-8");
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=[" << s2 << "]" << std::endl;
+        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=[" << s2 << "]\n";
     #endif
     return res;
 

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -225,39 +225,31 @@ void test_date_time(std::locale l)
     }
 }
 
-int main()
+void test_main(int /*argc*/, char** /*argv*/)
 {
-    try {
-        boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
-        mgr.select("winapi");
-        boost::locale::localization_backend_manager::global(mgr);
-        boost::locale::generator gen;
-        std::string name;
-        std::string names[] = { "en_US.UTF-8", "he_IL.UTF-8", "ru_RU.UTF-8" };
-        int lcids[] = { 0x0409, 0x040D ,0x0419 };
+    boost::locale::localization_backend_manager mgr = boost::locale::localization_backend_manager::global();
+    mgr.select("winapi");
+    boost::locale::localization_backend_manager::global(mgr);
+    boost::locale::generator gen;
+    std::string name;
+    std::string names[] = { "en_US.UTF-8", "he_IL.UTF-8", "ru_RU.UTF-8" };
+    int lcids[] = { 0x0409, 0x040D ,0x0419 };
 
-        for(unsigned i=0;i<sizeof(names)/sizeof(names[9]);i++) {
-            name = names[i];
-            std::cout << "- " << name << " locale" << std::endl;
-            if(boost::locale::impl_win::locale_to_lcid(name) == 0) {
-                std::cout << "-- not supported, skipping" << std::endl;
-                continue;
-            }
-            std::locale l1=gen(name);
-            std::cout << "-- UTF-8" << std::endl;
-            test_by_char<char>(l1,name,lcids[i]);
-            std::cout << "-- UTF-16" << std::endl;
-            test_by_char<wchar_t>(l1,name,lcids[i]);
+    for(unsigned i=0;i<sizeof(names)/sizeof(names[9]);i++) {
+        name = names[i];
+        std::cout << "- " << name << " locale" << std::endl;
+        if(boost::locale::impl_win::locale_to_lcid(name) == 0) {
+            std::cout << "-- not supported, skipping" << std::endl;
+            continue;
         }
-        std::cout << "- Testing strftime" << std::endl;
-        test_date_time(gen("en_US.UTF-8"));
+        std::locale l1=gen(name);
+        std::cout << "-- UTF-8" << std::endl;
+        test_by_char<char>(l1,name,lcids[i]);
+        std::cout << "-- UTF-16" << std::endl;
+        test_by_char<wchar_t>(l1,name,lcids[i]);
     }
-    catch(std::exception const &e) {
-        std::cerr << "Failed " << e.what() << std::endl;
-        return EXIT_FAILURE;
-    }
-    FINALIZE();
-
+    std::cout << "- Testing strftime" << std::endl;
+    test_date_time(gen("en_US.UTF-8"));
 }
 
 #endif // no winapi

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -40,7 +40,7 @@ bool equal(std::string const &s1,std::wstring const &s2)
     bool res = s1 == boost::locale::conv::from_utf(s2,"UTF-8");
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << s1 << "]!=["<<boost::locale::conv::from_utf(s2,"UTF-8")<<"]"<<std::endl;
+        std::cout << "[" << s1 << "]!=[" << boost::locale::conv::from_utf(s2,"UTF-8") << "]" << std::endl;
     #endif
     return res;
 }
@@ -50,7 +50,7 @@ bool equal(std::wstring const &s1,std::wstring const &s2)
     bool res = s1 == s2;
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=["<<boost::locale::conv::from_utf(s2,"UTF-8")<<"]"<<std::endl;
+        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=[" << boost::locale::conv::from_utf(s2,"UTF-8") << "]" << std::endl;
     #endif
     return res;
 }
@@ -61,7 +61,7 @@ bool equal(std::string const &s1,std::string const &s2)
     bool res = s1 == s2;
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << s1 << "]!=["<<s2<<"]"<<std::endl;
+        std::cout << "[" << s1 << "]!=[" << s2 << "]" << std::endl;
     #endif
     return res;
 }
@@ -71,7 +71,7 @@ bool equal(std::wstring const &s1,std::string const &s2)
     bool res = s1 == boost::locale::conv::to_utf<wchar_t>(s2,"UTF-8");
     #ifdef DEBUG_FMT
     if(!res)
-        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=["<<s2<<"]"<<std::endl;
+        std::cout << "[" << boost::locale::conv::from_utf(s1,"UTF-8") << "]!=[" << s2 << "]" << std::endl;
     #endif
     return res;
 
@@ -249,7 +249,7 @@ int main()
             std::cout << "-- UTF-16" << std::endl;
             test_by_char<wchar_t>(l1,name,lcids[i]);
         }
-        std::cout << "- Testing strftime" <<std::endl;
+        std::cout << "- Testing strftime" << std::endl;
         test_date_time(gen("en_US.UTF-8"));
     }
     catch(std::exception const &e) {


### PR DESCRIPTION
That example reads from stdin causing timeouts in some envs.

Remove `using namespace std;` to differentiate between Boost.Locale and `std` and adjust related formatting.