### PR TITLE
Refactor ICU build

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -60,8 +60,17 @@ explicit has_xlocale ;
 
 ICU_PATH =  [ modules.peek : ICU_PATH ] ;
 ICU_LINK =  [ modules.peek : ICU_LINK ] ;
+# Temporary workaround for incompatibility of ICU_LINK with Boost.Regex:
+# Use ICU_LINK_LOCALE instead of ICU_LINK.
+# Note that ICU_LINK and ICU_LINK_LOCALE will be removed in Boost 1.81
+# in favor of a similar solution to Boost.Regex or a B2 module.
+ICU_LINK_LOCALE =  [ modules.peek : ICU_LINK_LOCALE ] ;
 
-if $(ICU_LINK)
+if $(ICU_LINK_LOCALE)
+{
+    ICU_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK_LOCALE) <dll-path>$(ICU_PATH)/bin <runtime-link>shared ;
+    ICU64_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK_LOCALE) <dll-path>$(ICU_PATH)/bin64 <runtime-link>shared ;
+} else if $(ICU_LINK)
 {
     ICU_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK) <dll-path>$(ICU_PATH)/bin <runtime-link>shared ;
     ICU64_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK) <dll-path>$(ICU_PATH)/bin64 <runtime-link>shared ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -4,9 +4,9 @@
 # http://www.boost.org/LICENSE_1_0.txt.
 
 import configure ;
+import feature ;
 import os ;
 import toolset ;
-import feature ;
 
 path-constant TOP : .. ;
 
@@ -26,8 +26,7 @@ feature.feature boost.locale.winapi : on off : optional propagated ;
 
 ## iconv
 
-obj has_iconv_libc_obj : $(TOP)/build/has_iconv.cpp ;
-exe has_iconv : has_iconv_libc_obj ;
+exe has_iconv : $(TOP)/build/has_iconv.cpp ;
 explicit has_iconv ;
 
 ICONV_PATH = [ modules.peek : ICONV_PATH ] ;
@@ -41,8 +40,7 @@ lib iconv
 
 explicit iconv ;
 
-obj has_iconv_libc_ext : $(TOP)/build/has_iconv.cpp iconv ;
-exe has_external_iconv : has_iconv_libc_ext iconv ;
+exe has_external_iconv : $(TOP)/build/has_iconv.cpp iconv ;
 explicit has_external_iconv ;
 
 exe accepts_shared_option   : $(TOP)/build/option.cpp
@@ -53,8 +51,8 @@ exe accepts_shared_option   : $(TOP)/build/option.cpp
                             ;
 
 # Xlocale
-obj has_xlocale_obj : $(TOP)/build/has_xlocale.cpp ;
-exe has_xlocale : has_xlocale_obj ;
+
+exe has_xlocale : $(TOP)/build/has_xlocale.cpp ;
 explicit has_xlocale ;
 
 #end xlocale
@@ -67,8 +65,7 @@ if $(ICU_LINK)
 {
     ICU_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK) <dll-path>$(ICU_PATH)/bin <runtime-link>shared ;
     ICU64_OPTS = <include>$(ICU_PATH)/include <linkflags>$(ICU_LINK) <dll-path>$(ICU_PATH)/bin64 <runtime-link>shared ;
-}
-else
+} else
 {
     searched-lib icuuc : :  <name>icuuc
                             <search>$(ICU_PATH)/lib
@@ -186,14 +183,10 @@ else
       <dll-path>$(ICU_PATH)/bin64
         <runtime-link>shared ;
 
-
 }
 
-obj has_icu_obj     : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS)   ;
-obj has_icu64_obj   : $(TOP)/build/has_icu_test.cpp : $(ICU64_OPTS) ;
-
-exe has_icu   : has_icu_obj   : $(ICU_OPTS)   ;
-exe has_icu64 : has_icu64_obj : $(ICU64_OPTS) ;
+exe has_icu   : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS)   ;
+exe has_icu64 : $(TOP)/build/has_icu_test.cpp : $(ICU64_OPTS) ;
 
 explicit has_icu has_icu64 ;
 
@@ -209,22 +202,19 @@ rule configure-full ( properties * : flags-only )
 
     local found-iconv ;
 
