### PR TITLE
Update ICU configuration from Boost.Regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,7 @@ jobs:
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_SANITIZE: ${{matrix.sanitize}}
           B2_STDLIB: ${{matrix.stdlib}}
+          B2_FLAGS: runtime-link=static,shared
         run: ci/github/install.sh
 
       - name: Run tests

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -7,6 +7,7 @@
 
 import config : requires ;
 import configure ;
+import errors ;
 import feature ;
 import os ;
 import path ;
@@ -18,7 +19,6 @@ project /boost/locale
     : source-location $(TOP)/src/boost/locale
     ;
 
-import errors ;
 # Features
 
 feature.feature boost.locale.iconv : on off : optional propagated ;
@@ -26,6 +26,14 @@ feature.feature boost.locale.icu : on off :  optional propagated ;
 feature.feature boost.locale.posix : on off : optional propagated ;
 feature.feature boost.locale.std : on off : optional propagated ;
 feature.feature boost.locale.winapi : on off : optional propagated ;
+
+local rule debug-message ( message * )
+{
+    if --debug-configuration in [ modules.peek : ARGV ]
+    {
+        ECHO "notice:" "[locale]" $(message) ;
+    }
+}
 
 # Configuration of libraries
 
@@ -85,19 +93,22 @@ icu-path ?= $(ICU_PATH) ;                      # path-constant
 if $(icu-path)
 {
     icu-path = [ path.make $(icu-path) ] ; # Normalize
+    debug-message ICU path set to "$(icu-path)" ;
 }
 
 rule path_options ( properties * )
 {
     local result ;
-    result = <search>$(icu_path)/bin <search>$(icu_path)/lib ;
-    return $(result) ;
-}
-
-rule path_options64 ( properties * )
-{
-    local result ;
-    result = <search>$(icu_path)/bin64 <search>$(icu_path)/lib64 ;
+    if <address-model>64 in $(properties) && <toolset>msvc in $(properties)
+    {
+        debug-message Search 64 bit ICU in "$(icu-path)/lib64" ;
+        result = <search>$(icu-path)/bin64 <search>$(icu-path)/lib64 ;
+    }
+    else
+    {
+        debug-message Search ICU in "$(icu-path)/lib" ;
+        result = <search>$(icu-path)/bin <search>$(icu-path)/lib ;
+    }
     return $(result) ;
 }
 
@@ -113,69 +124,58 @@ if [ modules.peek : ICU_ICUIN_NAME ]
 {
    ICU_ICUIN_NAME =  [ modules.peek : ICU_ICUIN_NAME ] ;
 }
-if [ modules.peek : ICU_ICUUC_NAME64 ]
-{
-   ICU_ICUUC_NAME64 =  [ modules.peek : ICU_ICUUC_NAME64 ] ;
-}
-if [ modules.peek : ICU_ICUDT_NAME64 ]
-{
-   ICU_ICUDT_NAME64 =  [ modules.peek : ICU_ICUDT_NAME64 ] ;
-}
-if [ modules.peek : ICU_ICUIN_NAME64 ]
-{
-   ICU_ICUIN_NAME64 =  [ modules.peek : ICU_ICUIN_NAME64 ] ;
-}
 
 if $(ICU_ICUUC_NAME)
 {
-    lib icuuc : : <name>$(ICU_ICUUC_NAME) ;
+    lib icuuc : : <name>$(ICU_ICUUC_NAME) <conditional>@path_options ;
+    debug-message Using "$(ICU_ICUUC_NAME)" for library "icuuc" ;
 }
 else
 {
-	lib icuuc : :                                                               <runtime-link>shared <conditional>@path_options ;
-	lib icuuc : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
-	lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
-	lib icuuc : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options ;
-	lib icuuc : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
-	lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
-	lib icuuc : : <name>this_is_an_invalid_library_name ;
+    lib icuuc : :                                                               <runtime-link>shared <conditional>@path_options ;
+    lib icuuc : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
+    lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
+    lib icuuc : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options ;
+    lib icuuc : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
+    lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
+    lib icuuc : : <name>this_is_an_invalid_library_name ;
 }
