### PR TITLE
Simplify `ios_prop` and test

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -419,6 +419,7 @@ local cxx_requirements = [ requires
       cxx11_hdr_functional
       cxx11_hdr_type_traits
       cxx11_noexcept
+      cxx11_nullptr
       cxx11_override
       cxx11_range_based_for
       cxx11_rvalue_references

--- a/src/boost/locale/shared/ios_prop.hpp
+++ b/src/boost/locale/shared/ios_prop.hpp
@@ -8,13 +8,14 @@
 #ifndef BOOST_SRC_LOCALE_IOS_PROP_HPP
 #define BOOST_SRC_LOCALE_IOS_PROP_HPP
 
+#include <boost/locale/config.hpp>
 #include <boost/assert.hpp>
 #include <ios>
 
 namespace boost { namespace locale { namespace impl {
 
     template<typename Property>
-    class ios_prop {
+    class BOOST_SYMBOL_VISIBLE ios_prop {
     public:
         static Property& get(std::ios_base& ios)
         {
@@ -39,20 +40,16 @@ namespace boost { namespace locale { namespace impl {
 
         static void callback(std::ios_base::event ev, std::ios_base& ios, int id)
         {
+            Property* prop = get_impl(ios);
+            if(!prop)
+                return;
             switch(ev) {
-                case std::ios_base::erase_event: delete get_impl(ios); break;
-                case std::ios_base::copyfmt_event: {
-                    Property* prop = get_impl(ios);
-                    if(prop)
-                        ios.pword(id) = new Property(*prop);
+                case std::ios_base::erase_event:
+                    delete prop;
+                    ios.pword(id) = nullptr;
                     break;
-                }
-                case std::ios_base::imbue_event: {
-                    Property* prop = get_impl(ios);
-                    if(prop)
-                        prop->on_imbue();
-                    break;
-                }
+                case std::ios_base::copyfmt_event: ios.pword(id) = new Property(*prop); break;
+                case std::ios_base::imbue_event: prop->on_imbue(); break;
                 default: break;
             }
         }

--- a/src/boost/locale/shared/ios_prop.hpp
+++ b/src/boost/locale/shared/ios_prop.hpp
@@ -1,11 +1,14 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2022 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #ifndef BOOST_SRC_LOCALE_IOS_PROP_HPP
 #define BOOST_SRC_LOCALE_IOS_PROP_HPP
+
+#include <boost/assert.hpp>
 #include <ios>
 
 namespace boost { namespace locale { namespace impl {
@@ -13,69 +16,44 @@ namespace boost { namespace locale { namespace impl {
     template<typename Property>
     class ios_prop {
     public:
-        static void set(const Property& prop, std::ios_base& ios)
-        {
-            int id = get_id();
-            if(ios.pword(id) == 0) {
-                ios.pword(id) = new Property(prop);
-                ios.register_callback(callback, id);
-            } else if(ios.pword(id) == invalid) {
-                ios.pword(id) = new Property(prop);
-            } else {
-                *static_cast<Property*>(ios.pword(id)) = prop;
-            }
-        }
-
         static Property& get(std::ios_base& ios)
         {
-            int id = get_id();
-            if(!has(ios))
-                set(Property(), ios);
-            return *static_cast<Property*>(ios.pword(id));
+            Property* result = get_impl(ios);
+            return result ? *result : create(ios);
         }
 
-        static bool has(std::ios_base& ios)
-        {
-            int id = get_id();
-            if(ios.pword(id) == 0 || ios.pword(id) == invalid)
-                return false;
-            return true;
-        }
-
-        static void unset(std::ios_base& ios)
-        {
-            if(has(ios)) {
-                int id = get_id();
-                Property* p = static_cast<Property*>(ios.pword(id));
-                delete p;
-                ios.pword(id) = invalid;
-            }
-        }
         static void global_init() { get_id(); }
 
     private:
-        static void* const invalid;
+        static Property* get_impl(std::ios_base& ios) { return static_cast<Property*>(ios.pword(get_id())); }
+
+        static Property& create(std::ios_base& ios)
+        {
+            BOOST_ASSERT_MSG(!get_impl(ios), "Called create while the property already exists");
+            const int id = get_id();
+            ios.register_callback(callback, id);
+            Property* value = new Property();
+            ios.pword(id) = value;
+            return *value;
+        }
 
         static void callback(std::ios_base::event ev, std::ios_base& ios, int id)
         {
             switch(ev) {
-                case std::ios_base::erase_event:
-                    if(!has(ios))
-                        break;
-                    delete reinterpret_cast<Property*>(ios.pword(id));
+                case std::ios_base::erase_event: delete get_impl(ios); break;
+                case std::ios_base::copyfmt_event: {
+                    Property* prop = get_impl(ios);
+                    if(prop)
+                        ios.pword(id) = new Property(*prop);
                     break;
-                case std::ios_base::copyfmt_event:
-                    if(ios.pword(id) == invalid || ios.pword(id) == 0)
-                        break;
-                    ios.pword(id) = new Property(*reinterpret_cast<Property*>(ios.pword(id)));
+                }
+                case std::ios_base::imbue_event: {
+                    Property* prop = get_impl(ios);
+                    if(prop)
+                        prop->on_imbue();
                     break;
-                case std::ios_base::imbue_event:
-                    if(ios.pword(id) == invalid || ios.pword(id) == 0)
-                        break;
-                    reinterpret_cast<Property*>(ios.pword(id))->on_imbue();
-                    break;
-
-                default:;
+                }
+                default: break;
             }
         }
         static int get_id()
@@ -85,8 +63,6 @@ namespace boost { namespace locale { namespace impl {
         }
     };
 
-    template<typename Property>
-    void* const ios_prop<Property>::invalid = (void*)(-1);
 }}} // namespace boost::locale::impl
 
 #endif

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -61,6 +61,14 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ(imbued, 0);
             ss2.imbue(std::locale::classic());
             TEST_EQ(imbued, 1);
+            // Copy again over existing
+            ss2.copyfmt(ss);
+            TEST_EQ(counter, 2);
+            TEST_EQ(prop_type::get(ss).x, 1);
+            TEST_EQ(prop_type::get(ss2).x, 1); // Copied
+            prop_type::get(ss2).x = 2;
+            TEST_EQ(prop_type::get(ss).x, 1);
+            TEST_EQ(prop_type::get(ss2).x, 2); // Only this changed
         }
         // Copy from unset removes the property
         {

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2022 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -11,23 +12,20 @@
 
 int counter = 0;
 int imbued = 0;
-struct propery {
-    propery(int xx = -1) : x(xx) { counter++; }
-    propery(const propery& other)
+struct test_property {
+    explicit test_property(int xx = -1) : x(xx) { counter++; }
+    test_property(const test_property& other)
     {
         counter++;
         x = other.x;
     }
-    propery& operator=(const propery& other)
-    {
-        x = other.x;
-        return *this;
-    };
-    int x;
+    test_property& operator=(const test_property& other) = default;
+    ~test_property() { counter--; }
     void on_imbue() { imbued++; }
-    ~propery() { counter--; }
+
+    int x;
 };
-typedef boost::locale::impl::ios_prop<propery> prop_type;
+typedef boost::locale::impl::ios_prop<test_property> prop_type;
 
 struct init {
     init() { prop_type::global_init(); }
@@ -35,45 +33,50 @@ struct init {
 
 void test_main(int /*argc*/, char** /*argv*/)
 {
+    // Test get() default constructs the property if it does not exist or returns the existing one
     {
         std::stringstream ss;
-        TEST(!prop_type::has(ss));
-        TEST(prop_type::get(ss).x == -1);
-        TEST(prop_type::has(ss));
-        TEST(counter == 1);
+        TEST_EQ(prop_type::get(ss).x, -1);
+        TEST_EQ(counter, 1);
+        prop_type::get(ss).x = 42;
+        TEST_EQ(prop_type::get(ss).x, 42);
+        TEST_EQ(counter, 1);
     }
-    TEST(counter == 0);
+    TEST_EQ(counter, 0);
     {
         std::stringstream ss;
-        prop_type::set(propery(1), ss);
-        TEST(counter == 1);
-        TEST(prop_type::get(ss).x == 1);
+        prop_type::get(ss).x = 1;
+        {
+            std::stringstream ss2;
+            TEST_EQ(counter, 1);
+            ss2.copyfmt(ss);
+            TEST_EQ(counter, 2);
+            TEST_EQ(prop_type::get(ss).x, 1);
+            TEST_EQ(prop_type::get(ss2).x, 1);
+            // Check that both are distinct copies
+            prop_type::get(ss2).x = 2;
+            TEST_EQ(prop_type::get(ss).x, 1);
+            TEST_EQ(prop_type::get(ss2).x, 2); // Only 2nd is changed
+            // Imbue on 2nd calls on_imbue once
+            TEST_EQ(imbued, 0);
+            ss2.imbue(std::locale::classic());
+            TEST_EQ(imbued, 1);
+        }
+        // Copy from unset removes the property
+        {
+            std::stringstream ss2;
+            TEST_EQ(prop_type::get(ss).x, 1);
+            TEST_EQ(counter, 1);
+            ss.copyfmt(ss2);
+            TEST_EQ(counter, 0);
+            // All are default constructed, distinct instances
+            TEST_EQ(prop_type::get(ss).x, -1);
+            TEST_EQ(prop_type::get(ss2).x, -1);
+            prop_type::get(ss2).x = 2;
+            TEST_EQ(prop_type::get(ss).x, -1);
+            TEST_EQ(prop_type::get(ss2).x, 2);
+            TEST_EQ(counter, 2);
+        }
     }
-    TEST(counter == 0);
-    {
-        std::stringstream ss;
-        prop_type::set(propery(1), ss);
-        TEST(counter == 1);
-        TEST(prop_type::get(ss).x == 1);
-    }
-    TEST(counter == 0);
-    {
-        std::stringstream ss, ss2;
-        prop_type::set(propery(2), ss);
-        ss2.copyfmt(ss);
-        TEST(prop_type::get(ss).x == 2);
-        TEST(prop_type::has(ss2));
-        TEST(prop_type::has(ss));
-        TEST(prop_type::get(ss2).x == 2);
-        prop_type::get(ss2).x = 3;
-        TEST(prop_type::get(ss2).x == 3);
-        TEST(prop_type::get(ss).x == 2);
-        TEST(counter == 2);
-        TEST(imbued == 0);
-        ss2.imbue(std::locale::classic());
-        TEST(imbued == 1);
-    }
-    TEST(counter == 0);
+    TEST_EQ(counter, 0);
 }
-
-// boostinspect:noascii


### PR DESCRIPTION
Only the `get()` method is required, the rest can be removed. Also rewrite the test to better explain behavior