### PR TITLE
Fix configure check for external iconv and ICU (64 bit)

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -28,22 +28,24 @@ feature.feature boost.locale.winapi : on off : optional propagated ;
 # Configuration of libraries
 
 ## iconv
+# Iconv support may be builtin (i.e. in libc)
 
 exe has_iconv : $(TOP)/build/has_iconv.cpp ;
 explicit has_iconv ;
 
 ICONV_PATH = [ modules.peek : ICONV_PATH ] ;
 
-lib iconv
-  :
+# There may also be an external iconv library
+lib iconv :
   : <search>$(ICONV_PATH)/lib <link>shared <runtime-link>shared
-  :
-  : <include>$(ICONV_PATH)/include
+  : : <include>$(ICONV_PATH)/include
   ;
 
 explicit iconv ;
 
-exe has_external_iconv : $(TOP)/build/has_iconv.cpp iconv ;
+# Separate pair of obj & exe rules so the CPP file is built with the iconv include path
+obj has_external_iconv_obj : $(TOP)/build/has_iconv.cpp iconv ;
+exe has_external_iconv : has_external_iconv_obj iconv ;
 explicit has_external_iconv ;
 
 exe accepts_shared_option   : $(TOP)/build/option.cpp
@@ -204,8 +206,10 @@ if $(ICU_LINK)
 
 }
 
-exe has_icu   : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS)   ;
-exe has_icu64 : $(TOP)/build/has_icu_test.cpp : $(ICU64_OPTS) ;
+exe has_icu       : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS)   ;
+# Similar but build&link with 64bit options
+obj has_icu64_obj : $(TOP)/build/has_icu_test.cpp : $(ICU64_OPTS) ;
+exe has_icu64 : has_icu64_obj : $(ICU64_OPTS) ;
 
 explicit has_icu has_icu64 ;
 


### PR DESCRIPTION
More complete approach superseding #106 by @TheSalvator (thanks for proposing the fix which helped identifying the issue)

Partial revert of 72a8e9eb75bd578b60d560f6c1f798af9cdfbf49

The `exe` rule implicitly creates an `obj` rule for the given cpp file if it doesn't exist yet. This causes trouble when the cpp file is meant to be built with different options by multiple `exe` rules as the 2nd rule will reuse the `obj` rule from the first and hence ignores the different options such as the include path.

Here it affects the `has_external_iconv` target due to the conflict with the `has_iconv` target. Hence add back an `obj` rule for the former. Fixes #63 

The same problem exists with the `has_icu*` targets. Fix it similarly.

Closes #106

@myakushka or @TheSalvator Can you test this patch?