-
 
 if $(ICU_ICUDT_NAME)
 {
-	lib icudt : : <name>$(ICU_ICUDT_NAME) ;
+    lib icudt : : <name>$(ICU_ICUDT_NAME) <conditional>@path_options ;
+    debug-message Using "$(ICU_ICUDT_NAME)" for library "icudt" ;
 }
 else
 {
-	lib icudt : : <name>icudata                                   <runtime-link>shared <conditional>@path_options ;
-	lib icudt : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options ;
-	lib icudt : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options ;
-	lib icudt : : <name>sicudata                                   <runtime-link>static <conditional>@path_options ;
-	lib icudt : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options ;
-	lib icudt : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options ;
-	lib icudt : : <name>this_is_an_invalid_library_name ;
+    lib icudt : : <name>icudata                                   <runtime-link>shared <conditional>@path_options ;
+    lib icudt : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options ;
+    lib icudt : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options ;
+    lib icudt : : <name>sicudata                                   <runtime-link>static <conditional>@path_options ;
+    lib icudt : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options ;
+    lib icudt : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options ;
+    lib icudt : : <name>this_is_an_invalid_library_name ;
 }
 
 if $(ICU_ICUIN_NAME)
 {
-	lib icuin : : <name>$(ICU_ICUIN_NAME) ;
+    lib icuin : : <name>$(ICU_ICUIN_NAME) <conditional>@path_options ;
+    debug-message Using "$(ICU_ICUIN_NAME)" for library "icuin" ;
 }
 else
 {
-	lib icuin : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options ;
-	lib icuin : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
-	lib icuin : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options ;
-	lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
-	lib icuin : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options ;
-	lib icuin : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options ;
-	lib icuin : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
-	lib icuin : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options ;
-	lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
-	lib icuin : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options ;
-	lib icuin : : <name>this_is_an_invalid_library_name ;
+    lib icuin : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options ;
+    lib icuin : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
+    lib icuin : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options ;
+    lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
+    lib icuin : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options ;
+    lib icuin : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options ;
+    lib icuin : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
+    lib icuin : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options ;
+    lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
+    lib icuin : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options ;
+    lib icuin : : <name>this_is_an_invalid_library_name ;
 }
-explicit icuuc icudt icuin ;
 
 ICU_OPTS =
   <include>$(icu-path)/include
@@ -185,84 +185,12 @@ ICU_OPTS =
   <runtime-link>static:<library>icuuc
   <runtime-link>static:<library>icudt
   <runtime-link>static:<library>icuin
-  <dll-path>$(icu-path)/bin
-  <define>BOOST_HAS_ICU=1
+  <target-os>windows,<toolset>clang:<linkflags>"advapi32.lib"
   <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
-  <toolset>msvc:<find-static-library>advapi32
   ;
 
-
-if $(ICU_ICUUC_NAME64)
-{
-    lib icuuc_64 : : <name>$(ICU_ICUUC_NAME64) ;
-}
-else
-{
-	lib icuuc_64 : :                                                               <runtime-link>shared <conditional>@path_options64 ;
-	lib icuuc_64 : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options64 ;
-	lib icuuc_64 : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options64 ;
-	lib icuuc_64 : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options64 ;
-	lib icuuc_64 : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options64 ;
-	lib icuuc_64 : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options64 ;
-	lib icuuc_64 : : <name>this_is_an_invalid_library_name ;
-}
-
-if $(ICU_ICUDT_NAME64)
-{
-	lib icudt_64 : : <name>$(ICU_ICUDT_NAME64) ;
-}
-else
-{
-	lib icudt_64 : : <name>icudata                                   <runtime-link>shared <conditional>@path_options64 ;
-	lib icudt_64 : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options64 ;
-	lib icudt_64 : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options64 ;
-	lib icudt_64 : : <name>sicudata                                   <runtime-link>static <conditional>@path_options64 ;
-	lib icudt_64 : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options64 ;
-	lib icudt_64 : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options64 ;
-	lib icudt_64 : : <name>this_is_an_invalid_library_name ;
-}
-
-if $(ICU_ICUIN_NAME64)
-{
-	lib icuin_64 : : <name>$(ICU_ICUIN_NAME64) ;
-}
-else
-{
-	lib icuin_64 : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options64 ;
-	lib icuin_64 : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options64 ;
-	lib icuin_64 : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options64 ;
-	lib icuin_64 : : <name>this_is_an_invalid_library_name ;
-}
-explicit icuuc_64 icudt_64 icuin_64 ;
-
-ICU64_OPTS =
-  <include>$(icu-path)/include
-  <runtime-link>shared:<library>icuuc_64/<link>shared
-  <runtime-link>shared:<library>icudt_64/<link>shared
-  <runtime-link>shared:<library>icuin_64/<link>shared
-  <runtime-link>static:<library>icuuc_64
-  <runtime-link>static:<library>icudt_64
-  <runtime-link>static:<library>icuin_64
-  <dll-path>$(icu-path)/bin64
-  <define>BOOST_HAS_ICU=1
-  <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
-  <toolset>msvc:<find-static-library>advapi32
-  ;
-
-
-exe has_icu       : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS)   ;
-# Similar but build&link with 64bit options
-obj has_icu64_obj : $(TOP)/build/has_icu_test.cpp : $(ICU64_OPTS) ;
-exe has_icu64 : has_icu64_obj : $(ICU64_OPTS) ;
-
-explicit has_icu has_icu64 ;
+exe has_icu : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS) ;
+explicit has_icu ;
 
 
 # This function is called whenever the 'boost_locale' metatarget