+    # The system Iconv on Solaris may have bugs, while the GNU Iconv is fine.
+    # So enable by default only if not on Solaris.
     if <boost.locale.iconv>on in $(properties)
-      || ! <boost.locale.iconv> in $(properties:G)
-        && ! <target-os>solaris in $(properties)
+      || ( ! <boost.locale.iconv> in $(properties:G) && ! <target-os>solaris in $(properties) )
     {
         # See if iconv is bundled with standard library.
         if [ configure.builds has_iconv : $(properties) : "iconv (libc)" ]
         {
             found-iconv = true ;
-        }
-        else
+        } else if [ configure.builds has_external_iconv : $(properties) : "iconv (separate)" ]
         {
-            if [ configure.builds has_external_iconv : $(properties) : "iconv (separate)" ]
-            {
-                found-iconv = true ;
-                result += <library>iconv ;
-            }
+            found-iconv = true ;
+            result += <library>iconv ;
         }
     }
     if $(found-iconv)
@@ -240,8 +230,7 @@ rule configure-full ( properties * : flags-only )
         {
             found-icu = true ;
             flags-result += <define>BOOST_LOCALE_WITH_ICU=1 $(ICU_OPTS) ;
-        }
-        else if [ configure.builds has_icu64 : $(properties) : "icu (lib64)" ]
+        } else if [ configure.builds has_icu64 : $(properties) : "icu (lib64)" ]
         {
             found-icu = true ;
             flags-result += <define>BOOST_LOCALE_WITH_ICU=1 $(ICU64_OPTS) ;
@@ -265,7 +254,6 @@ rule configure-full ( properties * : flags-only )
                       <library>/boost/thread//boost_thread
                       ;
         }
-
     }
 
     if ! $(found-iconv) && ! $(found-icu) && ! <target-os>windows in $(properties) && ! <target-os>cygwin in $(properties)
@@ -279,8 +267,7 @@ rule configure-full ( properties * : flags-only )
         if <toolset>sun in $(properties)
         {
             properties += <boost.locale.std>off ;
-        }
-        else
+        } else
         {
             properties += <boost.locale.std>on ;
         }
@@ -289,8 +276,7 @@ rule configure-full ( properties * : flags-only )
     if <boost.locale.std>off in $(properties)
     {
         flags-result += <define>BOOST_LOCALE_NO_STD_BACKEND=1 ;
-    }
-    else
+    } else
     {
         STD_SOURCES =
           codecvt
@@ -304,12 +290,10 @@ rule configure-full ( properties * : flags-only )
 
     if ! <boost.locale.winapi> in $(properties:G)
     {
-        if <target-os>windows in $(properties)
-          || <target-os>cygwin in $(properties)
+        if <target-os>windows in $(properties) || <target-os>cygwin in $(properties)
         {
             properties += <boost.locale.winapi>on ;
-        }
-        else
+        } else
         {
             properties += <boost.locale.winapi>off ;
         }
@@ -329,8 +313,7 @@ rule configure-full ( properties * : flags-only )
     if <boost.locale.winapi>off in $(properties)
     {
         flags-result += <define>BOOST_LOCALE_NO_WINAPI_BACKEND=1 ;
-    }
-    else
+    } else
     {
         WINAPI_SOURCES =
             collate
@@ -354,8 +337,7 @@ rule configure-full ( properties * : flags-only )
             || ( <target-os>freebsd in $(properties) && [ configure.builds has_xlocale : $(properties) : "xlocale supported" ] )
         {
             properties += <boost.locale.posix>on ;
-        }
-        else
+        } else
         {
             properties += <boost.locale.posix>off ;
         }
