### PR TITLE
Fix int-overflow on negative roll of years in date_time

### DIFF
--- a/build/option.cpp
+++ b/build/option.cpp
@@ -5,5 +5,4 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 int main()
-{
-}
+{}

--- a/include/boost/locale/boundary/boundary_point.hpp
+++ b/include/boost/locale/boundary/boundary_point.hpp
@@ -54,16 +54,15 @@ namespace boundary {
         ///
         /// Empty default constructor
         ///
-        boundary_point() : rule_(0) {}
+        boundary_point(): rule_(0) {}
 
         ///
         /// Create a new boundary_point using iterator \p and a rule \a r
         ///
-        boundary_point(iterator_type p,rule_type r) :
+        boundary_point(iterator_type p,rule_type r):
             iterator_(p),
             rule_(r)
-        {
-        }
+        {}
         ///
         /// Set an new iterator value \a i
         ///

--- a/include/boost/locale/boundary/facets.hpp
+++ b/include/boost/locale/boundary/facets.hpp
@@ -40,20 +40,15 @@ namespace boost {
                 ///
                 /// Create empty break point at beginning
                 ///
-                break_info() :
-                    offset(0),
-                    rule(0)
-                {
-                }
+                break_info(): offset(0), rule(0) {}
                 ///
                 /// Create empty break point at offset v.
                 /// it is useful for order comparison with other points.
                 ///
-                break_info(size_t v) :
+                break_info(size_t v):
                     offset(v),
                     rule(0)
-                {
-                }
+                {}
 
                 ///
                 /// Offset from the beginning of the text where a break occurs.
@@ -98,9 +93,8 @@ namespace boost {
                 ///
                 /// Default constructor typical for facets
                 ///
-                boundary_indexing(size_t refs=0) : std::locale::facet(refs)
-                {
-                }
+                boundary_indexing(size_t refs=0): std::locale::facet(refs)
+                {}
                 ///
                 /// Create index for boundary type \a t for text in range [begin,end)
                 ///
@@ -124,9 +118,8 @@ namespace boost {
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<char> : public std::locale::facet {
             public:
-                boundary_indexing(size_t refs=0) : std::locale::facet(refs)
-                {
-                }
+                boundary_indexing(size_t refs=0): std::locale::facet(refs)
+                {}
                 ~boundary_indexing();
                 virtual index_type map(boundary_type t,char const *begin,char const *end) const = 0;
                 static std::locale::id id;
@@ -138,9 +131,8 @@ namespace boost {
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<wchar_t> : public std::locale::facet {
             public:
-                boundary_indexing(size_t refs=0) : std::locale::facet(refs)
-                {
-                }
+                boundary_indexing(size_t refs=0): std::locale::facet(refs)
+                {}
                 ~boundary_indexing();
                 virtual index_type map(boundary_type t,wchar_t const *begin,wchar_t const *end) const = 0;
 
@@ -154,9 +146,8 @@ namespace boost {
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<char16_t> : public std::locale::facet {
             public:
-                boundary_indexing(size_t refs=0) : std::locale::facet(refs)
-                {
-                }
+                boundary_indexing(size_t refs=0): std::locale::facet(refs)
+                {}
                 ~boundary_indexing();
                 virtual index_type map(boundary_type t,char16_t const *begin,char16_t const *end) const = 0;
                 static std::locale::id id;
@@ -170,9 +161,8 @@ namespace boost {
             template<>
             class BOOST_LOCALE_DECL boundary_indexing<char32_t> : public std::locale::facet {
             public:
-                boundary_indexing(size_t refs=0) : std::locale::facet(refs)
-                {
-                }
+                boundary_indexing(size_t refs=0): std::locale::facet(refs)
+                {}
                 ~boundary_indexing();
                 virtual index_type map(boundary_type t,char32_t const *begin,char32_t const *end) const = 0;
                 static std::locale::id id;

--- a/include/boost/locale/boundary/index.hpp
+++ b/include/boost/locale/boundary/index.hpp
@@ -124,9 +124,7 @@ namespace boost {
                         index_->swap(idx);
                     }
 
-                    mapping()
-                    {
-                    }
+                    mapping(){}
 
                     index_type const &index() const
                     {
@@ -162,18 +160,17 @@ namespace boost {
                     typedef mapping<base_iterator> mapping_type;
                     typedef segment<base_iterator> segment_type;
 
-                    segment_index_iterator() : current_(0,0),map_(0)
-                    {
-                    }
+                    segment_index_iterator(): current_(0,0),map_(0), mask_(0), full_select_(false)
+                    {}
 
-                    segment_index_iterator(base_iterator p,mapping_type const *map,rule_type mask,bool full_select) :
+                    segment_index_iterator(base_iterator p,mapping_type const *map,rule_type mask,bool full_select):
                         map_(map),
                         mask_(mask),
                         full_select_(full_select)
                     {
                         set(p);
                     }
-                    segment_index_iterator(bool is_begin,mapping_type const *map,rule_type mask,bool full_select) :
+                    segment_index_iterator(bool is_begin,mapping_type const *map,rule_type mask,bool full_select):
                         map_(map),
                         mask_(mask),
                         full_select_(full_select)
@@ -273,14 +270,14 @@ namespace boost {
 
                         if(full_select_) {
                             while(current_.first > 0) {
-                                current_.first --;
+                                current_.first--;
                                 if(valid_offset(current_.first))
                                     break;
                             }
                         }
                         else {
                             if(current_.first > 0)
-                                current_.first --;
+                                current_.first--;
                         }
                         value_.first = map_->begin();
                         std::advance(value_.first,get_offset(current_.first));
@@ -352,11 +349,10 @@ namespace boost {
                     typedef mapping<base_iterator> mapping_type;
                     typedef boundary_point<base_iterator> boundary_point_type;
 
-                    boundary_point_index_iterator() : current_(0),map_(0)
-                    {
-                    }
+                    boundary_point_index_iterator(): current_(0),map_(0),mask_(0)
+                    {}
 
-                    boundary_point_index_iterator(bool is_begin,mapping_type const *map,rule_type mask) :
+                    boundary_point_index_iterator(bool is_begin,mapping_type const *map,rule_type mask):
                         map_(map),
                         mask_(mask)
                     {
@@ -365,7 +361,7 @@ namespace boost {
                         else
                             set_end();
                     }
-                    boundary_point_index_iterator(base_iterator p,mapping_type const *map,rule_type mask) :
+                    boundary_point_index_iterator(base_iterator p,mapping_type const *map,rule_type mask):
                         map_(map),
                         mask_(mask)
                     {
@@ -596,9 +592,8 @@ namespace boost {
                 /// calling \ref begin(), \ref end() or \ref find() member functions would lead to undefined
                 /// behavior
                 ///
-                segment_index() : mask_(0xFFFFFFFFu),full_select_(false)
-                {
-                }
+                segment_index(): mask_(0xFFFFFFFFu),full_select_(false)
+                {}
                 ///
                 /// Create a segment_index for %boundary analysis \ref boundary_type "type" of the text
                 /// in range [begin,end) using a rule \a mask for locale \a loc.
@@ -612,8 +607,7 @@ namespace boost {
                         map_(type,begin,end,loc),
                         mask_(mask),
                         full_select_(false)
-                {
-                }
+                {}
                 ///
                 /// Create a segment_index for %boundary analysis \ref boundary_type "type" of the text
                 /// in range [begin,end) selecting all possible segments (full mask) for locale \a loc.
@@ -626,8 +620,7 @@ namespace boost {
                         map_(type,begin,end,loc),
                         mask_(0xFFFFFFFFu),
                         full_select_(false)
-                {
-                }
+                {}
 
                 ///
                 /// Create a segment_index from a \ref boundary_point_index. It copies all indexing information
@@ -865,9 +858,8 @@ namespace boost {
                 /// calling \ref begin(), \ref end() or \ref find() member functions would lead to undefined
                 /// behavior
                 ///
-                boundary_point_index() : mask_(0xFFFFFFFFu)
-                {
-                }
+                boundary_point_index(): mask_(0xFFFFFFFFu)
+                {}
 
                 ///
                 /// Create a segment_index for %boundary analysis \ref boundary_type "type" of the text
@@ -881,8 +873,7 @@ namespace boost {
                     :
                         map_(type,begin,end,loc),
                         mask_(mask)
-                {
-                }
+                {}
                 ///
                 /// Create a segment_index for %boundary analysis \ref boundary_type "type" of the text
                 /// in range [begin,end) selecting all possible %boundary points (full mask) for locale \a loc.
@@ -894,8 +885,7 @@ namespace boost {
                     :
                         map_(type,begin,end,loc),
                         mask_(0xFFFFFFFFu)
-                {
-                }
+                {}
 
                 ///
                 /// Create a boundary_point_index from a \ref segment_index. It copies all indexing information
@@ -1002,19 +992,17 @@ namespace boost {
 
             /// \cond INTERNAL
             template<typename BaseIterator>
-            segment_index<BaseIterator>::segment_index(boundary_point_index<BaseIterator> const &other) :
+            segment_index<BaseIterator>::segment_index(boundary_point_index<BaseIterator> const &other):
                 map_(other.map_),
                 mask_(0xFFFFFFFFu),
                 full_select_(false)
-            {
-            }
+            {}
 
             template<typename BaseIterator>
-            boundary_point_index<BaseIterator>::boundary_point_index(segment_index<BaseIterator> const &other) :
+            boundary_point_index<BaseIterator>::boundary_point_index(segment_index<BaseIterator> const &other):
                 map_(other.map_),
                 mask_(0xFFFFFFFFu)
-            {
-            }
+            {}
 
             template<typename BaseIterator>
             segment_index<BaseIterator> const &segment_index<BaseIterator>::operator=(boundary_point_index<BaseIterator> const &other)

--- a/include/boost/locale/boundary/index.hpp
+++ b/include/boost/locale/boundary/index.hpp
@@ -643,7 +643,7 @@ namespace boost {
                 ///
                 /// \note \ref rule() flags are not copied
                 ///
-                segment_index const &operator = (boundary_point_index<base_iterator> const &);
+                segment_index& operator=(boundary_point_index<base_iterator> const &);
 
 
                 ///
@@ -908,7 +908,7 @@ namespace boost {
                 ///
                 /// \note \ref rule() flags are not copied
                 ///
-                boundary_point_index const &operator=(segment_index<base_iterator> const &other);
+                boundary_point_index& operator=(segment_index<base_iterator> const &other);
 
                 ///
                 /// Create a new index for %boundary analysis \ref boundary_type "type" of the text
@@ -1005,14 +1005,14 @@ namespace boost {
             {}
 
             template<typename BaseIterator>
-            segment_index<BaseIterator> const &segment_index<BaseIterator>::operator=(boundary_point_index<BaseIterator> const &other)
+            segment_index<BaseIterator>& segment_index<BaseIterator>::operator=(boundary_point_index<BaseIterator> const &other)
             {
                 map_ = other.map_;
                 return *this;
             }
 
             template<typename BaseIterator>
-            boundary_point_index<BaseIterator> const &boundary_point_index<BaseIterator>::operator=(segment_index<BaseIterator> const &other)
+            boundary_point_index<BaseIterator>& boundary_point_index<BaseIterator>::operator=(segment_index<BaseIterator> const &other)
             {
                 map_ = other.map_;
                 return *this;

--- a/include/boost/locale/boundary/segment.hpp
+++ b/include/boost/locale/boundary/segment.hpp
@@ -172,7 +172,7 @@ namespace boundary {
         /// Convert the range to a string automatically
         ///
         template <class T, class A>
-        operator std::basic_string<char_type, T, A> ()const
+        operator std::basic_string<char_type, T, A>() const
         {
             return std::basic_string<char_type, T, A>(this->first, this->second);
         }
@@ -459,7 +459,7 @@ namespace boundary {
     /// Write the segment to the stream character by character
     ///
     template<typename CharType,typename TraitsType,typename Iterator>
-    std::basic_ostream<CharType,TraitsType> &operator<<(
+    std::basic_ostream<CharType,TraitsType>& operator<<(
             std::basic_ostream<CharType,TraitsType> &out,
             segment<Iterator> const &tok)
     {

--- a/include/boost/locale/boundary/segment.hpp
+++ b/include/boost/locale/boundary/segment.hpp
@@ -129,7 +129,7 @@ namespace boundary {
         ///
         /// Default constructor
         ///
-        segment() {}
+        segment(): rule_(0) {}
         ///
         /// Create a segment using two iterators and a rule that represents this point
         ///
@@ -148,7 +148,7 @@ namespace boundary {
         ///
         /// Set the end of the range
         ///
-         void end(iterator const &v)
+        void end(iterator const &v)
         {
             this->second = v;
         }

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -148,9 +148,7 @@ namespace locale {
         ///
         /// constructor of the collator object
         ///
-        collator(size_t refs = 0) : std::collate<CharType>(refs)
-        {
-        }
+        collator(size_t refs = 0): std::collate<CharType>(refs) {}
 
         ///
         /// This function is used to override default collation function that does not take in account collation level.
@@ -217,11 +215,10 @@ namespace locale {
         ///
         /// \note throws std::bad_cast if l does not have \ref collator facet installed
         ///
-        comparator(std::locale const &l=std::locale(),collator_base::level_type level=default_level) :
+        comparator(std::locale const &l=std::locale(),collator_base::level_type level=default_level):
             locale_(l),
             level_(level)
-        {
-        }
+        {}
 
         ///
         /// Compare two strings -- equivalent to return left < right according to collation rules

--- a/include/boost/locale/conversion.hpp
+++ b/include/boost/locale/conversion.hpp
@@ -60,9 +60,7 @@ namespace boost {
             static std::locale::id id;
 
             /// Standard constructor
-            converter(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            converter(size_t refs = 0): std::locale::facet(refs) {}
             ///
             /// Convert text in range [\a begin, \a end) according to conversion method \a how. Parameter
             /// \a flags is used for specification of normalization method like nfd, nfc etc.
@@ -79,9 +77,7 @@ namespace boost {
         public:
             static std::locale::id id;
 
-            converter(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            converter(size_t refs = 0): std::locale::facet(refs) {}
             ~converter();
             virtual std::string convert(conversion_type how,char const *begin,char const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
@@ -93,9 +89,7 @@ namespace boost {
         class BOOST_LOCALE_DECL converter<wchar_t> : public converter_base, public std::locale::facet {
         public:
             static std::locale::id id;
-            converter(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            converter(size_t refs = 0): std::locale::facet(refs) {}
             ~converter();
              virtual std::wstring convert(conversion_type how,wchar_t const *begin,wchar_t const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
@@ -108,9 +102,7 @@ namespace boost {
         class BOOST_LOCALE_DECL converter<char16_t> : public converter_base, public std::locale::facet {
         public:
             static std::locale::id id;
-            converter(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            converter(size_t refs = 0): std::locale::facet(refs) {}
             ~converter();
             virtual std::u16string convert(conversion_type how,char16_t const *begin,char16_t const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)
@@ -124,9 +116,7 @@ namespace boost {
         class BOOST_LOCALE_DECL converter<char32_t> : public converter_base, public std::locale::facet {
         public:
             static std::locale::id id;
-            converter(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            converter(size_t refs = 0): std::locale::facet(refs) {}
             ~converter();
             virtual std::u32string convert(conversion_type how,char32_t const *begin,char32_t const *end,int flags = 0) const = 0;
 #if defined (__SUNPRO_CC) && defined (_RWSTD_VER)

--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -420,7 +420,7 @@ namespace boost {
             ///
             /// Get item at position \a n the set, n should be in range [0,size)
             ///
-            date_time_period const &operator[](size_t n) const
+            date_time_period const & operator[](size_t n) const
             {
                 if(n >= size())
                     throw std::out_of_range("Invalid index to date_time_period");
@@ -508,7 +508,7 @@ namespace boost {
             ///
             /// assign calendar
             ///
-            calendar const &operator=(calendar const &other);
+            calendar& operator=(calendar const &other);
 
             ///
             /// Get minimum value for period f, For example for period::day it is 1.
@@ -602,7 +602,7 @@ namespace boost {
             ///
             /// assign the date_time
             ///
-            date_time const &operator=(date_time const &other);
+            date_time& operator=(date_time const &other);
             ~date_time();
 
             ///
@@ -635,7 +635,7 @@ namespace boost {
             ///
             /// assign values to various periods in set \a f
             ///
-            date_time const &operator=(date_time_period_set const &f);
+            date_time& operator=(date_time_period_set const &f);
 
             ///
             /// set specific period \a f value to \a v
@@ -673,14 +673,14 @@ namespace boost {
             ///
             /// add single period f to the current date_time
             ///
-            date_time const &operator+=(period::period_type f)
+            date_time& operator+=(period::period_type f)
             {
                 return *this+=date_time_period(f);
             }
             ///
             /// subtract single period f from the current date_time
             ///
-            date_time const &operator-=(period::period_type f)
+            date_time& operator-=(period::period_type f)
             {
                 return *this-=date_time_period(f);
             }
@@ -704,14 +704,14 @@ namespace boost {
             ///
             /// roll forward a date by single period f.
             ///
-            date_time const &operator<<=(period::period_type f)
+            date_time& operator<<=(period::period_type f)
             {
                 return *this <<= date_time_period(f);
             }
             ///
             /// roll backward a date by single period f.
             ///
-            date_time const &operator>>=(period::period_type f)
+            date_time& operator>>=(period::period_type f)
             {
                 return *this >>= date_time_period(f);
             }
@@ -727,11 +727,11 @@ namespace boost {
             ///
             /// add date_time_period to the current date_time
             ///
-            date_time const &operator+=(date_time_period const &v);
+            date_time& operator+=(date_time_period const &v);
             ///
             /// subtract date_time_period from the current date_time
             ///
-            date_time const &operator-=(date_time_period const &v);
+            date_time& operator-=(date_time_period const &v);
 
             ///
             /// roll current date_time forward by date_time_period v
@@ -744,11 +744,11 @@ namespace boost {
             ///
             /// roll current date_time forward by date_time_period v
             ///
-            date_time const &operator<<=(date_time_period const &v);
+            date_time& operator<<=(date_time_period const &v);
             ///
             /// roll current date_time backward by date_time_period v
             ///
-            date_time const &operator>>=(date_time_period const &v);
+            date_time& operator>>=(date_time_period const &v);
 
             ///
             /// add date_time_period_set v to the current date_time
@@ -761,11 +761,11 @@ namespace boost {
             ///
             /// add date_time_period_set v to the current date_time
             ///
-            date_time const &operator+=(date_time_period_set const &v);
+            date_time& operator+=(date_time_period_set const &v);
             ///
             /// subtract date_time_period_set v from the current date_time
             ///
-            date_time const &operator-=(date_time_period_set const &v);
+            date_time& operator-=(date_time_period_set const &v);
 
             ///
             /// roll current date_time forward by date_time_period_set v
@@ -778,11 +778,11 @@ namespace boost {
             ///
             /// roll current date_time forward by date_time_period_set v
             ///
-            date_time const &operator<<=(date_time_period_set const &v);
+            date_time& operator<<=(date_time_period_set const &v);
             ///
             /// roll current date_time backward by date_time_period_set v
             ///
-            date_time const &operator>>=(date_time_period_set const &v);
+            date_time& operator>>=(date_time_period_set const &v);
 
             ///
             /// Get POSIX time
@@ -866,7 +866,7 @@ namespace boost {
         /// The output may be Year:5770 Full Date:Jan 1, 2010
         ///
         template<typename CharType>
-        std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out,date_time const &t)
+        std::basic_ostream<CharType>& operator<<(std::basic_ostream<CharType> &out,date_time const &t)
         {
             double time_point = t.time();
             uint64_t display_flags = ios_info::get(out).display_flags();
@@ -893,7 +893,7 @@ namespace boost {
         /// This function uses locale, calendar and time zone of the source stream \a in.
         ///
         template<typename CharType>
-        std::basic_istream<CharType> &operator>>(std::basic_istream<CharType> &in,date_time &t)
+        std::basic_istream<CharType>& operator>>(std::basic_istream<CharType> &in,date_time &t)
         {
             double v;
             uint64_t display_flags = ios_info::get(in).display_flags();
@@ -951,7 +951,7 @@ namespace boost {
             ///
             /// Syntactic sugar for get(f)
             ///
-            int operator / (period::period_type f) const
+            int operator/ (period::period_type f) const
             {
                 return start().difference(end(),f);
             }

--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -38,7 +38,7 @@ namespace boost {
             ///
             /// Constructor of date_time_error class
             ///
-            date_time_error(std::string const &e) : std::runtime_error(e) {}
+            date_time_error(std::string const &e): std::runtime_error(e) {}
         };
 
 
@@ -66,7 +66,7 @@ namespace boost {
             ///
             /// Constructor that creates date_time_period from period_type \a f and a value \a v -- default 1.
             ///
-            date_time_period(period::period_type f=period::period_type(),int v=1) : type(f), value(v) {}
+            date_time_period(period::period_type f=period::period_type(),int v=1): type(f), value(v) {}
         };
 
         namespace period {
@@ -376,9 +376,7 @@ namespace boost {
             ///
             /// Default constructor - empty set
             ///
-            date_time_period_set()
-            {
-            }
+            date_time_period_set(){}
             ///
             /// Create a set of single period with value 1
             ///
@@ -937,11 +935,10 @@ namespace boost {
             /// Create an object were \a first represents earlier point on time line and \a second is later
             /// point.
             ///
-            date_time_duration(date_time const &first,date_time const &second) :
+            date_time_duration(date_time const &first,date_time const &second):
                 s_(first),
                 e_(second)
-            {
-            }
+            {}
 
             ///
             /// find a difference in terms of period_type \a f

--- a/include/boost/locale/date_time_facet.hpp
+++ b/include/boost/locale/date_time_facet.hpp
@@ -71,9 +71,7 @@ namespace boost {
                 ///
                 /// Create a period of specific type, default is invalid.
                 ///
-                period_type(marks::period_mark m = marks::invalid) : mark_(m)
-                {
-                }
+                period_type(marks::period_mark m = marks::invalid): mark_(m) {}
 
                 ///
                 /// Get the value of marks::period_mark it was created with.
@@ -232,9 +230,7 @@ namespace boost {
             ///
             /// Basic constructor
             ///
-            calendar_facet(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            calendar_facet(size_t refs = 0): std::locale::facet(refs) {}
             ///
             /// Create a new calendar that points to current point of time.
             ///

--- a/include/boost/locale/encoding_errors.hpp
+++ b/include/boost/locale/encoding_errors.hpp
@@ -28,7 +28,7 @@ namespace boost {
             ///
             class BOOST_SYMBOL_VISIBLE conversion_error : public std::runtime_error {
             public:
-                conversion_error() : std::runtime_error("Conversion failed") {}
+                conversion_error(): std::runtime_error("Conversion failed") {}
             };
 
             ///
@@ -39,10 +39,9 @@ namespace boost {
             public:
 
                 /// Create an error for charset \a charset
-                invalid_charset_error(std::string charset) :
+                invalid_charset_error(std::string charset):
                     std::runtime_error("Invalid or unsupported charset:" + charset)
-                {
-                }
+                {}
             };
 
 

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -38,17 +38,15 @@ namespace boost {
                 typedef std::basic_ostream<CharType> stream_type;
                 typedef void (*writer_type)(stream_type &output,void const *ptr);
 
-                formattible() :
+                formattible():
                     pointer_(0),
                     writer_(&formattible::void_write)
-                {
-                }
+                {}
 
-                formattible(formattible const &other) :
+                formattible(formattible const &other):
                     pointer_(other.pointer_),
                     writer_(other.writer_)
-                {
-                }
+                {}
 
                 formattible const &operator=(formattible const &other)
                 {
@@ -216,22 +214,20 @@ namespace boost {
             ///
             /// Create a format class for \a format_string
             ///
-            basic_format(string_type format_string) :
+            basic_format(string_type format_string):
                 format_(format_string),
                 translate_(false),
                 parameters_count_(0)
-            {
-            }
+            {}
             ///
             /// Create a format class using message \a trans. The message if translated first according
             /// to the rules of target locale and then interpreted as format string
             ///
-            basic_format(message_type const &trans) :
+            basic_format(message_type const &trans):
                 message_(trans),
                 translate_(true),
                 parameters_count_(0)
-            {
-            }
+            {}
 
             ///
             /// Add new parameter to format list. The object should be a type
@@ -275,11 +271,7 @@ namespace boost {
 
             class format_guard {
             public:
-                format_guard(details::format_parser &fmt) :
-                    fmt_(&fmt),
-                    restored_(false)
-                {
-                }
+                format_guard(details::format_parser &fmt): fmt_(&fmt), restored_(false) {}
                 void restore()
                 {
                     if(restored_)
@@ -292,8 +284,7 @@ namespace boost {
                     try {
                         restore();
                     }
-                    catch(...) {
-                    }
+                    catch(...) {}
                 }
             private:
                 details::format_parser *fmt_;

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -48,7 +48,7 @@ namespace boost {
                     writer_(other.writer_)
                 {}
 
-                formattible const &operator=(formattible const &other)
+                formattible& operator=(formattible const &other)
                 {
                     if(this != &other) {
                         pointer_=other.pointer_;
@@ -65,13 +65,13 @@ namespace boost {
                 }
 
                 template<typename Type>
-                formattible const &operator=(Type const &other)
+                formattible& operator=(Type const &other)
                 {
                     *this = formattible(other);
                     return *this;
                 }
 
-                friend stream_type &operator<<(stream_type &out,formattible const &fmt)
+                friend stream_type& operator<<(stream_type &out,formattible const &fmt)
                 {
                     fmt.writer_(out,fmt.pointer_);
                     return out;
@@ -234,7 +234,7 @@ namespace boost {
             /// with defined expression out << object where \c out is \c std::basic_ostream.
             ///
             template<typename Formattible>
-            basic_format &operator % (Formattible const &object)
+            basic_format& operator%(Formattible const &object)
             {
                 add(formattible_type(object));
                 return *this;
@@ -447,7 +447,7 @@ namespace boost {
         /// This operator actually causes actual text formatting. It uses the locale of \a out stream
         ///
         template<typename CharType>
-        std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out,basic_format<CharType> const &fmt)
+        std::basic_ostream<CharType>& operator<<(std::basic_ostream<CharType> &out,basic_format<CharType> const &fmt)
         {
             fmt.write(out);
             return out;

--- a/include/boost/locale/formatting.hpp
+++ b/include/boost/locale/formatting.hpp
@@ -102,7 +102,7 @@ namespace boost {
 
             ios_info();
             ios_info(ios_info const &);
-            ios_info const &operator=(ios_info const &);
+            ios_info& operator=(ios_info const &);
             ~ios_info();
 
             /// \endcond
@@ -221,7 +221,7 @@ namespace boost {
                 string_set();
                 ~string_set();
                 string_set(string_set const &other);
-                string_set const &operator=(string_set const &other);
+                string_set& operator=(string_set other);
                 void swap(string_set &other);
 
                 template<typename Char>
@@ -502,14 +502,14 @@ namespace boost {
                 };
 
                 template<typename CharType>
-                std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out,add_ftime<CharType> const &fmt)
+                std::basic_ostream<CharType>& operator<<(std::basic_ostream<CharType> &out,add_ftime<CharType> const &fmt)
                 {
                     fmt.apply(out);
                     return out;
                 }
 
                 template<typename CharType>
-                std::basic_istream<CharType> &operator>>(std::basic_istream<CharType> &in,add_ftime<CharType> const &fmt)
+                std::basic_istream<CharType>& operator>>(std::basic_istream<CharType> &in,add_ftime<CharType> const &fmt)
                 {
                     fmt.apply(in);
                     return in;
@@ -589,14 +589,14 @@ namespace boost {
                     std::string id;
                 };
                 template<typename CharType>
-                std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out,set_timezone const &fmt)
+                std::basic_ostream<CharType>& operator<<(std::basic_ostream<CharType> &out,set_timezone const &fmt)
                 {
                     ios_info::get(out).time_zone(fmt.id);
                     return out;
                 }
 
                 template<typename CharType>
-                std::basic_istream<CharType> &operator>>(std::basic_istream<CharType> &in,set_timezone const &fmt)
+                std::basic_istream<CharType>& operator>>(std::basic_istream<CharType> &in,set_timezone const &fmt)
                 {
                     ios_info::get(in).time_zone(fmt.id);
                     return in;

--- a/include/boost/locale/generic_codecvt.hpp
+++ b/include/boost/locale/generic_codecvt.hpp
@@ -62,7 +62,7 @@ public:
 /// public:
 ///
 ///     /* Standard codecvt constructor */
-///     latin1_codecvt(size_t refs = 0) : boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >(refs)
+///     latin1_codecvt(size_t refs = 0): boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >(refs)
 ///     {
 ///     }
 ///
@@ -109,7 +109,7 @@ public:
 /// public:
 ///
 ///     /* Standard codecvt constructor */
-///     icu_codecvt(std::string const &name,refs = 0) :
+///     icu_codecvt(std::string const &name,refs = 0):
 ///         boost::locale::generic_codecvt<CharType,latin1_codecvt<CharType> >(refs)
 ///     { ... }
 ///
@@ -152,10 +152,7 @@ public:
 
     typedef CharType uchar;
 
-    generic_codecvt(size_t refs = 0) :
-        std::codecvt<CharType,char,std::mbstate_t>(refs)
-    {
-    }
+    generic_codecvt(size_t refs = 0): std::codecvt<CharType,char,std::mbstate_t>(refs) {}
     CodecvtImpl const &implementation() const
     {
         return *static_cast<CodecvtImpl const *>(this);
@@ -449,10 +446,7 @@ class generic_codecvt<CharType,CodecvtImpl,4> : public std::codecvt<CharType,cha
 public:
     typedef CharType uchar;
 
-    generic_codecvt(size_t refs = 0) :
-        std::codecvt<CharType,char,std::mbstate_t>(refs)
-    {
-    }
+    generic_codecvt(size_t refs = 0): std::codecvt<CharType,char,std::mbstate_t>(refs) {}
 
     CodecvtImpl const &implementation() const
     {
@@ -655,9 +649,7 @@ public:
         return *static_cast<CodecvtImpl const *>(this);
     }
 
-    generic_codecvt(size_t refs = 0) :  std::codecvt<char,char,std::mbstate_t>(refs)
-    {
-    }
+    generic_codecvt(size_t refs = 0):  std::codecvt<char,char,std::mbstate_t>(refs) {}
 };
 
 } // locale

--- a/include/boost/locale/gnu_gettext.hpp
+++ b/include/boost/locale/gnu_gettext.hpp
@@ -32,11 +32,7 @@ namespace gnu_gettext {
     /// ignore gettext catalogs that use a charset different from \a encoding.
     ///
     struct messages_info {
-        messages_info() :
-            language("C"),
-            locale_category("LC_MESSAGES")
-        {
-        }
+        messages_info(): language("C"), locale_category("LC_MESSAGES") {}
 
         std::string language;   ///< The language we load the catalog for, like "ru", "en", "de"
         std::string country;    ///< The country we load the catalog for, like "US", "IL"

--- a/include/boost/locale/hold_ptr.hpp
+++ b/include/boost/locale/hold_ptr.hpp
@@ -17,8 +17,6 @@ namespace locale {
     ///
     template<typename T>
     class hold_ptr {
-        hold_ptr(hold_ptr const &other); // non copyable
-        hold_ptr const &operator=(hold_ptr const &other); // non assignable
     public:
         ///
         /// Create new empty pointer
@@ -37,6 +35,10 @@ namespace locale {
             delete ptr_;
         }
 
+        // Non-copyable
+        hold_ptr(hold_ptr const&) = delete;
+        hold_ptr& operator=(hold_ptr const&) = delete;
+
         ///
         /// Get a const pointer to the object
         ///
@@ -49,15 +51,15 @@ namespace locale {
         ///
         /// Get a const reference to the object
         ///
-        T const &operator *() const { return *ptr_; }
+        T const & operator*() const { return *ptr_; }
         ///
         /// Get a mutable reference to the object
         ///
-        T &operator *() { return *ptr_; }
+        T & operator*() { return *ptr_; }
         ///
         /// Get a const pointer to the object
         ///
-        T const *operator->() const { return ptr_; }
+        T const * operator->() const { return ptr_; }
         ///
         /// Get a mutable pointer to the object
         ///

--- a/include/boost/locale/hold_ptr.hpp
+++ b/include/boost/locale/hold_ptr.hpp
@@ -23,11 +23,11 @@ namespace locale {
         ///
         /// Create new empty pointer
         ///
-        hold_ptr() : ptr_(0) {}
+        hold_ptr(): ptr_(0) {}
         ///
         /// Create a pointer that holds \a v, ownership is transferred to smart pointer
         ///
-        explicit hold_ptr(T *v) : ptr_(v) {}
+        explicit hold_ptr(T *v): ptr_(v) {}
 
         ///
         /// Destroy smart pointer and the object it owns.

--- a/include/boost/locale/info.hpp
+++ b/include/boost/locale/info.hpp
@@ -53,9 +53,7 @@ namespace boost {
             ///
             /// Standard facet's constructor
             ///
-            info(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            info(size_t refs = 0): std::locale::facet(refs) {}
             ///
             /// Get language name
             ///

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -92,7 +92,7 @@ namespace boost {
             ///
             /// Assign localization_backend_manager
             ///
-            localization_backend_manager const &operator=(localization_backend_manager const &);
+            localization_backend_manager& operator=(localization_backend_manager const &);
 
             ///
             /// Destructor

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -290,13 +290,9 @@ namespace boost {
             ///
             /// Assign other message object to this one
             ///
-            basic_message const &operator=(basic_message const &other)
+            basic_message& operator=(basic_message other)
             {
-                if(this==&other) {
-                    return *this;
-                }
-                basic_message tmp(other);
-                swap(tmp);
+                swap(other);
                 return *this;
             }
 
@@ -490,7 +486,7 @@ namespace boost {
         /// Translate message \a msg and write it to stream
         ///
         template<typename CharType>
-        std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out,basic_message<CharType> const &msg)
+        std::basic_ostream<CharType>& operator<<(std::basic_ostream<CharType> &out,basic_message<CharType> const &msg)
         {
             msg.write(out);
             return out;
@@ -730,7 +726,7 @@ namespace boost {
                     std::string domain_id;
                 };
                 template<typename CharType>
-                std::basic_ostream<CharType> &operator<<(std::basic_ostream<CharType> &out, set_domain const &dom)
+                std::basic_ostream<CharType>& operator<<(std::basic_ostream<CharType> &out, set_domain const &dom)
                 {
                     int id = std::use_facet<message_format<CharType> >(out.getloc()).domain(dom.domain_id);
                     ios_info::get(out).domain_id(id);

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -63,9 +63,7 @@ namespace boost {
             ///
             /// Default constructor
             ///
-            message_format(size_t refs = 0) : base_message_format<CharType>(refs)
-            {
-            }
+            message_format(size_t refs = 0): base_message_format<CharType>(refs) {}
 
             ///
             /// This function returns a pointer to the string for a message defined by a \a context
@@ -177,25 +175,13 @@ namespace boost {
             ///
             /// Create default empty message
             ///
-            basic_message() :
-                n_(0),
-                c_id_(0),
-                c_context_(0),
-                c_plural_(0)
-            {
-            }
+            basic_message(): n_(0), c_id_(0), c_context_(0), c_plural_(0) {}
 
             ///
             /// Create a simple message from 0 terminated string. The string should exist
             /// until the message is destroyed. Generally useful with static constant strings
             ///
-            explicit basic_message(char_type const *id) :
-                n_(0),
-                c_id_(id),
-                c_context_(0),
-                c_plural_(0)
-            {
-            }
+            explicit basic_message(char_type const *id): n_(0), c_id_(id), c_context_(0), c_plural_(0) {}
 
             ///
             /// Create a simple plural form message from 0 terminated strings. The strings should exist
@@ -203,26 +189,24 @@ namespace boost {
             ///
             /// \a n is the number, \a single and \a plural are singular and plural forms of the message
             ///
-            explicit basic_message(char_type const *single,char_type const *plural,int n) :
+            explicit basic_message(char_type const *single,char_type const *plural,int n):
                 n_(n),
                 c_id_(single),
                 c_context_(0),
                 c_plural_(plural)
-            {
-            }
+            {}
 
             ///
             /// Create a simple message from 0 terminated strings, with context
             /// information. The string should exist
             /// until the message is destroyed. Generally useful with static constant strings
             ///
-            explicit basic_message(char_type const *context,char_type const *id) :
+            explicit basic_message(char_type const *context,char_type const *id):
                 n_(0),
                 c_id_(id),
                 c_context_(context),
                 c_plural_(0)
-            {
-            }
+            {}
 
             ///
             /// Create a simple plural form message from 0 terminated strings, with context. The strings should exist
@@ -230,61 +214,57 @@ namespace boost {
             ///
             /// \a n is the number, \a single and \a plural are singular and plural forms of the message
             ///
-            explicit basic_message(char_type const *context,char_type const *single,char_type const *plural,int n) :
+            explicit basic_message(char_type const *context,char_type const *single,char_type const *plural,int n):
                 n_(n),
                 c_id_(single),
                 c_context_(context),
                 c_plural_(plural)
-            {
-            }
+            {}
 
 
             ///
             /// Create a simple message from a string.
             ///
-            explicit basic_message(string_type const &id) :
+            explicit basic_message(string_type const &id):
                 n_(0),
                 c_id_(0),
                 c_context_(0),
                 c_plural_(0),
                 id_(id)
-            {
-            }
+            {}
 
             ///
             /// Create a simple plural form message from strings.
             ///
             /// \a n is the number, \a single and \a plural are single and plural forms of the message
             ///
-            explicit basic_message(string_type const &single,string_type const &plural,int number) :
+            explicit basic_message(string_type const &single,string_type const &plural,int number):
                 n_(number),
                 c_id_(0),
                 c_context_(0),
                 c_plural_(0),
                 id_(single),
                 plural_(plural)
-            {
-            }
+            {}
 
             ///
             /// Create a simple message from a string with context.
             ///
-            explicit basic_message(string_type const &context,string_type const &id) :
+            explicit basic_message(string_type const &context,string_type const &id):
                 n_(0),
                 c_id_(0),
                 c_context_(0),
                 c_plural_(0),
                 id_(id),
                 context_(context)
-            {
-            }
+            {}
 
             ///
             /// Create a simple plural form message from strings.
             ///
             /// \a n is the number, \a single and \a plural are single and plural forms of the message
             ///
-            explicit basic_message(string_type const &context,string_type const &single,string_type const &plural,int number) :
+            explicit basic_message(string_type const &context,string_type const &single,string_type const &plural,int number):
                 n_(number),
                 c_id_(0),
                 c_context_(0),
@@ -292,13 +272,12 @@ namespace boost {
                 id_(single),
                 context_(context),
                 plural_(plural)
-            {
-            }
+            {}
 
             ///
             /// Copy an object
             ///
-            basic_message(basic_message const &other) :
+            basic_message(basic_message const &other):
                 n_(other.n_),
                 c_id_(other.c_id_),
                 c_context_(other.c_context_),
@@ -306,8 +285,7 @@ namespace boost {
                 id_(other.id_),
                 context_(other.context_),
                 plural_(other.plural_)
-            {
-            }
+            {}
 
             ///
             /// Assign other message object to this one
@@ -463,7 +441,7 @@ namespace boost {
                 }
 
                 if(!translated) {
-                    char_type const *msg = plural ? ( n_ == 1 ? id : plural) : id;
+                    char_type const *msg = plural ? ( n_ == 1 ? id : plural): id;
 
                     if(facet) {
                         translated = facet->convert(msg,buffer);
@@ -706,18 +684,14 @@ namespace boost {
         template<>
         struct BOOST_LOCALE_DECL base_message_format<char> : public std::locale::facet
         {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            base_message_format(size_t refs = 0): std::locale::facet(refs) {}
             static std::locale::id id;
         };
 
         template<>
         struct BOOST_LOCALE_DECL base_message_format<wchar_t> : public std::locale::facet
         {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            base_message_format(size_t refs = 0): std::locale::facet(refs) {}
             static std::locale::id id;
         };
 
@@ -726,9 +700,7 @@ namespace boost {
         template<>
         struct BOOST_LOCALE_DECL base_message_format<char16_t> : public std::locale::facet
         {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            base_message_format(size_t refs = 0): std::locale::facet(refs) {}
             static std::locale::id id;
         };
 
@@ -739,9 +711,7 @@ namespace boost {
         template<>
         struct BOOST_LOCALE_DECL base_message_format<char32_t> : public std::locale::facet
         {
-            base_message_format(size_t refs = 0) : std::locale::facet(refs)
-            {
-            }
+            base_message_format(size_t refs = 0): std::locale::facet(refs) {}
             static std::locale::id id;
         };
 

--- a/include/boost/locale/utf8_codecvt.hpp
+++ b/include/boost/locale/utf8_codecvt.hpp
@@ -25,9 +25,7 @@ public:
 
     struct state_type {};
 
-    utf8_codecvt(size_t refs = 0) : generic_codecvt<CharType,utf8_codecvt<CharType> >(refs)
-    {
-    }
+    utf8_codecvt(size_t refs = 0): generic_codecvt<CharType,utf8_codecvt<CharType> >(refs) {}
 
     static int max_encoding_length()
     {

--- a/src/boost/locale/encoding/iconv_codepage.ipp
+++ b/src/boost/locale/encoding/iconv_codepage.ipp
@@ -21,9 +21,7 @@ class iconverter_base {
 public:
 
     iconverter_base() :
-    cvt_((iconv_t)(-1))
-    {
-    }
+    cvt_((iconv_t)(-1)) {}
 
     ~iconverter_base()
     {

--- a/src/boost/locale/encoding/wconv_codepage.ipp
+++ b/src/boost/locale/encoding/wconv_codepage.ipp
@@ -257,12 +257,7 @@ namespace impl {
 
     class wconv_between : public converter_between {
     public:
-        wconv_between() :
-            how_(skip),
-            to_code_page_ (-1),
-            from_code_page_ ( -1)
-        {
-        }
+        wconv_between() : how_(skip), to_code_page_(-1), from_code_page_(-1) {}
         bool open(char const *to_charset,char const *from_charset,method_type how) override
         {
             how_ = how;
@@ -359,11 +354,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_to_utf() :
-            how_(skip),
-            code_page_(-1)
-        {
-        }
+        wconv_to_utf() : how_(skip), code_page_(-1) {}
 
         bool open(char const *charset,method_type how) override
         {
@@ -397,11 +388,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_from_utf() :
-            how_(skip),
-            code_page_(-1)
-        {
-        }
+        wconv_from_utf() : how_(skip), code_page_(-1) {}
 
         bool open(char const *charset,method_type how) override
         {
@@ -461,11 +448,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_to_utf() :
-            how_(skip),
-            code_page_(-1)
-        {
-        }
+        wconv_to_utf() : how_(skip), code_page_(-1) {}
 
         bool open(char const *charset,method_type how) override
         {
@@ -499,11 +482,7 @@ namespace impl {
 
         typedef std::basic_string<char_type> string_type;
 
-        wconv_from_utf() :
-            how_(skip),
-            code_page_(-1)
-        {
-        }
+        wconv_from_utf() : how_(skip), code_page_(-1) {}
 
         bool open(char const *charset,method_type how) override
         {

--- a/src/boost/locale/icu/boundary.cpp
+++ b/src/boost/locale/icu/boundary.cpp
@@ -189,11 +189,7 @@ BOOST_LOCALE_END_CONST_CONDITION
 template<typename CharType>
 class boundary_indexing_impl : public boundary_indexing<CharType> {
 public:
-    boundary_indexing_impl(cdata const &data) :
-        locale_(data.locale),
-        encoding_(data.encoding)
-    {
-    }
+    boundary_indexing_impl(cdata const &data): locale_(data.locale), encoding_(data.encoding) {}
     index_type map(boundary_type t,CharType const *begin,CharType const *end) const
     {
         return do_map<CharType>(t,begin,end,locale_,encoding_);

--- a/src/boost/locale/icu/codecvt.cpp
+++ b/src/boost/locale/icu/codecvt.cpp
@@ -27,7 +27,7 @@ namespace impl_icu {
     class uconv_converter : public util::base_converter {
     public:
 
-        uconv_converter(std::string const &encoding) :
+        uconv_converter(std::string const &encoding):
             encoding_(encoding)
         {
             UErrorCode err=U_ZERO_ERROR;

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -121,13 +121,8 @@ namespace boost {
                     return gnu_gettext::pj_winberger_hash_function(reinterpret_cast<char *>(&tmp.front()));
                 }
 
-                collate_impl(cdata const &d) :
-                    cvt_(d.encoding),
-                    locale_(d.locale),
-                    is_utf8_(d.utf8)
-                {
+                collate_impl(cdata const &d): cvt_(d.encoding), locale_(d.locale), is_utf8_(d.utf8) {}
 
-                }
                 icu::Collator *get_collator(level_type ilevel) const
                 {
                     int l = limit(ilevel);

--- a/src/boost/locale/icu/conversion.cpp
+++ b/src/boost/locale/icu/conversion.cpp
@@ -61,11 +61,7 @@ namespace impl_icu {
         typedef CharType char_type;
         typedef std::basic_string<char_type> string_type;
 
-        converter_impl(cdata const &d) :
-            locale_(d.locale),
-            encoding_(d.encoding)
-        {
-        }
+        converter_impl(cdata const &d): locale_(d.locale), encoding_(d.encoding) {}
 
         string_type convert(converter_base::conversion_type how, char_type const* begin, char_type const* end, int flags = 0) const override
         {
@@ -103,7 +99,7 @@ namespace impl_icu {
         raii_casemap(raii_casemap const &);
         void operator = (raii_casemap const&);
     public:
-        raii_casemap(std::string const &locale_id) :
+        raii_casemap(std::string const &locale_id):
             map_(0)
         {
             UErrorCode err=U_ZERO_ERROR;
@@ -137,11 +133,7 @@ namespace impl_icu {
     class utf8_converter_impl : public converter<char> {
     public:
 
-        utf8_converter_impl(cdata const &d) :
-            locale_id_(d.locale.getName()),
-            map_(locale_id_)
-        {
-        }
+        utf8_converter_impl(cdata const &d): locale_id_(d.locale.getName()), map_(locale_id_) {}
 
         std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const override
         {

--- a/src/boost/locale/icu/conversion.cpp
+++ b/src/boost/locale/icu/conversion.cpp
@@ -96,11 +96,11 @@ namespace impl_icu {
 
     #ifdef BOOST_LOCALE_WITH_CASEMAP
     class raii_casemap {
-        raii_casemap(raii_casemap const &);
-        void operator = (raii_casemap const&);
     public:
-        raii_casemap(std::string const &locale_id):
-            map_(0)
+        raii_casemap(raii_casemap const&) = delete;
+        void operator=(raii_casemap const&) = delete;
+
+        raii_casemap(std::string const &locale_id): map_(0)
         {
             UErrorCode err=U_ZERO_ERROR;
             map_ = ucasemap_open(locale_id.c_str(),0,&err);

--- a/src/boost/locale/icu/date_time.cpp
+++ b/src/boost/locale/icu/date_time.cpp
@@ -259,11 +259,7 @@ namespace impl_icu {
 
     class icu_calendar_facet : public calendar_facet  {
     public:
-        icu_calendar_facet(cdata const &d,size_t refs = 0) :
-            calendar_facet(refs),
-            data_(d)
-        {
-        }
+        icu_calendar_facet(cdata const &d,size_t refs = 0): calendar_facet(refs), data_(d) {}
         abstract_calendar *create_calendar() const override
         {
             return new calendar_impl(data_);

--- a/src/boost/locale/icu/formatter.cpp
+++ b/src/boost/locale/icu/formatter.cpp
@@ -84,11 +84,7 @@ namespace locale {
                 return do_parse(str,value);
             }
 
-            number_format(icu::NumberFormat *fmt,std::string codepage) :
-                cvt_(codepage),
-                icu_fmt_(fmt)
-            {
-            }
+            number_format(icu::NumberFormat *fmt,std::string codepage): cvt_(codepage), icu_fmt_(fmt) {}
 
         private:
 
@@ -177,7 +173,7 @@ namespace locale {
                 return do_parse(str,value);
             }
 
-            date_format(icu::DateFormat *fmt,bool transfer_owneship,std::string codepage) :
+            date_format(icu::DateFormat *fmt,bool transfer_owneship,std::string codepage):
                 cvt_(codepage)
             {
                 if(transfer_owneship) {

--- a/src/boost/locale/icu/icu_backend.cpp
+++ b/src/boost/locale/icu/icu_backend.cpp
@@ -22,20 +22,15 @@ namespace locale {
 namespace impl_icu {
     class icu_localization_backend : public localization_backend {
     public:
-        icu_localization_backend() :
-            invalid_(true),
-            use_ansi_encoding_(false)
-        {
-        }
-        icu_localization_backend(icu_localization_backend const &other) :
+        icu_localization_backend(): invalid_(true), use_ansi_encoding_(false) {}
+        icu_localization_backend(icu_localization_backend const &other):
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
             locale_id_(other.locale_id_),
             invalid_(true),
             use_ansi_encoding_(other.use_ansi_encoding_)
-        {
-        }
+        {}
         icu_localization_backend *clone() const override
         {
             return new icu_localization_backend(*this);

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -117,12 +117,11 @@ public:
     typedef formatter<CharType> formatter_type;
     typedef hold_ptr<formatter_type> formatter_ptr;
 
-    num_format(cdata const &d,size_t refs = 0) :
+    num_format(cdata const &d,size_t refs = 0):
         std::num_put<CharType>(refs),
         loc_(d.locale),
         enc_(d.encoding)
-    {
-    }
+    {}
 protected:
 
 
@@ -206,12 +205,11 @@ template<typename CharType>
 class num_parse : public std::num_get<CharType>, protected num_base
 {
 public:
-    num_parse(cdata const &d,size_t refs = 0) :
+    num_parse(cdata const &d,size_t refs = 0):
         std::num_get<CharType>(refs),
         loc_(d.locale),
         enc_(d.encoding)
-    {
-    }
+    {}
 protected:
     typedef typename std::num_get<CharType>::iter_type iter_type;
     typedef std::basic_string<CharType> string_type;

--- a/src/boost/locale/icu/predefined_formatters.hpp
+++ b/src/boost/locale/icu/predefined_formatters.hpp
@@ -37,7 +37,7 @@ namespace locale {
 
             static std::locale::id id;
 
-            icu_formatters_cache(icu::Locale const &locale) :
+            icu_formatters_cache(icu::Locale const &locale):
                 locale_(locale)
             {
 

--- a/src/boost/locale/icu/time_zone.cpp
+++ b/src/boost/locale/icu/time_zone.cpp
@@ -74,7 +74,7 @@ namespace boost {
 
                 class directory {
                 public:
-                    directory(char const *name) : d(0),read_result(0)
+                    directory(char const *name): d(0),read_result(0)
                     {
                         d=opendir(name);
                         if(!d)

--- a/src/boost/locale/icu/uconv.hpp
+++ b/src/boost/locale/icu/uconv.hpp
@@ -74,7 +74,7 @@ namespace impl_icu {
             return cvt.go(str.getBuffer(),str.length(),max_len_);
         }
 
-        icu_std_converter(std::string charset,cpcvt_type cvt_type = cvt_skip) :
+        icu_std_converter(std::string charset,cpcvt_type cvt_type = cvt_skip):
             charset_(charset),
             cvt_type_(cvt_type)
         {
@@ -230,10 +230,7 @@ namespace impl_icu {
             return n;
         }
 
-        icu_std_converter(std::string /*charset*/,cpcvt_type mode=cvt_skip) :
-            mode_(mode)
-        {
-        }
+        icu_std_converter(std::string /*charset*/,cpcvt_type mode=cvt_skip): mode_(mode) {}
     private:
         cpcvt_type mode_;
 
@@ -303,10 +300,7 @@ namespace impl_icu {
             return str.countChar32(from_u,n);
         }
 
-        icu_std_converter(std::string /*charset*/,cpcvt_type mode=cvt_skip) :
-            mode_(mode)
-        {
-        }
+        icu_std_converter(std::string /*charset*/,cpcvt_type mode=cvt_skip): mode_(mode) {}
     private:
         cpcvt_type mode_;
 

--- a/src/boost/locale/posix/codecvt.cpp
+++ b/src/boost/locale/posix/codecvt.cpp
@@ -28,7 +28,7 @@ namespace impl_posix {
     class mb2_iconv_converter : public util::base_converter {
     public:
 
-        mb2_iconv_converter(std::string const &encoding) :
+        mb2_iconv_converter(std::string const &encoding):
             encoding_(encoding),
             to_utf_((iconv_t)(-1)),
             from_utf_((iconv_t)(-1))
@@ -85,13 +85,12 @@ namespace impl_posix {
             first_byte_table_->swap(first_byte_table);
         }
 
-        mb2_iconv_converter(mb2_iconv_converter const &other) :
+        mb2_iconv_converter(mb2_iconv_converter const &other):
             first_byte_table_(other.first_byte_table_),
             encoding_(other.encoding_),
             to_utf_((iconv_t)(-1)),
             from_utf_((iconv_t)(-1))
-        {
-        }
+        {}
 
         ~mb2_iconv_converter()
         {

--- a/src/boost/locale/posix/collate.cpp
+++ b/src/boost/locale/posix/collate.cpp
@@ -57,11 +57,10 @@ class collator : public std::collate<CharType> {
 public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
-    collator(std::shared_ptr<locale_t> l,size_t refs = 0) :
+    collator(std::shared_ptr<locale_t> l,size_t refs = 0):
         std::collate<CharType>(refs),
         lc_(std::move(l))
-    {
-    }
+    {}
 
     int do_compare(char_type const *lb,char_type const *le,char_type const *rb,char_type const *re) const override
     {

--- a/src/boost/locale/posix/converter.cpp
+++ b/src/boost/locale/posix/converter.cpp
@@ -60,11 +60,10 @@ public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
     typedef std::ctype<char_type> ctype_type;
-    std_converter(std::shared_ptr<locale_t> lc,size_t refs = 0) :
+    std_converter(std::shared_ptr<locale_t> lc,size_t refs = 0):
         converter<CharType>(refs),
         lc_(std::move(lc))
-    {
-    }
+    {}
     string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int /*flags*/ = 0) const override
     {
         switch(how) {
@@ -97,11 +96,10 @@ private:
 
 class utf8_converter : public converter<char> {
 public:
-    utf8_converter(std::shared_ptr<locale_t> lc,size_t refs = 0) :
+    utf8_converter(std::shared_ptr<locale_t> lc,size_t refs = 0):
         converter<char>(refs),
         lc_(std::move(lc))
-    {
-    }
+    {}
     std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int /*flags*/ = 0) const override
     {
         switch(how) {

--- a/src/boost/locale/posix/numeric.cpp
+++ b/src/boost/locale/posix/numeric.cpp
@@ -47,11 +47,10 @@ public:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    num_format(std::shared_ptr<locale_t> lc,size_t refs = 0) :
+    num_format(std::shared_ptr<locale_t> lc,size_t refs = 0):
         util::base_num_format<CharType>(refs),
         lc_(std::move(lc))
-    {
-    }
+    {}
 protected:
 
     iter_type do_format_currency(bool intl,iter_type out,std::ios_base &/*ios*/,char_type /*fill*/,long double val) const override
@@ -151,11 +150,10 @@ struct ftime_traits<wchar_t> {
 template<typename CharType>
 class time_put_posix : public std::time_put<CharType> {
 public:
-    time_put_posix(std::shared_ptr<locale_t> lc, size_t refs = 0) :
+    time_put_posix(std::shared_ptr<locale_t> lc, size_t refs = 0):
         std::time_put<CharType>(refs),
         lc_(std::move(lc))
-    {
-    }
+    {}
     typedef typename std::time_put<CharType>::iter_type iter_type;
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
@@ -377,10 +375,7 @@ struct basic_numpunct {
     std::string grouping;
     std::string thousands_sep;
     std::string decimal_point;
-    basic_numpunct() :
-        decimal_point(".")
-    {
-    }
+    basic_numpunct(): decimal_point(".") {}
     basic_numpunct(locale_t lc)
     {
     #if defined(__APPLE__) || defined(__FreeBSD__)
@@ -402,7 +397,7 @@ template<typename CharType>
 class num_punct_posix : public std::numpunct<CharType> {
 public:
     typedef std::basic_string<CharType> string_type;
-    num_punct_posix(locale_t lc,size_t refs = 0) :
+    num_punct_posix(locale_t lc,size_t refs = 0):
         std::numpunct<CharType>(refs)
     {
         basic_numpunct np(lc);

--- a/src/boost/locale/posix/posix_backend.cpp
+++ b/src/boost/locale/posix/posix_backend.cpp
@@ -28,18 +28,14 @@ namespace impl_posix {
 
     class posix_localization_backend : public localization_backend {
     public:
-        posix_localization_backend() :
-            invalid_(true)
-        {
-        }
-        posix_localization_backend(posix_localization_backend const &other) :
+        posix_localization_backend(): invalid_(true) {}
+        posix_localization_backend(posix_localization_backend const &other):
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
             locale_id_(other.locale_id_),
             invalid_(true)
-        {
-        }
+        {}
         posix_localization_backend *clone() const override
         {
             return new posix_localization_backend(*this);

--- a/src/boost/locale/shared/date_time.cpp
+++ b/src/boost/locale/shared/date_time.cpp
@@ -20,7 +20,7 @@ using namespace period;
 // Calendar
 ////////////////////////
 
-calendar::calendar(std::locale const &l,std::string const &zone) :
+calendar::calendar(std::locale const &l,std::string const &zone):
     locale_(l),
     tz_(zone),
     impl_(std::use_facet<calendar_facet>(l).create_calendar())
@@ -28,7 +28,7 @@ calendar::calendar(std::locale const &l,std::string const &zone) :
     impl_->set_timezone(tz_);
 }
 
-calendar::calendar(std::string const &zone) :
+calendar::calendar(std::string const &zone):
     tz_(zone),
     impl_(std::use_facet<calendar_facet>(std::locale()).create_calendar())
 {
@@ -36,7 +36,7 @@ calendar::calendar(std::string const &zone) :
 }
 
 
-calendar::calendar(std::locale const &l) :
+calendar::calendar(std::locale const &l):
     locale_(l),
     tz_(time_zone::global()),
     impl_(std::use_facet<calendar_facet>(l).create_calendar())
@@ -44,32 +44,28 @@ calendar::calendar(std::locale const &l) :
     impl_->set_timezone(tz_);
 }
 
-calendar::calendar(std::ios_base &ios) :
+calendar::calendar(std::ios_base &ios):
     locale_(ios.getloc()),
     tz_(ios_info::get(ios).time_zone()),
     impl_(std::use_facet<calendar_facet>(locale_).create_calendar())
 {
     impl_->set_timezone(tz_);
-
 }
 
-calendar::calendar() :
+calendar::calendar():
     tz_(time_zone::global()),
     impl_(std::use_facet<calendar_facet>(std::locale()).create_calendar())
 {
     impl_->set_timezone(tz_);
 }
 
-calendar::~calendar()
-{
-}
+calendar::~calendar(){}
 
-calendar::calendar(calendar const &other) :
+calendar::calendar(calendar const &other):
     locale_(other.locale_),
     tz_(other.tz_),
     impl_(other.impl_->clone())
-{
-}
+{}
 
 calendar const &calendar::operator = (calendar const &other)
 {
@@ -136,16 +132,14 @@ bool calendar::operator!=(calendar const &other) const
 // date_time
 /////////////////
 
-date_time::date_time() :
+date_time::date_time():
     impl_(std::use_facet<calendar_facet>(std::locale()).create_calendar())
 {
     impl_->set_timezone(time_zone::global());
 }
 
-date_time::date_time(date_time const &other)
-{
-    impl_.reset(other.impl_->clone());
-}
+date_time::date_time(date_time const &other): impl_(other.impl_->clone())
+{}
 
 date_time::date_time(date_time const &other,date_time_period_set const &s)
 {
@@ -166,30 +160,28 @@ date_time const &date_time::operator = (date_time const &other)
 }
 
 date_time::~date_time()
-{
-}
+{}
 
-date_time::date_time(double t) :
+date_time::date_time(double t):
     impl_(std::use_facet<calendar_facet>(std::locale()).create_calendar())
 {
     impl_->set_timezone(time_zone::global());
     time(t);
 }
 
-date_time::date_time(double t,calendar const &cal) :
+date_time::date_time(double t,calendar const &cal):
     impl_(cal.impl_->clone())
 {
     time(t);
 }
 
-date_time::date_time(calendar const &cal) :
+date_time::date_time(calendar const &cal):
     impl_(cal.impl_->clone())
-{
-}
+{}
 
 
 
-date_time::date_time(date_time_period_set const &s) :
+date_time::date_time(date_time_period_set const &s):
     impl_(std::use_facet<calendar_facet>(std::locale()).create_calendar())
 {
     impl_->set_timezone(time_zone::global());
@@ -198,7 +190,7 @@ date_time::date_time(date_time_period_set const &s) :
     }
     impl_->normalize();
 }
-date_time::date_time(date_time_period_set const &s,calendar const &cal) :
+date_time::date_time(date_time_period_set const &s,calendar const &cal):
     impl_(cal.impl_->clone())
 {
     for(unsigned i=0;i<s.size();i++) {

--- a/src/boost/locale/shared/date_time.cpp
+++ b/src/boost/locale/shared/date_time.cpp
@@ -67,13 +67,11 @@ calendar::calendar(calendar const &other):
     impl_(other.impl_->clone())
 {}
 
-calendar const &calendar::operator = (calendar const &other)
+calendar& calendar::operator=(calendar const &other)
 {
-    if(this !=&other) {
-        impl_.reset(other.impl_->clone());
-        locale_ = other.locale_;
-        tz_ = other.tz_;
-    }
+    impl_.reset(other.impl_->clone());
+    locale_ = other.locale_;
+    tz_ = other.tz_;
     return *this;
 }
 
@@ -150,12 +148,9 @@ date_time::date_time(date_time const &other,date_time_period_set const &s)
     impl_->normalize();
 }
 
-date_time const &date_time::operator = (date_time const &other)
+date_time& date_time::operator=(date_time const &other)
 {
-    if(this != &other) {
-        date_time tmp(other);
-        swap(tmp);
-    }
+    impl_.reset(other.impl_->clone());
     return *this;
 }
 
@@ -199,7 +194,7 @@ date_time::date_time(date_time_period_set const &s,calendar const &cal):
     impl_->normalize();
 }
 
-date_time const &date_time::operator=(date_time_period_set const &s)
+date_time& date_time::operator=(date_time_period_set const &s)
 {
     for(unsigned i=0;i<s.size();i++)
         impl_->set_value(s[i].type.mark(),s[i].value);
@@ -246,25 +241,25 @@ date_time date_time::operator>>(date_time_period const &v) const
     return tmp;
 }
 
-date_time const &date_time::operator+=(date_time_period const &v)
+date_time& date_time::operator+=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::move,v.value);
     return *this;
 }
 
-date_time const &date_time::operator-=(date_time_period const &v)
+date_time& date_time::operator-=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::move,-v.value);
     return *this;
 }
 
-date_time const &date_time::operator<<=(date_time_period const &v)
+date_time& date_time::operator<<=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::roll,v.value);
     return *this;
 }
 
-date_time const &date_time::operator>>=(date_time_period const &v)
+date_time& date_time::operator>>=(date_time_period const &v)
 {
     impl_->adjust_value(v.type.mark(),abstract_calendar::roll,-v.value);
     return *this;
@@ -299,7 +294,7 @@ date_time date_time::operator>>(date_time_period_set const &v) const
     return tmp;
 }
 
-date_time const &date_time::operator+=(date_time_period_set const &v)
+date_time& date_time::operator+=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this+=v[i];
@@ -307,7 +302,7 @@ date_time const &date_time::operator+=(date_time_period_set const &v)
     return *this;
 }
 
-date_time const &date_time::operator-=(date_time_period_set const &v)
+date_time& date_time::operator-=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this-=v[i];
@@ -315,7 +310,7 @@ date_time const &date_time::operator-=(date_time_period_set const &v)
     return *this;
 }
 
-date_time const &date_time::operator<<=(date_time_period_set const &v)
+date_time& date_time::operator<<=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this <<= v[i];
@@ -323,7 +318,7 @@ date_time const &date_time::operator<<=(date_time_period_set const &v)
     return *this;
 }
 
-date_time const &date_time::operator>>=(date_time_period_set const &v)
+date_time& date_time::operator>>=(date_time_period_set const &v)
 {
     for(unsigned i=0;i<v.size();i++) {
         *this >>= v[i];

--- a/src/boost/locale/shared/format.cpp
+++ b/src/boost/locale/shared/format.cpp
@@ -26,7 +26,7 @@ namespace boost {
                 void (*imbuer)(void *,std::locale const &);
             };
 
-            format_parser::format_parser(std::ios_base &ios,void *cookie,void (*imbuer)(void *,std::locale const &)) :
+            format_parser::format_parser(std::ios_base &ios,void *cookie,void (*imbuer)(void *,std::locale const &)):
                 ios_(ios),
                 d(new data)
             {
@@ -45,9 +45,7 @@ namespace boost {
                 d->imbuer(d->cookie,l);
             }
 
-            format_parser::~format_parser()
-            {
-            }
+            format_parser::~format_parser() {}
 
             void format_parser::restore()
             {

--- a/src/boost/locale/shared/formatting.cpp
+++ b/src/boost/locale/shared/formatting.cpp
@@ -14,15 +14,10 @@
 namespace boost {
     namespace locale {
 
-        ios_info::string_set::string_set() :
-            type(0),
-            size(0),
-            ptr(0)
-        {
-        }
+        ios_info::string_set::string_set(): type(0), size(0), ptr(0) { }
         ios_info::string_set::~string_set()
         {
-            delete [] ptr;
+            delete[] ptr;
         }
         ios_info::string_set::string_set(string_set const &other)
         {
@@ -57,16 +52,14 @@ namespace boost {
 
         struct ios_info::data {};
 
-        ios_info::ios_info() :
+        ios_info::ios_info():
             flags_(0),
             domain_id_(0),
             d(0)
         {
             time_zone_ = time_zone::global();
         }
-        ios_info::~ios_info()
-        {
-        }
+        ios_info::~ios_info() {}
 
         ios_info::ios_info(ios_info const &other)
         {
@@ -161,9 +154,7 @@ namespace boost {
             return impl::ios_prop<ios_info>::get(ios);
         }
 
-        void ios_info::on_imbue()
-        {
-        }
+        void ios_info::on_imbue() {}
 
         namespace {
             struct initializer {

--- a/src/boost/locale/shared/formatting.cpp
+++ b/src/boost/locale/shared/formatting.cpp
@@ -41,12 +41,9 @@ namespace boost {
             std::swap(ptr,other.ptr);
         }
 
-        ios_info::string_set const &ios_info::string_set::operator=(string_set const &other)
+        ios_info::string_set& ios_info::string_set::operator=(string_set other)
         {
-            if(this!=&other) {
-                string_set tmp(other);
-                swap(tmp);
-            }
+            swap(other);
             return *this;
         }
 
@@ -70,7 +67,7 @@ namespace boost {
         }
 
 
-        ios_info const &ios_info::operator=(ios_info const &other)
+        ios_info& ios_info::operator=(ios_info const &other)
         {
             if(this!=&other) {
                 flags_ = other.flags_;

--- a/src/boost/locale/shared/generator.cpp
+++ b/src/boost/locale/shared/generator.cpp
@@ -17,14 +17,13 @@
 namespace boost {
     namespace locale {
         struct generator::data {
-            data(localization_backend_manager const &mgr)  :
+            data(localization_backend_manager const &mgr):
                 cats(all_categories),
                 chars(all_characters),
                 caching_enabled(false),
                 use_ansi_encoding(false),
                 backend_manager(mgr)
-            {
-            }
+            {}
 
             typedef std::map<std::string,std::locale> cached_type;
             mutable cached_type cached;
@@ -45,17 +44,13 @@ namespace boost {
 
         };
 
-        generator::generator(localization_backend_manager const &mgr) :
+        generator::generator(localization_backend_manager const &mgr):
             d(new generator::data(mgr))
-        {
-        }
-        generator::generator() :
+        {}
+        generator::generator():
             d(new generator::data(localization_backend_manager::global()))
-        {
-        }
-        generator::~generator()
-        {
-        }
+        {}
+        generator::~generator() = default;
 
         locale_category_type generator::categories() const
         {

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -31,10 +31,8 @@
 namespace boost {
     namespace locale {
         class localization_backend_manager::impl {
-            void operator = (impl const &);
         public:
-            impl(impl const &other):
-                default_backends_(other.default_backends_)
+            impl(impl const &other): default_backends_(other.default_backends_)
             {
                 for(all_backends_type::const_iterator p=other.all_backends_.begin();p!=other.all_backends_.end();++p) {
                     all_backends_type::value_type v;
@@ -44,6 +42,8 @@ namespace boost {
                 }
             }
             impl(): default_backends_(32,-1) {}
+
+            impl& operator=(impl const&) = delete;
 
             localization_backend *create() const
             {
@@ -162,7 +162,7 @@ namespace boost {
             pimpl_(new impl(*other.pimpl_))
         {}
 
-        localization_backend_manager const &localization_backend_manager::operator = (localization_backend_manager const &other)
+        localization_backend_manager& localization_backend_manager::operator=(localization_backend_manager const &other)
         {
             pimpl_.reset(new impl(*other.pimpl_));
             return *this;

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -33,7 +33,7 @@ namespace boost {
         class localization_backend_manager::impl {
             void operator = (impl const &);
         public:
-            impl(impl const &other) :
+            impl(impl const &other):
                 default_backends_(other.default_backends_)
             {
                 for(all_backends_type::const_iterator p=other.all_backends_.begin();p!=other.all_backends_.end();++p) {
@@ -43,10 +43,7 @@ namespace boost {
                     all_backends_.push_back(v);
                 }
             }
-            impl() :
-                default_backends_(32,-1)
-            {
-            }
+            impl(): default_backends_(32,-1) {}
 
             localization_backend *create() const
             {
@@ -157,25 +154,17 @@ namespace boost {
 
 
 
-        localization_backend_manager::localization_backend_manager() :
-            pimpl_(new impl())
-        {
-        }
+        localization_backend_manager::localization_backend_manager(): pimpl_(new impl()) {}
 
-        localization_backend_manager::~localization_backend_manager()
-        {
-        }
+        localization_backend_manager::~localization_backend_manager() = default;
 
-        localization_backend_manager::localization_backend_manager(localization_backend_manager const &other) :
+        localization_backend_manager::localization_backend_manager(localization_backend_manager const &other):
             pimpl_(new impl(*other.pimpl_))
-        {
-        }
+        {}
 
         localization_backend_manager const &localization_backend_manager::operator = (localization_backend_manager const &other)
         {
-            if(this!=&other) {
-                pimpl_.reset(new impl(*other.pimpl_));
-            }
+            pimpl_.reset(new impl(*other.pimpl_));
             return *this;
         }
 

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -368,7 +368,7 @@ namespace boost {
                     else
                         c_context_ = &empty;
                 }
-                bool operator < (message_key const &other) const
+                bool operator<(message_key const &other) const
                 {
                     int cc = compare(context(),other.context());
                     if(cc != 0)

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -49,10 +49,7 @@ namespace boost {
 
                 FILE *file;
 
-                c_file() :
-                    file(0)
-                {
-                }
+                c_file(): file(0){}
                 ~c_file()
                 {
                     close();
@@ -107,7 +104,7 @@ namespace boost {
             public:
                 typedef std::pair<char const *,char const *> pair_type;
 
-                mo_file(std::vector<char> &file) :
+                mo_file(std::vector<char> &file):
                     native_byteorder_(true),
                     size_(0)
                 {
@@ -115,7 +112,7 @@ namespace boost {
                     init();
                 }
 
-                mo_file(FILE *file) :
+                mo_file(FILE *file):
                     native_byteorder_(true),
                     size_(0)
                 {
@@ -318,10 +315,7 @@ namespace boost {
             template<typename CharType>
             class converter {
             public:
-                converter(std::string /*out_enc*/,std::string in_enc) :
-                    in_(in_enc)
-                {
-                }
+                converter(std::string /*out_enc*/,std::string in_enc): in_(in_enc) {}
 
                 std::basic_string<CharType> operator()(char const *begin,char const *end)
                 {
@@ -335,11 +329,7 @@ namespace boost {
             template<>
             class converter<char> {
             public:
-                converter(std::string out_enc,std::string in_enc) :
-                    out_(out_enc),
-                    in_(in_enc)
-                {
-                }
+                converter(std::string out_enc,std::string in_enc): out_(out_enc), in_(in_enc) {}
 
                 std::string operator()(char const *begin,char const *end)
                 {
@@ -356,7 +346,7 @@ namespace boost {
                 typedef std::basic_string<char_type> string_type;
 
 
-                message_key(string_type const &c = string_type()) :
+                message_key(string_type const &c = string_type()):
                     c_context_(0),
                     c_key_(0)
                 {
@@ -369,7 +359,7 @@ namespace boost {
                         key_ = c.substr(pos+1);
                     }
                 }
-                message_key(char_type const *c,char_type const *k) :
+                message_key(char_type const *c,char_type const *k):
                     c_key_(k)
                 {
                     static const char_type empty = 0;

--- a/src/boost/locale/shared/mo_lambda.cpp
+++ b/src/boost/locale/shared/mo_lambda.cpp
@@ -31,10 +31,7 @@ namespace { // anon
 
     struct unary : public plural
     {
-        unary(plural_ptr ptr) :
-            op1(ptr)
-        {
-        }
+        unary(plural_ptr ptr): op1(ptr) {}
     protected:
         plural_ptr op1;
     };
@@ -42,21 +39,14 @@ namespace { // anon
 
     struct binary : public plural
     {
-        binary(plural_ptr p1,plural_ptr p2) :
-            op1(p1),
-            op2(p2)
-        {
-        }
+        binary(plural_ptr p1,plural_ptr p2): op1(p1), op2(p2) {}
     protected:
         plural_ptr op1,op2;
     };
 
     struct number : public plural
     {
-        number(int v) :
-            val(v)
-        {
-        }
+        number(int v): val(v) {}
         int operator()(int /*n*/) const override
         {
             return val;
@@ -72,9 +62,7 @@ namespace { // anon
 
     #define UNOP(name,oper)                         \
     struct name: public unary {                     \
-        name(plural_ptr op) : unary(op)             \
-        {                                           \
-        };                                          \
+        name(plural_ptr op): unary(op) {}          \
         int operator()(int n) const override  \
         {                                           \
             return oper (*op1)(n);                  \
@@ -89,10 +77,9 @@ namespace { // anon
     #define BINOP(name,oper)                        \
     struct name : public binary                     \
     {                                               \
-        name(plural_ptr p1,plural_ptr p2) :         \
+        name(plural_ptr p1,plural_ptr p2):         \
             binary(p1,p2)                           \
-        {                                           \
-        }                                           \
+        {}                                          \
                                                     \
         int operator()(int n) const override \
         {                                           \
@@ -108,10 +95,9 @@ namespace { // anon
 
     #define BINOPD(name,oper)                       \
     struct name : public binary {                   \
-        name(plural_ptr p1,plural_ptr p2) :         \
+        name(plural_ptr p1,plural_ptr p2):         \
             binary(p1,p2)                           \
-        {                                           \
-        }                                           \
+        {}                                          \
         int operator()(int n) const override  \
         {                                           \
             int v1=(*op1)(n);                       \
@@ -171,12 +157,11 @@ namespace { // anon
     static int level1[]={1,OR};
 
     struct conditional : public plural {
-        conditional(plural_ptr p1,plural_ptr p2,plural_ptr p3) :
+        conditional(plural_ptr p1,plural_ptr p2,plural_ptr p3):
              op1(p1),
              op2(p2),
              op3(p3)
-        {
-        }
+        {}
         int operator()(int n) const override
         {
             return (*op1)(n) ? (*op2)(n) : (*op3)(n);
@@ -300,7 +285,7 @@ namespace { // anon
     class parser {
     public:
 
-        parser(tokenizer &tin) : t(tin) {};
+        parser(tokenizer &tin): t(tin) {};
 
         plural_ptr compile()
         {

--- a/src/boost/locale/std/collate.cpp
+++ b/src/boost/locale/std/collate.cpp
@@ -18,11 +18,10 @@ namespace impl_std {
 class utf8_collator_from_wide : public std::collate<char> {
 public:
     typedef std::collate<wchar_t> wfacet;
-    utf8_collator_from_wide(std::locale const &base,size_t refs = 0) :
+    utf8_collator_from_wide(std::locale const &base,size_t refs = 0):
         std::collate<char>(refs),
         base_(base)
-    {
-    }
+    {}
     int do_compare(char const *lb,char const *le,char const *rb,char const *re) const override
     {
         std::wstring l=conv::to_utf<wchar_t>(lb,le,"UTF-8");

--- a/src/boost/locale/std/converter.cpp
+++ b/src/boost/locale/std/converter.cpp
@@ -31,11 +31,10 @@ public:
     typedef CharType char_type;
     typedef std::basic_string<char_type> string_type;
     typedef std::ctype<char_type> ctype_type;
-    std_converter(std::locale const &base,size_t refs = 0) :
+    std_converter(std::locale const &base,size_t refs = 0):
         converter<CharType>(refs),
         base_(base)
-    {
-    }
+    {}
     string_type convert(converter_base::conversion_type how,char_type const *begin,char_type const *end,int /*flags*/ = 0) const override
     {
         switch(how) {
@@ -66,11 +65,10 @@ class utf8_converter : public converter<char> {
 public:
     typedef std::ctype<char> ctype_type;
     typedef std::ctype<wchar_t> wctype_type;
-    utf8_converter(std::locale const &base,size_t refs = 0) :
+    utf8_converter(std::locale const &base,size_t refs = 0):
         converter<char>(refs),
         base_(base)
-    {
-    }
+    {}
     std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int /*flags*/ = 0) const override
     {
         switch(how) {

--- a/src/boost/locale/std/numeric.cpp
+++ b/src/boost/locale/std/numeric.cpp
@@ -24,11 +24,10 @@ namespace impl_std {
 template<typename CharType>
 class time_put_from_base : public std::time_put<CharType> {
 public:
-    time_put_from_base(std::locale const &base, size_t refs = 0) :
+    time_put_from_base(std::locale const &base, size_t refs = 0):
         std::time_put<CharType>(refs),
         base_(base)
-    {
-    }
+    {}
     typedef typename std::time_put<CharType>::iter_type iter_type;
 
     iter_type do_put(iter_type out,std::ios_base &/*ios*/,CharType fill,std::tm const *tm,char format,char modifier) const override
@@ -43,11 +42,10 @@ private:
 
 class utf8_time_put_from_wide : public std::time_put<char> {
 public:
-    utf8_time_put_from_wide(std::locale const &base, size_t refs = 0) :
+    utf8_time_put_from_wide(std::locale const &base, size_t refs = 0):
         std::time_put<char>(refs),
         base_(base)
-    {
-    }
+    {}
     iter_type do_put(iter_type out,std::ios_base &/*ios*/,char fill,std::tm const *tm,char format,char modifier = 0) const override
     {
         std::basic_ostringstream<wchar_t> wtmps;
@@ -66,7 +64,7 @@ private:
 
 class utf8_numpunct_from_wide : public std::numpunct<char> {
 public:
-    utf8_numpunct_from_wide(std::locale const &base,size_t refs = 0) : std::numpunct<char>(refs)
+    utf8_numpunct_from_wide(std::locale const &base,size_t refs = 0): std::numpunct<char>(refs)
     {
         typedef std::numpunct<wchar_t> wfacet_type;
         wfacet_type const &wfacet = std::use_facet<wfacet_type>(base);
@@ -136,7 +134,7 @@ private:
 template<bool Intl>
 class utf8_moneypunct_from_wide : public std::moneypunct<char,Intl> {
 public:
-    utf8_moneypunct_from_wide(std::locale const &base,size_t refs = 0) : std::moneypunct<char,Intl>(refs)
+    utf8_moneypunct_from_wide(std::locale const &base,size_t refs = 0): std::moneypunct<char,Intl>(refs)
     {
         typedef std::moneypunct<wchar_t,Intl> wfacet_type;
         wfacet_type const &wfacet = std::use_facet<wfacet_type>(base);
@@ -235,10 +233,7 @@ private:
 class utf8_numpunct : public std::numpunct_byname<char> {
 public:
     typedef std::numpunct_byname<char> base_type;
-    utf8_numpunct(char const *name,size_t refs = 0) :
-        std::numpunct_byname<char>(name,refs)
-    {
-    }
+    utf8_numpunct(char const *name,size_t refs = 0): std::numpunct_byname<char>(name,refs) {}
     char do_thousands_sep() const override
     {
         unsigned char bs = base_type::do_thousands_sep();
@@ -263,10 +258,7 @@ template<bool Intl>
 class utf8_moneypunct : public std::moneypunct_byname<char,Intl> {
 public:
     typedef std::moneypunct_byname<char,Intl> base_type;
-    utf8_moneypunct(char const *name,size_t refs = 0) :
-        std::moneypunct_byname<char,Intl>(name,refs)
-    {
-    }
+    utf8_moneypunct(char const *name,size_t refs = 0): std::moneypunct_byname<char,Intl>(name,refs) {}
     char do_thousands_sep() const override
     {
         unsigned char bs = base_type::do_thousands_sep();

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -31,20 +31,15 @@ namespace impl_std {
 
     class std_localization_backend : public localization_backend {
     public:
-        std_localization_backend() :
-            invalid_(true),
-            use_ansi_encoding_(false)
-        {
-        }
-        std_localization_backend(std_localization_backend const &other) :
+        std_localization_backend(): invalid_(true), use_ansi_encoding_(false) {}
+        std_localization_backend(std_localization_backend const &other):
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
             locale_id_(other.locale_id_),
             invalid_(true),
             use_ansi_encoding_(other.use_ansi_encoding_)
-        {
-        }
+        {}
         std_localization_backend *clone() const override
         {
             return new std_localization_backend(*this);

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -146,10 +146,7 @@ namespace util {
     class simple_converter : public base_converter {
     public:
 
-        simple_converter(std::string const &encoding) :
-            cvt_(encoding)
-        {
-        }
+        simple_converter(std::string const &encoding): cvt_(encoding) {}
 
         int max_len() const override
         {
@@ -182,11 +179,10 @@ namespace util {
     {
     public:
 
-        simple_codecvt(std::string const &encoding,size_t refs = 0) :
+        simple_codecvt(std::string const &encoding,size_t refs = 0):
             generic_codecvt<CharType,simple_codecvt<CharType> >(refs),
             cvt_(encoding)
-        {
-        }
+        {}
 
         struct state_type {};
         static state_type initial_state(generic_codecvt_base::initial_convertion_state /* unused */)
@@ -293,7 +289,7 @@ namespace util {
         typedef std::unique_ptr<base_converter> base_converter_ptr;
         typedef base_converter_ptr state_type;
 
-        code_converter(base_converter_ptr cvt,size_t refs = 0) :
+        code_converter(base_converter_ptr cvt,size_t refs = 0):
             generic_codecvt<CharType,code_converter<CharType> >(refs),
             cvt_(std::move(cvt))
         {

--- a/src/boost/locale/util/gregorian.cpp
+++ b/src/boost/locale/util/gregorian.cpp
@@ -820,11 +820,10 @@ BOOST_LOCALE_END_CONST_CONDITION
 
     class gregorian_facet : public calendar_facet {
     public:
-        gregorian_facet(std::string const &terr,size_t refs = 0) :
+        gregorian_facet(std::string const &terr,size_t refs = 0):
             calendar_facet(refs),
             terr_(terr)
-        {
-        }
+        {}
         abstract_calendar *create_calendar() const override
         {
             return create_gregorian_calendar(terr_);

--- a/src/boost/locale/util/info.cpp
+++ b/src/boost/locale/util/info.cpp
@@ -22,7 +22,7 @@ namespace util {
 
     class simple_info : public info {
     public:
-        simple_info(std::string const &name,size_t refs = 0) :
+        simple_info(std::string const &name,size_t refs = 0):
             info(refs),
             name_(name)
         {

--- a/src/boost/locale/util/locale_data.hpp
+++ b/src/boost/locale/util/locale_data.hpp
@@ -15,12 +15,7 @@ namespace boost {
 
             class locale_data {
             public:
-                locale_data() :
-                    language("C"),
-                    encoding("us-ascii"),
-                    utf8(false)
-                {
-                }
+                locale_data(): language("C"), encoding("us-ascii"), utf8(false) {}
 
                 std::string language;
                 std::string country;

--- a/src/boost/locale/util/numeric.hpp
+++ b/src/boost/locale/util/numeric.hpp
@@ -68,12 +68,8 @@ public:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    base_num_format(size_t refs = 0) :
-        std::num_put<CharType>(refs)
-    {
-    }
+    base_num_format(size_t refs = 0): std::num_put<CharType>(refs) {}
 protected:
-
 
     iter_type do_put (iter_type out, std::ios_base &ios, char_type fill, long val) const override
     {
@@ -253,10 +249,7 @@ template<typename CharType>
 class base_num_parse : public std::num_get<CharType>
 {
 public:
-    base_num_parse(size_t refs = 0) :
-        std::num_get<CharType>(refs)
-    {
-    }
+    base_num_parse(size_t refs = 0): std::num_get<CharType>(refs) {}
 protected:
     typedef typename std::num_get<CharType>::iter_type iter_type;
     typedef std::basic_string<CharType> string_type;

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -71,10 +71,7 @@ namespace impl_win {
 
     class winlocale{
     public:
-        winlocale() :
-            lcid(0)
-        {
-        }
+        winlocale(): lcid(0) {}
 
         winlocale(std::string const &name)
         {

--- a/src/boost/locale/win32/collate.cpp
+++ b/src/boost/locale/win32/collate.cpp
@@ -19,11 +19,7 @@ namespace impl_win {
 
 class utf8_collator : public collator<char> {
 public:
-    utf8_collator(winlocale lc,size_t refs = 0) :
-        collator<char>(refs),
-        lc_(lc)
-    {
-    }
+    utf8_collator(winlocale lc,size_t refs = 0): collator<char>(refs), lc_(lc) {}
     int do_compare(collator_base::level_type level,char const *lb,char const *le,char const *rb,char const *re) const override
     {
         std::wstring l=conv::to_utf<wchar_t>(lb,le,"UTF-8");
@@ -70,11 +66,7 @@ private:
 class utf16_collator : public collator<wchar_t> {
 public:
     typedef std::collate<wchar_t> wfacet;
-    utf16_collator(winlocale lc,size_t refs = 0) :
-        collator<wchar_t>(refs),
-        lc_(lc)
-    {
-    }
+    utf16_collator(winlocale lc,size_t refs = 0): collator<wchar_t>(refs), lc_(lc) {}
     int do_compare(collator_base::level_type level,wchar_t const *lb,wchar_t const *le,wchar_t const *rb,wchar_t const *re) const override
     {
         return wcscoll_l(level,lb,le,rb,re,lc_);

--- a/src/boost/locale/win32/converter.cpp
+++ b/src/boost/locale/win32/converter.cpp
@@ -22,11 +22,7 @@ namespace impl_win {
 class utf16_converter : public converter<wchar_t>
 {
 public:
-    utf16_converter(winlocale const &lc,size_t refs = 0) :
-        converter<wchar_t>(refs),
-        lc_(lc)
-    {
-    }
+    utf16_converter(winlocale const &lc,size_t refs = 0): converter<wchar_t>(refs), lc_(lc) {}
     std::wstring convert(converter_base::conversion_type how,wchar_t const *begin,wchar_t const *end,int flags = 0) const override
     {
         switch(how) {
@@ -48,11 +44,7 @@ private:
 
 class utf8_converter : public converter<char> {
 public:
-    utf8_converter(winlocale const &lc,size_t refs = 0) :
-        converter<char>(refs),
-        lc_(lc)
-    {
-    }
+    utf8_converter(winlocale const &lc,size_t refs = 0): converter<char>(refs), lc_(lc) {}
     std::string convert(converter_base::conversion_type how,char const *begin,char const *end,int flags = 0) const override
     {
         std::wstring tmp = conv::to_utf<wchar_t>(begin,end,"UTF-8");

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -51,11 +51,7 @@ public:
     typedef std::basic_string<CharType> string_type;
     typedef CharType char_type;
 
-    num_format(winlocale const &lc,size_t refs = 0) :
-        util::base_num_format<CharType>(refs),
-        lc_(lc)
-    {
-    }
+    num_format(winlocale const &lc,size_t refs = 0): util::base_num_format<CharType>(refs), lc_(lc) {}
 private:
 
     iter_type do_format_currency(bool /*intl*/,iter_type out,std::ios_base &ios,char_type fill,long double val) const override
@@ -87,11 +83,7 @@ private:
 template<typename CharType>
 class time_put_win : public std::time_put<CharType> {
 public:
-    time_put_win(winlocale const &lc, size_t refs = 0) :
-        std::time_put<CharType>(refs),
-        lc_(lc)
-    {
-    }
+    time_put_win(winlocale const &lc, size_t refs = 0): std::time_put<CharType>(refs), lc_(lc) {}
 
     typedef typename std::time_put<CharType>::iter_type iter_type;
     typedef CharType char_type;
@@ -116,7 +108,7 @@ template<typename CharType>
 class num_punct_win : public std::numpunct<CharType> {
 public:
     typedef std::basic_string<CharType> string_type;
-    num_punct_win(winlocale const &lc,size_t refs = 0) :
+    num_punct_win(winlocale const &lc,size_t refs = 0):
         std::numpunct<CharType>(refs)
     {
         numeric_info np = wcsnumformat_l(lc) ;

--- a/src/boost/locale/win32/win_backend.cpp
+++ b/src/boost/locale/win32/win_backend.cpp
@@ -24,18 +24,14 @@ namespace impl_win {
 
     class winapi_localization_backend : public localization_backend {
     public:
-        winapi_localization_backend() :
-            invalid_(true)
-        {
-        }
-        winapi_localization_backend(winapi_localization_backend const &other) :
+        winapi_localization_backend(): invalid_(true) {}
+        winapi_localization_backend(winapi_localization_backend const &other):
             localization_backend(),
             paths_(other.paths_),
             domains_(other.domains_),
             locale_id_(other.locale_id_),
             invalid_(true)
-        {
-        }
+        {}
         winapi_localization_backend *clone() const override
         {
             return new winapi_localization_backend(*this);

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -26,8 +26,7 @@ int main()
 
 template<typename Char>
 void print_str(std::basic_string<Char> const &/*s*/)
-{
-}
+{}
 
 template<>
 void print_str<char>(std::basic_string<char> const &s)

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -86,8 +86,8 @@ void test_main(int /*argc*/, char** /*argv*/)
             date_time time_point = year(1970) + february() + day(5);
 
             ss << as::ftime("%Y-%m-%d")<< time_point;
-
             TEST_EQ(ss.str(), "1970-02-05");
+
             time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second();
             ss.str("");
             ss << as::ftime("%Y-%m-%d %H:%M:%S") << time_point;
@@ -171,7 +171,7 @@ void test_main(int /*argc*/, char** /*argv*/)
                 TEST_EQ(time_point.get(era()), 0);
                 TEST_EQ(time_point.get(year()), 4);
             }
-            
+
             time_point = tp_5_feb_1970_153313;
             TEST_EQ(time_point.get(month()), 1);
             TEST_EQ(time_point.get(day()), 5);

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -94,22 +94,64 @@ void test_main(int /*argc*/, char** /*argv*/)
             ss.imbue(loc);
             ss << boost::locale::as::time_zone(tz);
 
-            date_time time_point = year(1970) + february() + day(5);
-
-            ss << as::ftime("%Y-%m-%d")<< time_point;
-            TEST_EQ(ss.str(), "1970-02-05");
-
-            time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second();
-            ss.str("");
-            ss << as::ftime("%Y-%m-%d %H:%M:%S") << time_point;
-            TEST_EQ( ss.str(), "1970-02-05 15:33:13"); ss.str("");
-
             const time_t one_h = 60 * 60;
             const time_t a_date = 24 * one_h * (31+4); // Feb 5th
             const time_t a_time = 15 * one_h + 60 * 33 + 13; // 15:33:13
             const time_t a_datetime = a_date + a_time;
 
             const date_time tp_5_feb_1970_153313 = date_time(a_datetime); /// 5th Feb 1970 15:33:13
+            ss << as::ftime("%Y-%m-%d");
+            TEST_EQ_FMT(tp_5_feb_1970_153313, "1970-02-05");
+            ss << as::ftime("%Y-%m-%d %H:%M:%S");
+            TEST_EQ_FMT(tp_5_feb_1970_153313, "1970-02-05 15:33:13");
+
+            // Test set()
+            date_time time_point = tp_5_feb_1970_153313;
+            time_point.set(year(), 1990);
+            TEST_EQ_FMT(time_point, "1990-02-05 15:33:13");
+            time_point.set(month(), 5);
+            TEST_EQ_FMT(time_point, "1990-06-05 15:33:13");
+            time_point.set(day(), 9);
+            TEST_EQ_FMT(time_point, "1990-06-09 15:33:13");
+            time_point.set(hour(), 11);
+            TEST_EQ_FMT(time_point, "1990-06-09 11:33:13");
+            time_point.set(minute(), 42);
+            TEST_EQ_FMT(time_point, "1990-06-09 11:42:13");
+            time_point.set(second(), 24);
+            TEST_EQ_FMT(time_point, "1990-06-09 11:42:24");
+            time_point.set(am_pm(), 1);
+            TEST_EQ_FMT(time_point, "1990-06-09 23:42:24");
+            // Overflow day of month
+            time_point.set(day(), time_point.maximum(day()) + 1);
+            TEST_EQ_FMT(time_point, "1990-07-01 23:42:24");
+
+            // Same via assignment
+            time_point = tp_5_feb_1970_153313;
+            time_point = year(1990);
+            TEST_EQ_FMT(time_point, "1990-02-05 15:33:13");
+            time_point = month(5);
+            TEST_EQ_FMT(time_point, "1990-06-05 15:33:13");
+            time_point = day(9);
+            TEST_EQ_FMT(time_point, "1990-06-09 15:33:13");
+            time_point = hour(11);
+            TEST_EQ_FMT(time_point, "1990-06-09 11:33:13");
+            time_point = minute(42);
+            TEST_EQ_FMT(time_point, "1990-06-09 11:42:13");
+            time_point = second(24);
+            TEST_EQ_FMT(time_point, "1990-06-09 11:42:24");
+            time_point = am_pm(1);
+            TEST_EQ_FMT(time_point, "1990-06-09 23:42:24");
+            // Overflow day of month
+            time_point = day(time_point.maximum(day()) + 1);
+            TEST_EQ_FMT(time_point, "1990-07-01 23:42:24");
+            // All at once
+            time_point = year(1989) + month(2) + day(5) + hour(7) + minute(9) + second(11);
+            TEST_EQ_FMT(time_point, "1989-03-05 07:09:11");
+            // Partials:
+            time_point = year(1970) + february() + day(5);
+            TEST_EQ_FMT(time_point, "1970-02-05 07:09:11");
+            time_point = 3 * hour_12() + 1 * am_pm() + 33 * minute() + 13 * second();
+            TEST_EQ_FMT(time_point, "1970-02-05 15:33:13");
 
             time_point = tp_5_feb_1970_153313;
             time_point += hour();

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -14,6 +14,7 @@
 #include <boost/locale/localization_backend.hpp>
 #include <ctime>
 #include <iomanip>
+#include <limits>
 #include "boostLocale/test/unit_test.hpp"
 
 #ifdef BOOST_LOCALE_WITH_ICU
@@ -227,8 +228,9 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ_FMT(tp_5_april_1990_153313 - month(12 * 3 + 1), "1987-03-05 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 >> month(12 * 3 + 1), "1990-03-05 15:33:13");
             // Check that possible int overflows get handled
-            TEST_EQ_FMT(tp_5_april_1990_153313 >> month((std::numeric_limits<int>::max() / 12) * 12), "1990-04-05 15:33:13");
-            TEST_EQ_FMT(tp_5_april_1990_153313 << month((std::numeric_limits<int>::max() / 12) * 12), "1990-04-05 15:33:13");
+            const int max_full_years_in_months = (std::numeric_limits<int>::max() / 12) * 12;
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> month(max_full_years_in_months), "1990-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << month(max_full_years_in_months), "1990-04-05 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 + day(30 + 2), "1990-05-07 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 << day(30 + 2), "1990-04-07 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 - day(10), "1990-03-26 15:33:13");

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -192,14 +192,73 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ( (time_point + 2* month()- (time_point+month())) / day(), 31);
             TEST_EQ( day(time_point + 2* month()- (time_point+month())), 31);
 
-            time_point = tp_5_feb_1970_153313;
-            TEST_EQ_FMT( time_point + hour(), "1970-02-05 16:33:13");
-            TEST_EQ_FMT( time_point - hour(2), "1970-02-05 13:33:13");
-            TEST_EQ_FMT( time_point >> minute(), "1970-02-05 15:32:13");
-            TEST_EQ_FMT( time_point << second(), "1970-02-05 15:33:14");
+            // To subtract from the year, don't use 1970 which may be the lowest possible year
+            const date_time tp_5_april_1990_153313 = (date_time(tp_5_feb_1970_153313) = (year(1990) + april()));
+            TEST_EQ_FMT(tp_5_april_1990_153313, "1990-04-05 15:33:13");
+            // Test each period
+            TEST_EQ_FMT(tp_5_april_1990_153313 + year(2), "1992-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << year(2), "1992-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - year(10), "1980-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> year(10), "1980-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + month(2), "1990-06-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << month(2), "1990-06-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - month(1), "1990-03-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> month(1), "1990-03-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + day(2), "1990-04-07 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << day(2), "1990-04-07 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - day(3), "1990-04-02 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> day(3), "1990-04-02 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + hour(2), "1990-04-05 17:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << hour(2), "1990-04-05 17:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - hour(3), "1990-04-05 12:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> hour(3), "1990-04-05 12:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + minute(2), "1990-04-05 15:35:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << minute(2), "1990-04-05 15:35:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - minute(3), "1990-04-05 15:30:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> minute(3), "1990-04-05 15:30:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + second(2), "1990-04-05 15:33:15");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << second(2), "1990-04-05 15:33:15");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - second(2), "1990-04-05 15:33:11");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> second(2), "1990-04-05 15:33:11");
+            // Difference between add and roll: The latter only changes the given field
+            // So this tests what happens when going over/under the bound for each field
+            TEST_EQ_FMT(tp_5_april_1990_153313 + month(12 + 2), "1991-06-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << month(12 + 2), "1990-06-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - month(12 * 3 + 1), "1987-03-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> month(12 * 3 + 1), "1990-03-05 15:33:13");
+            // Check that possible int overflows get handled
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> month((std::numeric_limits<int>::max() / 12) * 12), "1990-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << month((std::numeric_limits<int>::max() / 12) * 12), "1990-04-05 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + day(30 + 2), "1990-05-07 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << day(30 + 2), "1990-04-07 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - day(10), "1990-03-26 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> day(10), "1990-04-25 15:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + hour(24 * 3 + 2), "1990-04-08 17:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << hour(24 * 3 + 2), "1990-04-05 17:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - hour(24 * 5 + 3), "1990-03-31 12:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> hour(24 * 5 + 3), "1990-04-05 12:33:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + minute(60 * 5 + 3), "1990-04-05 20:36:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << minute(60 * 5 + 3), "1990-04-05 15:36:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - minute(60 * 5 + 3), "1990-04-05 10:30:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> minute(60 * 5 + 3), "1990-04-05 15:30:13");
+            TEST_EQ_FMT(tp_5_april_1990_153313 + second(60 * 3 + 2), "1990-04-05 15:36:15");
+            TEST_EQ_FMT(tp_5_april_1990_153313 << second(60 * 3 + 2), "1990-04-05 15:33:15");
+            TEST_EQ_FMT(tp_5_april_1990_153313 - second(60 * 5 + 2), "1990-04-05 15:28:11");
+            TEST_EQ_FMT(tp_5_april_1990_153313 >> second(60 * 5 + 2), "1990-04-05 15:33:11");
 
-            TEST(time_point == time_point);
-            TEST(!(time_point != time_point));
+            // Add a set of periods
+            TEST_EQ_FMT(tp_5_feb_1970_153313 << (year(2) + month(3) - day(1) + hour(5) + minute(7) + second(9)), "1972-05-04 20:40:22");
+            TEST_EQ_FMT(tp_5_feb_1970_153313 + (year(2) + month(3) - day(1) + hour(5) + minute(7) + second(9)), "1972-05-04 20:40:22");
+            // std calendar can't go below 1970
+            time_point = tp_5_feb_1970_153313;
+            time_point = year(1972) + july();
+            TEST_EQ_FMT(time_point, "1972-07-05 15:33:13");
+            TEST_EQ_FMT(time_point >> (year(2) + month(3) - day(11) + hour(5) + minute(7) + second(9)), "1970-04-16 10:26:04");
+            TEST_EQ_FMT(time_point - (year(2) + month(3) - day(11) + hour(5) + minute(7) + second(9)), "1970-04-16 10:26:04");
+
+            time_point = tp_5_feb_1970_153313;
+            TEST(time_point == tp_5_feb_1970_153313);
+            TEST(!(time_point != tp_5_feb_1970_153313));
             TEST_EQ(time_point.get(hour()), 15);
             TEST_EQ(time_point/hour(), 15);
             TEST(time_point+year() != time_point);

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -63,9 +63,14 @@ void test_main(int /*argc*/, char** /*argv*/)
 
             std::locale::global(loc);
 
-            std::string tz("GMT");
+            const std::string tz = "GMT";
             time_zone::global(tz);
-            calendar cal(loc,tz);
+            // A call returns the old tz
+            TEST_EQ(time_zone::global("GMT+01:00"), tz);
+            TEST_EQ(time_zone::global(tz), "GMT+01:00");
+            calendar cal(loc, tz);
+            TEST(cal.get_locale() == loc);
+            TEST(cal.get_time_zone() == tz);
 
             TEST(calendar() == cal);
             TEST(calendar(loc) == cal);
@@ -79,6 +84,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ(cal.greatest_minimum(day()), 1);
             TEST_EQ(cal.least_maximum(day()), 28);
             TEST_EQ(cal.maximum(day()), 31);
+            TEST(cal.is_gregorian());
 
             TEST_EQ(calendar(g("ar_EG.UTF-8")).first_day_of_week(), 7);
             TEST_EQ(calendar(g("he_IL.UTF-8")).first_day_of_week(), 1);

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -17,7 +17,7 @@ bool has_message(std::locale const &l)
 }
 
 struct test_facet : public std::locale::facet {
-    test_facet() : std::locale::facet(0) {}
+    test_facet(): std::locale::facet(0) {}
     static std::locale::id id;
 };
 

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -12,7 +12,7 @@
 int counter=0;
 int imbued=0;
 struct propery {
-    propery(int xx=-1) : x(xx) { counter ++; }
+    propery(int xx=-1): x(xx) { counter ++; }
     propery(propery const &other) { counter++; x=other.x; }
     propery const &operator=(propery const &other) {
         x=other.x;

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -14,7 +14,7 @@ int imbued=0;
 struct propery {
     propery(int xx=-1): x(xx) { counter ++; }
     propery(propery const &other) { counter++; x=other.x; }
-    propery const &operator=(propery const &other) {
+    propery& operator=(propery const &other) {
         x=other.x;
         return *this;
     };


### PR DESCRIPTION
For 64bit `time_t` the years could be in range [1, INT_MAX]
For negative differences `addon` then was set to `INT_MAX` causing the expression `value - cur_min + difference + addon` to overflow for almost any `value` leading to undefined behavior.

Fix this by rewriting the logic using a simpler approach and making assumptions clear using assertions.

Also improve the test a lot to find and verify this.