@@ -304,14 +232,7 @@ rule configure-full ( properties * : flags-only )
         {
             found-icu = true ;
             flags-result += <define>BOOST_LOCALE_WITH_ICU=1 $(ICU_OPTS) ;
-        } else if [ configure.builds has_icu64 : $(properties) : "icu (lib64)" ]
-        {
-            found-icu = true ;
-            flags-result += <define>BOOST_LOCALE_WITH_ICU=1 $(ICU64_OPTS) ;
-        }
 
-        if $(found-icu)
-        {
             ICU_SOURCES =
                 boundary
                 codecvt

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -87,13 +87,13 @@ if [ modules.peek : ICU_LINK_LOCALE ]
 #   - `b2 .. -s ICU_PATH=x`
 #   - In project-config.jam as `path-constant ICU_PATH : x ;
 
-local icu-path = [ modules.peek : ICU_PATH ] ; # -sICU_PATH=x or env variable
-icu-path ?= $(ICU_PATH) ;                      # path-constant
+.icu-path = [ modules.peek : ICU_PATH ] ; # -sICU_PATH=x or env variable
+.icu-path ?= $(ICU_PATH) ;                # path-constant
 
-if $(icu-path)
+if $(.icu-path)
 {
-    icu-path = [ path.make $(icu-path) ] ; # Normalize
-    debug-message ICU path set to "$(icu-path)" ;
+    .icu-path = [ path.make $(.icu-path) ] ; # Normalize
+    debug-message ICU path set to "$(.icu-path)" ;
 }
 
 rule path_options ( properties * )
@@ -101,13 +101,13 @@ rule path_options ( properties * )
     local result ;
     if <address-model>64 in $(properties) && <toolset>msvc in $(properties)
     {
-        debug-message Search 64 bit ICU in "$(icu-path)/lib64" ;
-        result = <search>$(icu-path)/bin64 <search>$(icu-path)/lib64 ;
+        debug-message Search 64 bit ICU in "$(.icu-path)/lib64" ;
+        result = <search>$(.icu-path)/bin64 <search>$(.icu-path)/lib64 ;
     }
     else
     {
-        debug-message Search ICU in "$(icu-path)/lib" ;
-        result = <search>$(icu-path)/bin <search>$(icu-path)/lib ;
+        debug-message Search ICU in "$(.icu-path)/lib" ;
+        result = <search>$(.icu-path)/bin <search>$(.icu-path)/lib ;
     }
     return $(result) ;
 }
@@ -178,7 +178,7 @@ else
 }
 
 ICU_OPTS =
-  <include>$(icu-path)/include
+  <include>$(.icu-path)/include
   <runtime-link>shared:<library>icuuc/<link>shared
   <runtime-link>shared:<library>icudt/<link>shared
   <runtime-link>shared:<library>icuin/<link>shared

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -18,6 +18,7 @@ project /boost/locale
     : source-location $(TOP)/src/boost/locale
     ;
 
+import errors ;
 # Features
 
 feature.feature boost.locale.iconv : on off : optional propagated ;
@@ -63,6 +64,16 @@ explicit has_xlocale ;
 
 #end xlocale
 
