### PR TITLE
Refactor tests and fix possible overflow in ICU case conversion

### DIFF
--- a/examples/calendar.cpp
+++ b/examples/calendar.cpp
@@ -26,13 +26,13 @@ int main()
     start.set(period::month(), now.minimum(period::month()));
     start.set(period::day(), start.minimum(period::day()));
 
-    int current_year = period::year(now);
+    const int current_year = period::year(now);
 
     // Display current year
     std::cout << format("{1,ftime='%Y'}") % now << std::endl;
 
     //
-    // Run forward untill current year is the date
+    // Run forward until current year is the date
     //
     for(now = start; period::year(now) == current_year;) {
         // Print heading of month
@@ -43,7 +43,7 @@ int main()
                            % now % date_time(now, now.maximum(period::day()) * period::day())
                       << std::endl;
 
-        int first = calendar().first_day_of_week();
+        const int first = calendar().first_day_of_week();
 
         // Print weeks days
         for(int i = 0; i < 7; i++) {
@@ -52,8 +52,8 @@ int main()
         }
         std::cout << std::endl;
 
-        int current_month = now / period::month();
-        int skip = now / period::day_of_week_local() - 1;
+        const int current_month = now / period::month();
+        const int skip = now / period::day_of_week_local() - 1;
         for(int i = 0; i < skip * 9; i++)
             std::cout << ' ';
         for(; now / period::month() == current_month; now += period::day()) {

--- a/include/boost/locale/boundary/index.hpp
+++ b/include/boost/locale/boundary/index.hpp
@@ -55,7 +55,7 @@ namespace boost { namespace locale { namespace boundary {
 
         template<typename CharType, typename SomeIteratorType>
         struct linear_iterator_traits {
-            static const bool is_linear =
+            static constexpr bool is_linear =
               std::is_same<SomeIteratorType, CharType*>::value || std::is_same<SomeIteratorType, const CharType*>::value
               || std::is_same<SomeIteratorType, typename std::basic_string<CharType>::iterator>::value
               || std::is_same<SomeIteratorType, typename std::basic_string<CharType>::const_iterator>::value

--- a/include/boost/locale/boundary/types.hpp
+++ b/include/boost/locale/boundary/types.hpp
@@ -51,8 +51,8 @@ namespace boost { namespace locale {
         /// \anchor bl_boundary_word_rules
         /// \name Flags that describe a type of word selected
         /// @{
-        static const rule_type word_none = 0x0000F, ///< Not a word, like white space or punctuation mark
-          word_number = 0x000F0,                    ///< Word that appear to be a number
+        constexpr rule_type word_none = 0x0000F, ///< Not a word, like white space or punctuation mark
+          word_number = 0x000F0,                 ///< Word that appear to be a number
           word_letter = 0x00F00,    ///< Word that contains letters, excluding kana and ideographic characters
           word_kana = 0x0F000,      ///< Word that contains kana characters
           word_ideo = 0xF0000,      ///< Word that contains ideographic characters
@@ -66,10 +66,10 @@ namespace boost { namespace locale {
         /// \anchor bl_boundary_line_rules
         /// \name Flags that describe a type of line break
         /// @{
-        static const rule_type line_soft = 0x0F, ///< Soft line break: optional but not required
-          line_hard = 0xF0,                      ///< Hard line break: like break is required (as per CR/LF)
-          line_any = 0xFF,                       ///< Soft or Hard line break
-          line_mask = 0xFF;                      ///< Select all types of line breaks
+        constexpr rule_type line_soft = 0x0F, ///< Soft line break: optional but not required
+          line_hard = 0xF0,                   ///< Hard line break: like break is required (as per CR/LF)
+          line_any = 0xFF,                    ///< Soft or Hard line break
+          line_mask = 0xFF;                   ///< Select all types of line breaks
 
         /// @}
 
@@ -78,9 +78,8 @@ namespace boost { namespace locale {
         /// \name Flags that describe a type of sentence break
         ///
         /// @{
-        static const rule_type sentence_term =
-                                 0x0F, ///< \brief The sentence was terminated with a sentence terminator
-                                       ///  like ".", "!" possible followed by hard separator like CR, LF, PS
+        constexpr rule_type sentence_term = 0x0F, ///< \brief The sentence was terminated with a sentence terminator
+                                                  ///  like ".", "!" possible followed by hard separator like CR, LF, PS
           sentence_sep =
             0xF0, ///< \brief The sentence does not contain terminator like ".", "!" but ended with hard separator
                   ///  like CR, LF, PS or end of input.
@@ -95,8 +94,8 @@ namespace boost { namespace locale {
         /// At this point break iterator does not distinguish different
         /// kinds of characters so it is used for consistency.
         ///@{
-        static const rule_type character_any = 0xF, ///< Not in use, just for consistency
-          character_mask = 0xF;                     ///< Select all character breaking points
+        constexpr rule_type character_any = 0xF, ///< Not in use, just for consistency
+          character_mask = 0xF;                  ///< Select all character breaking points
 
         ///@}
 

--- a/include/boost/locale/date_time_facet.hpp
+++ b/include/boost/locale/date_time_facet.hpp
@@ -147,8 +147,8 @@ namespace boost { namespace locale {
         ///
         /// Set specific \a value for period \a p, note not all values are settable.
         ///
-        /// After call of set_value you may want to call normalize() function to make sure
-        /// vall periods are updated, if you set sereral fields that are part of single
+        /// After calling set_value you may want to call normalize() function to make sure
+        /// all periods are updated, if you set several fields that are part of a single
         /// date/time representation you should call set_value several times and then
         /// call normalize().
         ///
@@ -174,6 +174,8 @@ namespace boost { namespace locale {
         /// Get current time point
         ///
         virtual posix_time get_time() const = 0;
+        // Get current time since epoch in milliseconds
+        virtual double get_time_ms() const = 0;
 
         ///
         /// Set option for calendar, for future use
@@ -193,7 +195,7 @@ namespace boost { namespace locale {
         ///
         /// Calculate the difference between this calendar  and \a other in \a p units
         ///
-        virtual int difference(const abstract_calendar* other, period::marks::period_mark m) const = 0;
+        virtual int difference(const abstract_calendar& other, period::marks::period_mark m) const = 0;
 
         ///
         /// Set time zone, empty - use system

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -400,7 +400,7 @@ namespace boost { namespace locale {
 
         static void imbue_locale(void* ptr, const std::locale& l) { reinterpret_cast<stream_type*>(ptr)->imbue(l); }
 
-        static const unsigned base_params_ = 8;
+        static constexpr unsigned base_params_ = 8;
 
         message_type message_;
         string_type format_;

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -207,7 +207,8 @@ namespace boost { namespace locale {
         ///
         /// Create a format class for \a format_string
         ///
-        basic_format(string_type format_string) : format_(format_string), translate_(false), parameters_count_(0) {}
+        basic_format(const string_type& format_string) : format_(format_string), translate_(false), parameters_count_(0)
+        {}
         ///
         /// Create a format class using message \a trans. The message if translated first according
         /// to the rules of target locale and then interpreted as format string

--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -28,37 +28,37 @@ namespace locale {
     class localization_backend;
     class localization_backend_manager;
 
-    static const uint32_t nochar_facet = 0;        ///< Unspecified character category for character independent facets
-    static const uint32_t char_facet = 1 << 0;     ///< 8-bit character facets
-    static const uint32_t wchar_t_facet = 1 << 1;  ///< wide character facets
-    static const uint32_t char16_t_facet = 1 << 2; ///< C++11 char16_t facets
-    static const uint32_t char32_t_facet = 1 << 3; ///< C++11 char32_t facets
+    constexpr uint32_t nochar_facet = 0;        ///< Unspecified character category for character independent facets
+    constexpr uint32_t char_facet = 1 << 0;     ///< 8-bit character facets
+    constexpr uint32_t wchar_t_facet = 1 << 1;  ///< wide character facets
+    constexpr uint32_t char16_t_facet = 1 << 2; ///< C++11 char16_t facets
+    constexpr uint32_t char32_t_facet = 1 << 3; ///< C++11 char32_t facets
 
-    static const uint32_t character_first_facet = char_facet;    ///< First facet specific for character type
-    static const uint32_t character_last_facet = char32_t_facet; ///< Last facet specific for character type
-    static const uint32_t all_characters = 0xFFFF;               ///< Special mask -- generate all
+    constexpr uint32_t character_first_facet = char_facet;    ///< First facet specific for character type
+    constexpr uint32_t character_last_facet = char32_t_facet; ///< Last facet specific for character type
+    constexpr uint32_t all_characters = 0xFFFF;               ///< Special mask -- generate all
 
     typedef uint32_t character_facet_type; ///< type that specifies the character type that locales can be generated for
 
-    static const uint32_t convert_facet = 1 << 0;    ///< Generate conversion facets
-    static const uint32_t collation_facet = 1 << 1;  ///< Generate collation facets
-    static const uint32_t formatting_facet = 1 << 2; ///< Generate numbers, currency, date-time formatting facets
-    static const uint32_t parsing_facet = 1 << 3;    ///< Generate numbers, currency, date-time formatting facets
-    static const uint32_t message_facet = 1 << 4;    ///< Generate message facets
-    static const uint32_t codepage_facet =
-      1 << 5; ///< Generate character set conversion facets (derived from std::codecvt)
-    static const uint32_t boundary_facet = 1 << 6; ///< Generate boundary analysis facet
+    constexpr uint32_t convert_facet = 1 << 0;    ///< Generate conversion facets
+    constexpr uint32_t collation_facet = 1 << 1;  ///< Generate collation facets
+    constexpr uint32_t formatting_facet = 1 << 2; ///< Generate numbers, currency, date-time formatting facets
+    constexpr uint32_t parsing_facet = 1 << 3;    ///< Generate numbers, currency, date-time formatting facets
+    constexpr uint32_t message_facet = 1 << 4;    ///< Generate message facets
+    constexpr uint32_t codepage_facet = 1
+                                        << 5; ///< Generate character set conversion facets (derived from std::codecvt)
+    constexpr uint32_t boundary_facet = 1 << 6; ///< Generate boundary analysis facet
 
-    static const uint32_t per_character_facet_first = convert_facet; ///< First facet specific for character
-    static const uint32_t per_character_facet_last = boundary_facet; ///< Last facet specific for character
+    constexpr uint32_t per_character_facet_first = convert_facet; ///< First facet specific for character
+    constexpr uint32_t per_character_facet_last = boundary_facet; ///< Last facet specific for character
 
-    static const uint32_t calendar_facet = 1 << 16;    ///< Generate boundary analysis facet
-    static const uint32_t information_facet = 1 << 17; ///< Generate general locale information facet
+    constexpr uint32_t calendar_facet = 1 << 16;    ///< Generate boundary analysis facet
+    constexpr uint32_t information_facet = 1 << 17; ///< Generate general locale information facet
 
-    static const uint32_t non_character_facet_first = calendar_facet;   ///< First character independent facet
-    static const uint32_t non_character_facet_last = information_facet; ///< Last character independent facet
+    constexpr uint32_t non_character_facet_first = calendar_facet;   ///< First character independent facet
+    constexpr uint32_t non_character_facet_last = information_facet; ///< Last character independent facet
 
-    static const uint32_t all_categories = 0xFFFFFFFFu; ///< Generate all of them
+    constexpr uint32_t all_categories = 0xFFFFFFFFu; ///< Generate all of them
 
     typedef uint32_t locale_category_type; ///< a type used for more fine grained generation of facets
 

--- a/include/boost/locale/utf.hpp
+++ b/include/boost/locale/utf.hpp
@@ -25,12 +25,12 @@ namespace boost { namespace locale {
         ///
         /// \brief Special constant that defines illegal code point
         ///
-        static const code_point illegal = 0xFFFFFFFFu;
+        constexpr code_point illegal = 0xFFFFFFFFu;
 
         ///
         /// \brief Special constant that defines incomplete code point
         ///
-        static const code_point incomplete = 0xFFFFFFFEu;
+        constexpr code_point incomplete = 0xFFFFFFFEu;
 
         ///
         /// \brief the function checks if \a v is a valid code point
@@ -78,7 +78,7 @@ namespace boost { namespace locale {
             /// - UTF-16 - 2
             /// - UTF-32 - 1
             ///
-            static const int max_width;
+            static constexpr int max_width;
             ///
             /// The width of specific code point in the code units.
             ///
@@ -148,7 +148,7 @@ namespace boost { namespace locale {
                 return -1;
             }
 
-            static const int max_width = 4;
+            static constexpr int max_width = 4;
 
             static int width(code_point value)
             {
@@ -340,7 +340,7 @@ namespace boost { namespace locale {
                 return combine_surrogate(w1, w2);
             }
 
-            static const int max_width = 2;
+            static constexpr int max_width = 2;
             static int width(code_point u) { return u >= 0x10000 ? 2 : 1; }
             template<typename It>
             static It encode(code_point u, It out)
@@ -384,7 +384,7 @@ namespace boost { namespace locale {
                     return boost::locale::utf::illegal;
                 return c;
             }
-            static const int max_width = 1;
+            static constexpr int max_width = 1;
             static int width(code_point /*u*/) { return 1; }
             template<typename It>
             static It encode(code_point u, It out)

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -79,13 +79,13 @@ namespace boost { namespace locale {
             /// For example if a UCS-32 code-point is in the range reserved for UTF-16 surrogates
             /// or an invalid UTF-8 sequence is found
             ///
-            static const uint32_t illegal = utf::illegal;
+            static constexpr uint32_t illegal = utf::illegal;
 
             ///
             /// This value is returned in following cases: The of incomplete input sequence was found or
             /// insufficient output buffer was provided so complete output could not be written.
             ///
-            static const uint32_t incomplete = utf::incomplete;
+            static constexpr uint32_t incomplete = utf::incomplete;
 
             virtual ~base_converter();
             ///

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -129,11 +129,11 @@ namespace boost { namespace locale { namespace impl_icu {
         icu::Collator* get_collator(level_type ilevel) const
         {
             int l = limit(ilevel);
-            static const icu::Collator::ECollationStrength levels[level_count] = {icu::Collator::PRIMARY,
-                                                                                  icu::Collator::SECONDARY,
-                                                                                  icu::Collator::TERTIARY,
-                                                                                  icu::Collator::QUATERNARY,
-                                                                                  icu::Collator::IDENTICAL};
+            constexpr icu::Collator::ECollationStrength levels[level_count] = {icu::Collator::PRIMARY,
+                                                                               icu::Collator::SECONDARY,
+                                                                               icu::Collator::TERTIARY,
+                                                                               icu::Collator::QUATERNARY,
+                                                                               icu::Collator::IDENTICAL};
 
             icu::Collator* col = collates_[l].get();
             if(col)
@@ -151,7 +151,7 @@ namespace boost { namespace locale { namespace impl_icu {
         }
 
     private:
-        static const int level_count = 5;
+        static constexpr int level_count = 5;
         icu_std_converter<CharType> cvt_;
         icu::Locale locale_;
         mutable boost::thread_specific_ptr<icu::Collator> collates_[level_count];

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -327,7 +327,7 @@ namespace boost { namespace locale { namespace impl_icu {
             if(v < 0 && value_limits::is_signed == false)
                 return false;
 
-            static const CastedType max_val = static_cast<CastedType>(value_limits::max());
+            constexpr CastedType max_val = static_cast<CastedType>(value_limits::max());
 
             if(sizeof(CastedType) > sizeof(ValueType) && v > max_val)
                 return false;

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -591,7 +591,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
             if(mo_encoding.empty())
                 throw std::runtime_error("Invalid mo-format, encoding is not specified");
 
-            if(!plural.empty()) 
+            if(!plural.empty())
                 plural_forms_[idx] = lambda::compile(plural.c_str());
 
             if(mo_useable_directly(mo_encoding, *mo))

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -266,7 +266,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
 
     template<typename CharType>
     struct mo_file_use_traits {
-        static const bool in_use = false;
+        static constexpr bool in_use = false;
         typedef CharType char_type;
         typedef std::pair<const char_type*, const char_type*> pair_type;
         static pair_type use(const mo_file& /*mo*/, const char_type* /*context*/, const char_type* /*key*/)
@@ -277,7 +277,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
 
     template<>
     struct mo_file_use_traits<char> {
-        static const bool in_use = true;
+        static constexpr bool in_use = true;
         typedef char char_type;
         typedef std::pair<const char_type*, const char_type*> pair_type;
         static pair_type use(const mo_file& mo, const char* context, const char* key) { return mo.find(context, key); }

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -406,7 +406,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
         }
     };
 
-    // By default for wide types the conversion is not requiredyy
+    // By default for wide types the conversion is not required
     template<typename CharType>
     const CharType* runtime_conversion(const CharType* msg,
                                        std::basic_string<CharType>& /*buffer*/,
@@ -460,7 +460,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
             if(plural_forms_.at(domain_id))
                 form = (*plural_forms_[domain_id])(n);
             else
-                form = n == 1 ? 0 : 1; // Fallback to english plural form
+                form = n == 1 ? 0 : 1; // Fallback to English plural form
 
             const CharType* p = ptr.first;
             for(int i = 0; p < ptr.second && i < form; i++) {
@@ -591,14 +591,12 @@ namespace boost { namespace locale { namespace gnu_gettext {
             if(mo_encoding.empty())
                 throw std::runtime_error("Invalid mo-format, encoding is not specified");
 
-            if(!plural.empty()) {
+            if(!plural.empty()) 
                 plural_forms_[idx] = lambda::compile(plural.c_str());
-                ;
-            }
 
-            if(mo_useable_directly(mo_encoding, *mo)) {
+            if(mo_useable_directly(mo_encoding, *mo))
                 mo_catalogs_[idx] = mo;
-            } else {
+            else {
                 converter<CharType> cvt_value(locale_encoding, mo_encoding);
                 converter<CharType> cvt_key(key_encoding, mo_encoding);
                 for(unsigned i = 0; i < mo->size(); i++) {

--- a/src/boost/locale/shared/mo_hash.hpp
+++ b/src/boost/locale/shared/mo_hash.hpp
@@ -11,7 +11,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
     struct pj_winberger_hash {
         typedef uint32_t state_type;
 
-        static const state_type initial_state = 0;
+        static constexpr state_type initial_state = 0;
 
         static state_type update_state(state_type value, char c)
         {

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -67,7 +67,7 @@ namespace boost { namespace locale { namespace util {
 
     class simple_converter_impl {
     public:
-        static const int hash_table_size = 1024;
+        static constexpr int hash_table_size = 1024;
 
         simple_converter_impl(const std::string& encoding)
         {

--- a/src/boost/locale/util/gregorian.cpp
+++ b/src/boost/locale/util/gregorian.cpp
@@ -496,6 +496,10 @@ namespace boost { namespace locale { namespace util {
             posix_time pt = {time_, 0};
             return pt;
         }
+        double get_time_ms() const override
+        {
+            return time_ * 1e3;
+        }
 
         ///
         /// Set option for calendar, for future use
@@ -606,13 +610,13 @@ namespace boost { namespace locale { namespace util {
         ///
         /// Calculate the difference between this calendar  and \a other in \a p units
         ///
-        int difference(const abstract_calendar* other_cal, period::marks::period_mark m) const override
+        int difference(const abstract_calendar& other_cal, period::marks::period_mark m) const override
         {
             hold_ptr<gregorian_calendar> keeper;
-            const gregorian_calendar* other = dynamic_cast<const gregorian_calendar*>(other_cal);
+            const gregorian_calendar* other = dynamic_cast<const gregorian_calendar*>(&other_cal);
             if(!other) {
                 keeper.reset(clone());
-                keeper->set_time(other_cal->get_time());
+                keeper->set_time(other_cal.get_time());
                 other = keeper.get();
             }
 

--- a/src/boost/locale/util/gregorian.cpp
+++ b/src/boost/locale/util/gregorian.cpp
@@ -40,27 +40,30 @@ namespace boost { namespace locale { namespace util {
 
         int days_in_month(int year, int month)
         {
-            static const int tbl[2][12] = {{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
-                                           {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}};
+            constexpr int tbl[2][12] = {{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
+                                        {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}};
             return tbl[is_leap(year)][month - 1];
         }
 
-        inline int days_from_0(int year)
+        constexpr int days_from_0_impl(int year_m1)
         {
-            year--;
-            return 365 * year + (year / 400) - (year / 100) + (year / 4);
+            return 365 * year_m1 + (year_m1 / 400) - (year_m1 / 100) + (year_m1 / 4);
+        }
+        constexpr int days_from_0(int year)
+        {
+            return days_from_0_impl(year - 1);
         }
 
-        int days_from_1970(int year)
+        constexpr int days_from_0_to_1970 = days_from_0(1970);
+        constexpr int days_from_1970(int year)
         {
-            static const int days_from_0_to_1970 = days_from_0(1970);
             return days_from_0(year) - days_from_0_to_1970;
         }
 
         int days_from_1jan(int year, int month, int day)
         {
-            static const int days[2][12] = {{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
-                                            {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}};
+            constexpr int days[2][12] = {{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
+                                         {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}};
             return days[is_leap(year)][month - 1] + day - 1;
         }
 
@@ -110,11 +113,11 @@ namespace boost { namespace locale { namespace util {
 
         int first_day_of_week(const char* terr)
         {
-            static const char* const sat[] = {"AE", "AF", "BH", "DJ", "DZ", "EG", "ER", "ET", "IQ", "IR", "JO", "KE",
-                                              "KW", "LY", "MA", "OM", "QA", "SA", "SD", "SO", "SY", "TN", "YE"};
-            static const char* const sunday[] = {"AR", "AS", "AZ", "BW", "CA", "CN", "FO", "GE", "GL", "GU", "HK", "IL",
-                                                 "IN", "JM", "JP", "KG", "KR", "LA", "MH", "MN", "MO", "MP", "MT", "NZ",
-                                                 "PH", "PK", "SG", "TH", "TT", "TW", "UM", "US", "UZ", "VI", "ZW"};
+            constexpr const char* sat[] = {"AE", "AF", "BH", "DJ", "DZ", "EG", "ER", "ET", "IQ", "IR", "JO", "KE",
+                                           "KW", "LY", "MA", "OM", "QA", "SA", "SD", "SO", "SY", "TN", "YE"};
+            constexpr const char* sunday[] = {"AR", "AS", "AZ", "BW", "CA", "CN", "FO", "GE", "GL", "GU", "HK", "IL",
+                                              "IN", "JM", "JP", "KG", "KR", "LA", "MH", "MN", "MO", "MP", "MT", "NZ",
+                                              "PH", "PK", "SG", "TH", "TT", "TW", "UM", "US", "UZ", "VI", "ZW"};
             if(strcmp(terr, "MV") == 0)
                 return 5; // fri
             if(std::binary_search<const char* const*>(sat, sat + sizeof(sat) / (sizeof(sat[0])), terr, comparator))
@@ -249,7 +252,7 @@ namespace boost { namespace locale { namespace util {
         {
             /// This is the number of days that are considered within
             /// period such that the week belongs there
-            static const int days_in_full_week = 4;
+            constexpr int days_in_full_week = 4;
 
             // Always use local week start
             int current_dow = (wday - first_day_of_week_ + 7) % 7;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,10 @@ endif()
 boost_test_jamfile(FILE Jamfile.v2)
 
 boost_test(NAME show_config  SOURCES show_config.cpp)
-boost_test(NAME test_message SOURCES test_message.cpp)
-set_target_properties(${PROJECT_NAME}-test_message PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-set_tests_properties(run-${PROJECT_NAME}-test_message PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Those require to be run in the test directory
+foreach(name test_formatting test_message)
+  boost_test(NAME ${name} SOURCES ${name}.cpp)
+  set_target_properties(${PROJECT_NAME}-${name} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+  set_tests_properties(run-${PROJECT_NAME}-${name} PROPERTIES WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endforeach()

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,8 +11,16 @@ project : requirements
     <library>/boost/locale//boost_locale
     <warnings>extra
     <toolset>msvc:<warnings-as-errors>on
+    <toolset>gcc-8:<warnings-as-errors>on
+    <toolset>gcc-9:<warnings-as-errors>on
+    <toolset>gcc-10:<warnings-as-errors>on
     <toolset>gcc-11:<warnings-as-errors>on
     <toolset>clang-5:<warnings-as-errors>on
+    <toolset>clang-9:<warnings-as-errors>on
+    <toolset>clang-10:<warnings-as-errors>on
+    <toolset>clang-11:<warnings-as-errors>on
+    <toolset>clang-12:<warnings-as-errors>on
+    <toolset>clang-13:<warnings-as-errors>on
     <include>.
     # Make sure we get all defines we need
     # Otherwise we would have problem knowing

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -39,7 +39,7 @@ run test_generator.cpp ;
 run test_collate.cpp ;
 run test_convert.cpp ;
 run test_boundary.cpp ;
-run test_formatting.cpp ;
+run test_formatting.cpp : $(BOOST_ROOT)/libs/locale/test ;
 run test_icu_vs_os_timezone.cpp ;
 # winapi
 run test_winapi_collate.cpp ;

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -18,8 +18,8 @@
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 
-static const unsigned illegal = 0xFFFFFFFF;
-static const unsigned incomplete = 0xFFFFFFFE;
+constexpr auto illegal = boost::locale::util::base_converter::illegal;
+constexpr auto incomplete = boost::locale::util::base_converter::incomplete;
 
 bool test_to(boost::locale::util::base_converter& cvt, const char* s, unsigned codepoint)
 {
@@ -43,7 +43,7 @@ bool test_incomplete(boost::locale::util::base_converter& cvt, unsigned codepoin
 {
     char buf[32] = {0};
     unsigned res = cvt.from_unicode(codepoint, buf, buf + len);
-    return res == incomplete;
+    return res == boost::locale::util::base_converter::incomplete;
 }
 
 #define TEST_TO(str, codepoint) TEST(test_to(*cvt, str, codepoint))

--- a/test/test_collate.cpp
+++ b/test/test_collate.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/locale/collator.hpp>
 #include <boost/locale/generator.hpp>
+#include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 #include <iomanip>
 #include <iostream>

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -7,6 +7,7 @@
 #include <boost/locale/conversion.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/info.hpp>
+#include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 #include <iomanip>
 #include <iostream>

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -18,6 +18,7 @@
 namespace bl = boost::locale;
 
 std::string backend;
+std::string message_path = "./";
 
 bool file_loader_is_actually_called = false;
 
@@ -329,6 +330,9 @@ bool iso_8859_8_not_supported = false;
 
 void test_main(int argc, char** argv)
 {
+    if(argc == 2)
+        message_path = argv[1];
+
     std::string def[] = {
 #ifdef BOOST_LOCALE_WITH_ICU
       "icu",
@@ -356,10 +360,7 @@ void test_main(int argc, char** argv)
         g.add_messages_domain("simple");
         g.add_messages_domain("full");
         g.add_messages_domain("fall");
-        if(argc == 2)
-            g.add_messages_path(argv[1]);
-        else
-            g.add_messages_path("./");
+        g.add_messages_path(message_path);
         g.set_default_messages_domain("default");
 
         for(const std::string locale_name : {"he_IL.UTF-8", "he_IL.ISO8859-8"}) {

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -65,7 +65,7 @@ void test_by_char(const std::locale& l, locale_t lreal)
         ss >> n;
         TEST(ss);
         TEST_EQ(n, 1045.45);
-        TEST_EQ(ss.str(), to_correct_string<CharType>("1045.45", l));
+        TEST_EQ(ss.str(), ascii_to<CharType>("1045.45"));
     }
 
     {

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -46,7 +46,7 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
         ss >> n;
         TEST(ss);
         TEST_EQ(n, 1045.45);
-        TEST_EQ(ss.str(), to_correct_string<CharType>("1045.45", l));
+        TEST_EQ(ss.str(), ascii_to<CharType>("1045.45"));
     }
 
     {

--- a/test/test_winapi_collate.cpp
+++ b/test/test_winapi_collate.cpp
@@ -7,6 +7,7 @@
 #include <boost/locale/collator.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/localization_backend.hpp>
+#include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 #include <iomanip>
 

--- a/test/test_winapi_convert.cpp
+++ b/test/test_winapi_convert.cpp
@@ -76,10 +76,8 @@ void test_main(int /*argc*/, char** /*argv*/)
     std::cout << "Testing Unicode normalization" << std::endl;
     test_norm("\xEF\xAC\x81", "\xEF\xAC\x81", boost::locale::norm_nfd); /// ligature fi
     test_norm("\xEF\xAC\x81", "\xEF\xAC\x81", boost::locale::norm_nfc);
-#if defined(_WIN32_NT) && _WIN32_NT >= 0x600
     test_norm("\xEF\xAC\x81", "fi", boost::locale::norm_nfkd);
     test_norm("\xEF\xAC\x81", "fi", boost::locale::norm_nfkc);
-#endif
     test_norm("ä", "ä", boost::locale::norm_nfd); // ä to a and accent
     test_norm("ä", "ä", boost::locale::norm_nfc);
 }


### PR DESCRIPTION
- Refactor tests and remove/combine/handle special cases for some ICU versions in tests

Prepares for adding better tests for basic_format

- Fix possible overflow in ICU (case) conversion
- Fix loss of precision when getting the time from a timepoint (conversion from `double` to `posix_time` to `double`)
- Avoid the bug in the time conversion resulting in always zero nanoseconds resulting from wrong conversion from seconds to nanoseconds

Extract the size type used by the ICU function from its signature and cast the parameters after checking the range.