@@ -364,8 +346,7 @@ rule configure-full ( properties * : flags-only )
     if <boost.locale.posix>off in $(properties)
     {
         flags-result += <define>BOOST_LOCALE_NO_POSIX_BACKEND=1 ;
-    }
-    else
+    } else
     {
         POSIX_SOURCES =
           collate
@@ -385,8 +366,7 @@ rule configure-full ( properties * : flags-only )
     if "$(flags-only)" = "flags"
     {
         return $(flags-result) ;
-    }
-    else
+    } else
     {
         result += $(flags-result) ;
         return $(result) ;

--- a/src/boost/locale/icu/boundary.cpp
+++ b/src/boost/locale/icu/boundary.cpp
@@ -9,18 +9,16 @@
 #include <boost/locale/boundary.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/hold_ptr.hpp>
-#include <unicode/uversion.h>
-#if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 306
+#include "boost/locale/icu/all_generator.hpp"
+#include "boost/locale/icu/cdata.hpp"
+#include "boost/locale/icu/icu_util.hpp"
+#include "boost/locale/icu/uconv.hpp"
+#if BOOST_LOCALE_ICU_VERSION >= 306
 #include <unicode/utext.h>
 #endif
 #include <unicode/brkiter.h>
 #include <unicode/rbbi.h>
 #include <vector>
-
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/uconv.hpp"
 
 #ifdef BOOST_MSVC
 #pragma warning(disable:4244) // 'argument' : conversion from 'int'
@@ -143,7 +141,7 @@ index_type do_map(boundary_type t,CharType const *begin,CharType const *end,icu:
     index_type indx;
     hold_ptr<icu::BreakIterator> bi(get_iterator(t,loc));
 
-#if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 306
+#if BOOST_LOCALE_ICU_VERSION >= 306
     UErrorCode err=U_ZERO_ERROR;
 BOOST_LOCALE_START_CONST_CONDITION
     if(sizeof(CharType) == 2 || (sizeof(CharType)==1 && encoding=="UTF-8"))

--- a/src/boost/locale/icu/cdata.hpp
+++ b/src/boost/locale/icu/cdata.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_LOCALE_ICU_CDATA_HPP
 #define BOOST_LOCALE_ICU_CDATA_HPP
 
+#include <boost/locale/config.hpp>
 #include <unicode/locid.h>
 #include <string>
 

--- a/src/boost/locale/icu/codecvt.hpp
+++ b/src/boost/locale/icu/codecvt.hpp
@@ -7,9 +7,11 @@
 //
 #ifndef BOOST_LOCALE_IMPL_ICU_CODECVT_HPP
 #define BOOST_LOCALE_IMPL_ICU_CODECVT_HPP
+
 #include <boost/locale/config.hpp>
 #include <boost/locale/util.hpp>
-#include <memory>
+#include <string>
+
 namespace boost {
 namespace locale {
 namespace impl_icu {

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -8,18 +8,20 @@
 #define BOOST_LOCALE_SOURCE
 #include <boost/locale/collator.hpp>
 #include <boost/locale/generator.hpp>
+#include "boost/locale/icu/all_generator.hpp"
+#include "boost/locale/icu/cdata.hpp"
+#include "boost/locale/icu/icu_util.hpp"
+#include "boost/locale/icu/uconv.hpp"
+#include "boost/locale/shared/mo_hash.hpp"
 #include <boost/thread.hpp>
 #include <vector>
 #include <limits>
-
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/uconv.hpp"
-#include "boost/locale/shared/mo_hash.hpp"
-
 #include <unicode/coll.h>
-#if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 402
+#if BOOST_LOCALE_ICU_VERSION >= 402
+#  define BOOST_LOCALE_WITH_STRINGPIECE 1
 #  include <unicode/stringpiece.h>
+#else
+#  define BOOST_LOCALE_WITH_STRINGPIECE 0
 #endif
 
 #ifdef BOOST_MSVC
@@ -44,7 +46,7 @@ namespace boost {
                     return level;
                 }
 
-                #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 402
+                #if BOOST_LOCALE_WITH_STRINGPIECE
                 int do_utf8_compare(    level_type level,
                                         char const *b1,char const *e1,
                                         char const *b2,char const *e2,
@@ -163,7 +165,7 @@ namespace boost {
             };
 
 
-            #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 402
+            #if BOOST_LOCALE_WITH_STRINGPIECE
             template<>
             int collate_impl<char>::do_real_compare(
                                     level_type level,

--- a/src/boost/locale/icu/conversion.cpp
+++ b/src/boost/locale/icu/conversion.cpp
@@ -9,15 +9,16 @@
 #include <boost/locale/conversion.hpp>
 #include "boost/locale/icu/all_generator.hpp"
 #include "boost/locale/icu/cdata.hpp"
+#include "boost/locale/icu/icu_util.hpp"
 #include "boost/locale/icu/uconv.hpp"
 
 #include <unicode/normlzr.h>
 #include <unicode/ustring.h>
 #include <unicode/locid.h>
 #include <unicode/uversion.h>
-#if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 308
+#if BOOST_LOCALE_ICU_VERSION >= 308
 #include <unicode/ucasemap.h>
-#define WITH_CASE_MAPS
+#define BOOST_LOCALE_WITH_CASEMAP
 #endif
 #include <vector>
 
@@ -98,7 +99,7 @@ namespace impl_icu {
         std::string encoding_;
     }; // converter_impl
 
-    #ifdef WITH_CASE_MAPS
+    #ifdef BOOST_LOCALE_WITH_CASEMAP
     class raii_casemap {
         raii_casemap(raii_casemap const &);
         void operator = (raii_casemap const&);
@@ -176,13 +177,13 @@ namespace impl_icu {
         raii_casemap map_;
     }; // converter_impl
 
-#endif // WITH_CASE_MAPS
+#endif // BOOST_LOCALE_WITH_CASEMAP
 
     std::locale create_convert(std::locale const &in,cdata const &cd,character_facet_type type)
     {
         switch(type) {
         case char_facet:
-            #ifdef WITH_CASE_MAPS
+            #ifdef BOOST_LOCALE_WITH_CASEMAP
             if(cd.utf8)
                 return std::locale(in,new utf8_converter_impl(cd));
             #endif

--- a/src/boost/locale/icu/date_time.cpp
+++ b/src/boost/locale/icu/date_time.cpp
@@ -10,6 +10,11 @@
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/hold_ptr.hpp>
+#include "boost/locale/icu/all_generator.hpp"
+#include "boost/locale/icu/cdata.hpp"
+#include "boost/locale/icu/icu_util.hpp"
+#include "boost/locale/icu/time_zone.hpp"
+#include "boost/locale/icu/uconv.hpp"
 #include <boost/thread.hpp>
 #include <cmath>
 #include <iostream>
@@ -17,11 +22,6 @@
 #include <unicode/calendar.h>
 #include <unicode/gregocal.h>
 #include <unicode/utypes.h>
-
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/time_zone.hpp"
-#include "boost/locale/icu/uconv.hpp"
 
 namespace boost {
 namespace locale {
@@ -70,7 +70,7 @@ namespace impl_icu {
             UErrorCode err=U_ZERO_ERROR;
             calendar_.reset(icu::Calendar::createInstance(dat.locale,err));
             check_and_throw_dt(err);
-            #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM < 402
+            #if BOOST_LOCALE_ICU_VERSION < 402
             // workaround old/invalid data, it should be 4 in general
             calendar_->setMinimalDaysInFirstWeek(4);
             #endif

--- a/src/boost/locale/icu/formatter.cpp
+++ b/src/boost/locale/icu/formatter.cpp
@@ -10,22 +10,17 @@
 #include "boost/locale/icu/formatter.hpp"
 #include <boost/locale/info.hpp>
 #include "boost/locale/icu/uconv.hpp"
-
+#include "boost/locale/icu/predefined_formatters.hpp"
+#include "boost/locale/icu/time_zone.hpp"
+#include <boost/core/ignore_unused.hpp>
 
 #include <unicode/numfmt.h>
 #include <unicode/rbnf.h>
 #include <unicode/datefmt.h>
 #include <unicode/smpdtfmt.h>
 #include <unicode/decimfmt.h>
-
 #include <limits>
-
 #include <iostream>
-
-#include "boost/locale/icu/predefined_formatters.hpp"
-#include "boost/locale/icu/time_zone.hpp"
-
-#include <boost/core/ignore_unused.hpp>
 
 #ifdef BOOST_MSVC
 #  pragma warning(disable : 4244) // lose data

--- a/src/boost/locale/icu/formatter.hpp
+++ b/src/boost/locale/icu/formatter.hpp
@@ -8,10 +8,10 @@
 #ifndef BOOST_LOCALE_FORMATTER_HPP_INCLUDED
 #define BOOST_LOCALE_FORMATTER_HPP_INCLUDED
 
+#include <boost/locale/config.hpp>
+#include <boost/cstdint.hpp>
 #include <string>
 #include <memory>
-#include <boost/cstdint.hpp>
-#include <boost/locale/config.hpp>
 #include <unicode/locid.h>
 
 namespace boost {

--- a/src/boost/locale/icu/icu_backend.hpp
+++ b/src/boost/locale/icu/icu_backend.hpp
@@ -7,6 +7,9 @@
 //
 #ifndef BOOST_LOCALE_IMPL_ICU_LOCALIZATION_BACKEND_HPP
 #define BOOST_LOCALE_IMPL_ICU_LOCALIZATION_BACKEND_HPP
+
+#include <boost/locale/config.hpp>
+
 namespace boost {
     namespace locale {
         class localization_backend;

--- a/src/boost/locale/icu/icu_util.hpp
+++ b/src/boost/locale/icu/icu_util.hpp
@@ -7,8 +7,16 @@
 //
 #ifndef BOOST_SRC_ICU_UTIL_HPP
 #define BOOST_SRC_ICU_UTIL_HPP
+
+#include <boost/locale/config.hpp>
+#ifdef BOOST_HAS_STDINT_H
+#include <stdint.h> // Avoid ICU defining e.g. INT8_MIN causing macro redefinition warnings
+#endif
 #include <unicode/utypes.h>
+#include <unicode/uversion.h>
 #include <stdexcept>
+
+#define BOOST_LOCALE_ICU_VERSION (U_ICU_VERSION_MAJOR_NUM * 100 + U_ICU_VERSION_MINOR_NUM)
 
 namespace boost {
 namespace locale {

--- a/src/boost/locale/icu/predefined_formatters.hpp
+++ b/src/boost/locale/icu/predefined_formatters.hpp
@@ -8,12 +8,13 @@
 #ifndef BOOST_LOCALE_PREDEFINED_FORMATTERS_HPP_INCLUDED
 #define BOOST_LOCALE_PREDEFINED_FORMATTERS_HPP_INCLUDED
 
-#include <string>
-#include <memory>
-#include <boost/cstdint.hpp>
-#include <boost/thread.hpp>
 #include <boost/locale/config.hpp>
 #include <boost/locale/hold_ptr.hpp>
+#include "boost/locale/icu/icu_util.hpp"
+#include <boost/cstdint.hpp>
+#include <boost/thread.hpp>
+#include <string>
+#include <memory>
 
 #include <unicode/locid.h>
 #include <unicode/numfmt.h>
@@ -99,28 +100,26 @@ namespace locale {
                 case fmt_sci:
                     ap.reset(icu::NumberFormat::createScientificInstance(locale_,err));
                     break;
-                #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 402
-                    #if U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM >= 408
+#if BOOST_LOCALE_ICU_VERSION >= 408
                     case fmt_curr_nat:
                         ap.reset(icu::NumberFormat::createInstance(locale_,UNUM_CURRENCY,err));
                         break;
                     case fmt_curr_iso:
                         ap.reset(icu::NumberFormat::createInstance(locale_,UNUM_CURRENCY_ISO,err));
                         break;
-                    #else
+#elif BOOST_LOCALE_ICU_VERSION >= 402
                     case fmt_curr_nat:
                         ap.reset(icu::NumberFormat::createInstance(locale_,icu::NumberFormat::kCurrencyStyle,err));
                         break;
                     case fmt_curr_iso:
                         ap.reset(icu::NumberFormat::createInstance(locale_,icu::NumberFormat::kIsoCurrencyStyle,err));
                         break;
-                    #endif
-                #else
+#else
                 case fmt_curr_nat:
                 case fmt_curr_iso:
                     ap.reset(icu::NumberFormat::createCurrencyInstance(locale_,err));
                     break;
-                #endif
+#endif
                 case fmt_per:
                     ap.reset(icu::NumberFormat::createPercentInstance(locale_,err));
                     break;

--- a/src/boost/locale/icu/time_zone.cpp
+++ b/src/boost/locale/icu/time_zone.cpp
@@ -7,6 +7,7 @@
 //
 #define BOOST_LOCALE_SOURCE
 #include "boost/locale/icu/time_zone.hpp"
+#include "boost/locale/icu/icu_util.hpp"
 #include <boost/locale/hold_ptr.hpp>
 #include <boost/predef/os.h>
 
@@ -20,7 +21,8 @@
 // It is also relevant only for Linux, BSD and Apple (as I see in ICU code)
 //
 
-#if U_ICU_VERSION_MAJOR_NUM == 4 && (U_ICU_VERSION_MINOR_NUM * 100 + U_ICU_VERSION_PATCHLEVEL_NUM) <= 402
+#if BOOST_LOCALE_ICU_VERSION >= 400 && BOOST_LOCALE_ICU_VERSION <= 406 \
+    && (BOOST_LOCALE_ICU_VERSION != 404 || U_ICU_VERSION_PATCHLEVEL_NUM >= 3)
 # if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
 #   define BOOST_LOCALE_WORKAROUND_ICU_BUG
 # endif

--- a/src/boost/locale/icu/time_zone.hpp
+++ b/src/boost/locale/icu/time_zone.hpp
@@ -8,6 +8,10 @@
 #ifndef BOOST_LOCALE_IMPL_ICU_GET_TIME_ZONE_HPP
 #define BOOST_LOCALE_IMPL_ICU_GET_TIME_ZONE_HPP
 
+#include <boost/locale/config.hpp>
+#ifdef BOOST_HAS_STDINT_H
+#include <stdint.h> // Avoid ICU defining e.g. INT8_MIN causing macro redefinition warnings
+#endif
 #include <unicode/calendar.h>
 #include <string>
 

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -15,9 +15,9 @@
 
 #ifdef BOOST_LOCALE_WITH_ICU
 #include <unicode/uversion.h>
-#define BOOST_ICU_VER (U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM)
+#define BOOST_LOCALE_ICU_VERSION (U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM)
 #else
-#define BOOST_ICU_VER 406
+#define BOOST_LOCALE_ICU_VERSION 0
 #endif
 
 #ifdef BOOST_MSVC
@@ -200,7 +200,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST(time_point.get(week_of_year()) == 6);
 
             // cldr changes
-#if BOOST_ICU_VER >= 408 && BOOST_ICU_VER <= 6000
+#if BOOST_LOCALE_ICU_VERSION >= 408 && BOOST_LOCALE_ICU_VERSION <= 6000
             const bool ICU_cldr_issue = backend_name == "icu";
 #else
             const bool ICU_cldr_issue = false;

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -207,8 +207,8 @@ BOOST_LOCALE_START_CONST_CONDITION                  \
     }while(0) BOOST_LOCALE_END_CONST_CONDITION
 
 
-#define BOOST_ICU_VER (U_ICU_VERSION_MAJOR_NUM*100 + U_ICU_VERSION_MINOR_NUM)
-#define BOOST_ICU_EXACT_VER (U_ICU_VERSION_MAJOR_NUM*10000 + U_ICU_VERSION_MINOR_NUM  * 100 + U_ICU_VERSION_PATCHLEVEL_NUM)
+#define BOOST_LOCALE_ICU_VERSION (U_ICU_VERSION_MAJOR_NUM * 100 + U_ICU_VERSION_MINOR_NUM)
+#define BOOST_LOCALE_ICU_VERSION_EXACT (BOOST_LOCALE_ICU_VERSION  * 100 + U_ICU_VERSION_PATCHLEVEL_NUM)
 
 bool short_parsing_fails()
 {
@@ -280,7 +280,7 @@ BOOST_LOCALE_END_CONST_CONDITION
     TEST_FP3(as::number,std::left,std::setw(3),15,"15 ",int,15);
     TEST_FP3(as::number,std::right,std::setw(3),15," 15",int,15);
     TEST_FP3(as::number,std::setprecision(3),std::fixed,13.1,"13.100",double,13.1);
-    #if BOOST_ICU_VER < 5601
+    #if BOOST_LOCALE_ICU_VERSION < 5601
     // bug #13276
     TEST_FP3(as::number,std::setprecision(3),std::scientific,13.1,"1.310E1",double,13.1);
     #endif
@@ -300,14 +300,14 @@ BOOST_LOCALE_END_CONST_CONDITION
     TEST_NOPAR(as::currency,"$",double);
 
 
-    #if BOOST_ICU_VER >= 402
+    #if BOOST_LOCALE_ICU_VERSION >= 402
     TEST_FP2(as::currency,as::currency_national,1345,"$1,345.00",int,1345);
     TEST_FP2(as::currency,as::currency_national,1345.34,"$1,345.34",double,1345.34);
     TEST_FP2(as::currency,as::currency_iso,1345,"USD1,345.00",int,1345);
     TEST_FP2(as::currency,as::currency_iso,1345.34,"USD1,345.34",double,1345.34);
     #endif
     TEST_FP1(as::spellout,10,"ten",int,10);
-    #if 402 <= BOOST_ICU_VER && BOOST_ICU_VER < 408
+    #if 402 <= BOOST_LOCALE_ICU_VERSION && BOOST_LOCALE_ICU_VERSION < 408
     if(e_charset=="UTF-8") {
         TEST_FMT(as::ordinal,1,"1\xcb\xa2\xe1\xb5\x97"); // 1st with st as ligatures
     }
@@ -328,7 +328,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 
     TEST_NOPAR(as::date>>as::date_short,"aa/bb/cc",double);
 
-#if BOOST_ICU_VER >= 5901
+#if BOOST_LOCALE_ICU_VERSION >= 5901
 #define GMT_FULL "Greenwich Mean Time"
 #else
 #define GMT_FULL "GMT"
@@ -337,9 +337,9 @@ BOOST_LOCALE_END_CONST_CONDITION
     TEST_FP2(as::time,                as::gmt,a_datetime,"3:33:13 PM",time_t,a_time+a_timesec);
     TEST_FP3(as::time,as::time_short ,as::gmt,a_datetime,"3:33 PM",time_t,a_time);
     TEST_FP3(as::time,as::time_medium,as::gmt,a_datetime,"3:33:13 PM",time_t,a_time+a_timesec);
-    #if BOOST_ICU_VER >= 408
+    #if BOOST_LOCALE_ICU_VERSION >= 408
     TEST_FP3(as::time,as::time_long  ,as::gmt,a_datetime,"3:33:13 PM GMT",time_t,a_time+a_timesec);
-        #if BOOST_ICU_EXACT_VER != 40800
+        #if BOOST_LOCALE_ICU_VERSION_EXACT != 40800
             // know bug #8675
             TEST_FP3(as::time,as::time_full  ,as::gmt,a_datetime,"3:33:13 PM " GMT_FULL,time_t,a_time+a_timesec);
         #endif
@@ -370,7 +370,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 #endif
 
     TEST_FP3(as::time,as::time_long  ,as::time_zone("GMT+01:00"),a_datetime,"4:33:13 PM "  GMT_P100,time_t,a_time+a_timesec);
-    #if BOOST_ICU_VER == 308 && defined(__CYGWIN__)
+    #if BOOST_LOCALE_ICU_VERSION == 308 && defined(__CYGWIN__)
     // Known faliture ICU issue
     #else
     TEST_FP3(as::time,as::time_full  ,as::time_zone("GMT+01:00"),a_datetime,"4:33:13 PM GMT+01:00",time_t,a_time+a_timesec);
@@ -379,9 +379,9 @@ BOOST_LOCALE_END_CONST_CONDITION
     TEST_FP2(as::datetime,                                as::gmt,a_datetime,"Feb 5, 1970" PERIOD  " 3:33:13 PM",time_t,a_datetime);
     TEST_FP4(as::datetime,as::date_short ,as::time_short ,as::gmt,a_datetime,"2/5/70" PERIOD " 3:33 PM",time_t,a_date+a_time);
     TEST_FP4(as::datetime,as::date_medium,as::time_medium,as::gmt,a_datetime,"Feb 5, 1970" PERIOD " 3:33:13 PM",time_t,a_datetime);
-    #if BOOST_ICU_VER >= 408
+    #if BOOST_LOCALE_ICU_VERSION >= 408
     TEST_FP4(as::datetime,as::date_long  ,as::time_long  ,as::gmt,a_datetime,"February 5, 1970" ICUAT " 3:33:13 PM GMT",time_t,a_datetime);
-        #if BOOST_ICU_EXACT_VER != 40800
+        #if BOOST_LOCALE_ICU_VERSION_EXACT != 40800
             // know bug #8675
             TEST_FP4(as::datetime,as::date_full  ,as::time_full  ,as::gmt,a_datetime,"Thursday, February 5, 1970" ICUAT " 3:33:13 PM " GMT_FULL,time_t,a_datetime);
         #endif
@@ -410,7 +410,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 
     std::string result[]= {
         "Thu","Thursday","Feb","February",  // aAbB
-        #if BOOST_ICU_VER >= 408
+        #if BOOST_LOCALE_ICU_VERSION >= 408
         "Thursday, February 5, 1970" ICUAT  " 3:33:13 PM " GMT_FULL, // c
         #else
         "Thursday, February 5, 1970 3:33:13 PM GMT+00:00", // c
@@ -420,7 +420,7 @@ BOOST_LOCALE_END_CONST_CONDITION
         "33","\n","PM", "03:33:13 PM",// Mnpr
         "15:33","13","\t","15:33:13", // RStT
         "Feb 5, 1970","3:33:13 PM","70","1970", // xXyY
-        #if BOOST_ICU_VER >= 408
+        #if BOOST_LOCALE_ICU_VERSION >= 408
         GMT_FULL // Z
         #else
         "GMT+00:00" // Z
@@ -465,7 +465,7 @@ void test_format(std::string charset="UTF-8")
     FORMAT("{1}",1200.1,"1200.1");
     FORMAT("Test {1,num}",1200.1,"Test 1,200.1");
     FORMAT("{{}} {1,number}",1200.1,"{} 1,200.1");
-    #if BOOST_ICU_VER < 5601
+    #if BOOST_LOCALE_ICU_VERSION < 5601
     // bug #13276
     FORMAT("{1,num=sci,p=3}",13.1,"1.310E1");
     FORMAT("{1,num=scientific,p=3}",13.1,"1.310E1");
@@ -479,20 +479,20 @@ void test_format(std::string charset="UTF-8")
     FORMAT("{1,cur}",1234,"$1,234.00");
     FORMAT("{1,currency}",1234,"$1,234.00");
     if(charset=="UTF-8") {
-#if BOOST_ICU_VER >= 400
+#if BOOST_LOCALE_ICU_VERSION >= 400
             FORMAT("{1,cur,locale=de_DE}",10,"10,00\xC2\xA0€");
 #else
             FORMAT("{1,cur,locale=de_DE}",10,"10,00 €");
 #endif
     }
-    #if BOOST_ICU_VER >= 402
+    #if BOOST_LOCALE_ICU_VERSION >= 402
     FORMAT("{1,cur=nat}",1234,"$1,234.00");
     FORMAT("{1,cur=national}",1234,"$1,234.00");
     FORMAT("{1,cur=iso}",1234,"USD1,234.00");
     #endif
     FORMAT("{1,spell}",10,"ten");
     FORMAT("{1,spellout}",10,"ten");
-    #if 402 <= BOOST_ICU_VER && BOOST_ICU_VER < 408
+    #if 402 <= BOOST_LOCALE_ICU_VERSION && BOOST_LOCALE_ICU_VERSION < 408
     if(charset=="UTF-8") {
         FORMAT("{1,ord}",1,"1\xcb\xa2\xe1\xb5\x97");
         FORMAT("{1,ordinal}",1,"1\xcb\xa2\xe1\xb5\x97");
@@ -519,7 +519,7 @@ void test_format(std::string charset="UTF-8")
     time_t a_datetime = a_date + a_time + a_timesec;
     FORMAT("{1,date,gmt};{1,time,gmt};{1,datetime,gmt};{1,dt,gmt}",a_datetime,
             "Feb 5, 1970;3:33:13 PM;Feb 5, 1970" PERIOD " 3:33:13 PM;Feb 5, 1970" PERIOD " 3:33:13 PM");
-    #if BOOST_ICU_VER >= 408
+    #if BOOST_LOCALE_ICU_VERSION >= 408
     FORMAT("{1,time=short,gmt};{1,time=medium,gmt};{1,time=long,gmt};{1,date=full,gmt}",a_datetime,
             "3:33 PM;3:33:13 PM;3:33:13 PM GMT;Thursday, February 5, 1970");
     FORMAT("{1,time=s,gmt};{1,time=m,gmt};{1,time=l,gmt};{1,date=f,gmt}",a_datetime,


### PR DESCRIPTION
- Introduce and use `BOOST_LOCALE_ICU_VERSION`
- Make sure headers include the config header first
- Avoid INT8_MIN etc. macro redefinition warnings when using old ICU