+if [ modules.peek : ICU_LINK ]
+{
+    errors.user-error : "The ICU_LINK option is no longer supported by the Boost.Locale build - please refer to the documentation for equivalent options" ;
+}
+
+if [ modules.peek : ICU_LINK_LOCALE ]
+{
+    errors.user-error : "The ICU_LINK_LOCALE option is no longer supported by the Boost.Locale build - please refer to the documentation for equivalent options" ;
+}
+
 # Specify the root path to the installed ICU libraries via
 #   - Environment variable: ICU_PATH
 #   - `b2 .. -s ICU_PATH=x`
@@ -76,136 +87,175 @@ if $(icu-path)
     icu-path = [ path.make $(icu-path) ] ; # Normalize
 }
 
-ICU_LINK = [ modules.peek : ICU_LINK ] ;
-# Temporary workaround for incompatibility of ICU_LINK with Boost.Regex:
-# Use ICU_LINK_LOCALE instead of ICU_LINK.
-# Note that ICU_LINK and ICU_LINK_LOCALE will be removed in Boost 1.81
-# in favor of a similar solution to Boost.Regex or a B2 module.
-ICU_LINK ?= [ modules.peek : ICU_LINK_LOCALE ] ;
-
-if $(ICU_LINK)
+rule path_options ( properties * )
 {
-    ICU_OPTS = <include>$(icu-path)/include <linkflags>$(ICU_LINK) <dll-path>$(icu-path)/bin <runtime-link>shared ;
-    ICU64_OPTS = <include>$(icu-path)/include <linkflags>$(ICU_LINK) <dll-path>$(icu-path)/bin64 <runtime-link>shared ;
-} else
-{
-    searched-lib icuuc : :  <name>icuuc
-                            <search>$(icu-path)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuuc : :  <toolset>msvc
-                            <variant>debug
-                            <name>icuucd
-                            <search>$(icu-path)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuuc : :  <name>this_is_an_invalid_library_name ;
-
-    searched-lib icudt : :  <search>$(icu-path)/lib
-                            <name>icudata
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icudt : :  <search>$(icu-path)/lib
-                            <name>icudt
-                            <toolset>msvc
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icudt : :  <name>this_is_an_invalid_library_name ;
-
-    searched-lib icuin : :  <search>$(icu-path)/lib
-                            <name>icui18n
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuin : :  <toolset>msvc
-                            <variant>debug
-                            <name>icuind
-                            <search>$(icu-path)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuin : :  <toolset>msvc
-                            <variant>release
-                            <name>icuin
-                            <search>$(icu-path)/lib
-                            <link>shared
-                            <runtime-link>shared ;
-
-    searched-lib icuin : :  <name>this_is_an_invalid_library_name ;
-
-    explicit icuuc icudt icuin ;
-
-    ICU_OPTS =   <include>$(icu-path)/include
-      <library>icuuc/<link>shared/<runtime-link>shared
-      <library>icudt/<link>shared/<runtime-link>shared
-      <library>icuin/<link>shared/<runtime-link>shared
-      <dll-path>$(icu-path)/bin
-        <runtime-link>shared ;
-
-
-
-    searched-lib icuuc_64 : :   <name>icuuc
-                                <search>$(icu-path)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuuc_64 : :   <toolset>msvc
-                                <variant>debug
-                                <name>icuucd
-                                <search>$(icu-path)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuuc_64 : :   <name>this_is_an_invalid_library_name ;
-
-    searched-lib icudt_64 : :   <search>$(icu-path)/lib64
-                                <name>icudata
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icudt_64 : :   <search>$(icu-path)/lib64
-                                <name>icudt
-                                <toolset>msvc
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icudt_64 : :   <name>this_is_an_invalid_library_name ;
-
-    searched-lib icuin_64 : :   <search>$(icu-path)/lib64
-                                <name>icui18n
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuin_64 : :   <toolset>msvc
-                                <variant>debug
-                                <name>icuind
-                                <search>$(icu-path)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuin_64 : :   <toolset>msvc
-                                <variant>release
-                                <name>icuin
-                                <search>$(icu-path)/lib64
-                                <link>shared
-                                <runtime-link>shared ;
-
-    searched-lib icuin_64 : :   <name>this_is_an_invalid_library_name ;
-
-    explicit icuuc_64 icudt_64 icuin_64 ;
-
-    ICU64_OPTS =   <include>$(icu-path)/include
-      <library>icuuc_64/<link>shared/<runtime-link>shared
-      <library>icudt_64/<link>shared/<runtime-link>shared
-      <library>icuin_64/<link>shared/<runtime-link>shared
-      <dll-path>$(icu-path)/bin64
-        <runtime-link>shared ;
-
+    local result ;
+    result = <search>$(icu_path)/bin <search>$(icu_path)/lib ;
+    return $(result) ;
 }
+
+rule path_options64 ( properties * )
+{
+    local result ;
+    result = <search>$(icu_path)/bin64 <search>$(icu_path)/lib64 ;
+    return $(result) ;
+}
+
+if [ modules.peek : ICU_ICUUC_NAME ]
+{
+   ICU_ICUUC_NAME =  [ modules.peek : ICU_ICUUC_NAME ] ;
+}
+if [ modules.peek : ICU_ICUDT_NAME ]
+{
+   ICU_ICUDT_NAME =  [ modules.peek : ICU_ICUDT_NAME ] ;
+}
+if [ modules.peek : ICU_ICUIN_NAME ]
+{
+   ICU_ICUIN_NAME =  [ modules.peek : ICU_ICUIN_NAME ] ;
+}
+if [ modules.peek : ICU_ICUUC_NAME64 ]
+{
+   ICU_ICUUC_NAME64 =  [ modules.peek : ICU_ICUUC_NAME64 ] ;
+}
+if [ modules.peek : ICU_ICUDT_NAME64 ]
+{
+   ICU_ICUDT_NAME64 =  [ modules.peek : ICU_ICUDT_NAME64 ] ;
+}
+if [ modules.peek : ICU_ICUIN_NAME64 ]
+{
+   ICU_ICUIN_NAME64 =  [ modules.peek : ICU_ICUIN_NAME64 ] ;
+}
+
+if $(ICU_ICUUC_NAME)
+{
+    lib icuuc : : <name>$(ICU_ICUUC_NAME) ;
+}
+else
+{
+	lib icuuc : :                                                               <runtime-link>shared <conditional>@path_options ;
+	lib icuuc : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
+	lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options ;
+	lib icuuc : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options ;
+	lib icuuc : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
+	lib icuuc : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options ;
+	lib icuuc : : <name>this_is_an_invalid_library_name ;
+}
+
+
+if $(ICU_ICUDT_NAME)
+{
+	lib icudt : : <name>$(ICU_ICUDT_NAME) ;
+}
+else
+{
+	lib icudt : : <name>icudata                                   <runtime-link>shared <conditional>@path_options ;
+	lib icudt : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options ;
+	lib icudt : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options ;
+	lib icudt : : <name>sicudata                                   <runtime-link>static <conditional>@path_options ;
+	lib icudt : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options ;
+	lib icudt : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options ;
+	lib icudt : : <name>this_is_an_invalid_library_name ;
+}
+
+if $(ICU_ICUIN_NAME)
+{
+	lib icuin : : <name>$(ICU_ICUIN_NAME) ;
+}
+else
+{
+	lib icuin : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options ;
+	lib icuin : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options ;
+	lib icuin : : <name>this_is_an_invalid_library_name ;
+}
+explicit icuuc icudt icuin ;
+
+ICU_OPTS =
+  <include>$(icu-path)/include
+  <runtime-link>shared:<library>icuuc/<link>shared
+  <runtime-link>shared:<library>icudt/<link>shared
+  <runtime-link>shared:<library>icuin/<link>shared
+  <runtime-link>static:<library>icuuc
+  <runtime-link>static:<library>icudt
+  <runtime-link>static:<library>icuin
+  <dll-path>$(icu-path)/bin
+  <define>BOOST_HAS_ICU=1
+  <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
+  <toolset>msvc:<find-static-library>advapi32
+  ;
+
+
+if $(ICU_ICUUC_NAME64)
+{
+    lib icuuc_64 : : <name>$(ICU_ICUUC_NAME64) ;
+}
+else
+{
+	lib icuuc_64 : :                                                               <runtime-link>shared <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>msvc                     <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>intel <target-os>windows <variant>debug <name>icuucd <runtime-link>shared <conditional>@path_options64 ;
+	lib icuuc_64 : :                                                  <name>sicuuc <runtime-link>static <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>msvc                     <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options64 ;
+	lib icuuc_64 : : <toolset>intel <target-os>windows <variant>debug <name>sicuucd <runtime-link>static <conditional>@path_options64 ;
+	lib icuuc_64 : : <name>this_is_an_invalid_library_name ;
+}
+
+if $(ICU_ICUDT_NAME64)
+{
+	lib icudt_64 : : <name>$(ICU_ICUDT_NAME64) ;
+}
+else
+{
+	lib icudt_64 : : <name>icudata                                   <runtime-link>shared <conditional>@path_options64 ;
+	lib icudt_64 : : <name>icudt   <toolset>msvc                     <runtime-link>shared <conditional>@path_options64 ;
+	lib icudt_64 : : <name>icudt   <toolset>intel <target-os>windows <runtime-link>shared <conditional>@path_options64 ;
+	lib icudt_64 : : <name>sicudata                                   <runtime-link>static <conditional>@path_options64 ;
+	lib icudt_64 : : <name>sicudt   <toolset>msvc                     <runtime-link>static <conditional>@path_options64 ;
+	lib icudt_64 : : <name>sicudt   <toolset>intel <target-os>windows <runtime-link>static <conditional>@path_options64 ;
+	lib icudt_64 : : <name>this_is_an_invalid_library_name ;
+}
+
+if $(ICU_ICUIN_NAME64)
+{
+	lib icuin_64 : : <name>$(ICU_ICUIN_NAME64) ;
+}
+else
+{
+	lib icuin_64 : :                                                    <name>icui18n <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                     <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                                      <name>icuin   <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows <variant>debug   <name>icuind  <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows                  <name>icuin   <runtime-link>shared <conditional>@path_options64 ;
+	lib icuin_64 : :                                                    <name>sicui18n <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                     <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>msvc                                      <name>sicuin   <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows <variant>debug   <name>sicuind  <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <toolset>intel <target-os>windows                  <name>sicuin   <runtime-link>static <conditional>@path_options64 ;
+	lib icuin_64 : : <name>this_is_an_invalid_library_name ;
+}
+explicit icuuc_64 icudt_64 icuin_64 ;
+
+ICU64_OPTS =
+  <include>$(icu-path)/include
+  <runtime-link>shared:<library>icuuc_64/<link>shared
+  <runtime-link>shared:<library>icudt_64/<link>shared
+  <runtime-link>shared:<library>icuin_64/<link>shared
+  <runtime-link>static:<library>icuuc_64
+  <runtime-link>static:<library>icudt_64
+  <runtime-link>static:<library>icuin_64
+  <dll-path>$(icu-path)/bin64
+  <define>BOOST_HAS_ICU=1
+  <runtime-link>static:<define>U_STATIC_IMPLEMENTATION=1
+  <toolset>msvc:<find-static-library>advapi32
+  ;
+
 
 exe has_icu       : $(TOP)/build/has_icu_test.cpp : $(ICU_OPTS)   ;
 # Similar but build&link with 64bit options

--- a/build/has_icu_test.cpp
+++ b/build/has_icu_test.cpp
@@ -9,10 +9,6 @@
 #include <unicode/utypes.h>
 #include <unicode/uversion.h>
 
-#if defined(_MSC_VER) && !defined(_DLL)
-#    error "Mixing ICU with a static runtime doesn't work"
-#endif
-
 int main()
 {
     icu::Locale loc;

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -10,6 +10,13 @@
 
 - 1.81.0
     - Require C++11 or higher
+    - Modernize code (C++11 features instead of Boost replacements, consistent formatting)
+    - Error on use of `-sICU_LINK_LOCALE` and `-sICU_LINK`, use `-sICU_*_NAME` when `-sICU_PATH` is not enough
+    - Fix build on macOS with iconv
+    - Fix int-overflow on negative roll of years in `date_time`
+    - Assume and use UTF-16 encoding for Windows `wchar_t-codecvt`
+    - Fix rounding issues with calendar time
+    - Make `basic_format` movable allowing it to be returned from functions
 - 1.80.0
     - Deprecated support for C++03 and earlier, C++11 will be required in the next release
     - Provide `-sICU_LINK_LOCALE` as a temporary replacement for `-sICU_LINK` which is incompatible with Boost.Regex.


### PR DESCRIPTION
Use the same mechanism for getting the ICU configuration as Boost.Regex does.

Error on use of `ICU_LINK` or `ICU_LINK_LOCALE` now that we have proper support.

Closes #70 as the work of @SSE4 is integrated here   
Fixes #55

/cc @grafikrobot

TODO: Check that the omission of `<dll-path>` doesn't break anything.