### PR TITLE
Fix handling of codepages not supporting `MB_ERR_INVALID_CHARS`

### DIFF
--- a/doc/conversions.txt
+++ b/doc/conversions.txt
@@ -89,7 +89,7 @@ For more details on normalization forms, read <a href="http://unicode.org/report
     character width. So be careful when using non-UTF encodings as they may be treated incorrectly.
 -   \ref boost::locale::fold_case() "fold_case" is generally a locale-independent operation, but it receives a locale as a parameter to
     determine the 8-bit encoding.
--   All of these functions can work with an STL string, a NUL terminated string, or a range defined by two pointers. They always
+-   All of these functions can work with an STL string, a NULL terminated string, or a range defined by two pointers. They always
     return a newly created STL string.
 -   The length of the string may change, see the above example.
 */

--- a/include/boost/locale/boundary/segment.hpp
+++ b/include/boost/locale/boundary/segment.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_BOUNDARY_SEGMENT_HPP_INCLUDED
 
 #include <boost/locale/config.hpp>
+#include <boost/locale/util/string.hpp>
 #include <iosfwd>
 #include <iterator>
 #include <locale>
@@ -54,19 +55,13 @@ namespace boost { namespace locale { namespace boundary {
         template<typename Left, typename Char>
         int compare_string(const Left& l, const Char* begin)
         {
-            const Char* end = begin;
-            while(*end != 0)
-                end++;
-            return compare_text(l.begin(), l.end(), begin, end);
+            return compare_text(l.begin(), l.end(), begin, util::str_end(begin));
         }
 
         template<typename Right, typename Char>
         int compare_string(const Char* begin, const Right& r)
         {
-            const Char* end = begin;
-            while(*end != 0)
-                end++;
-            return compare_text(begin, end, r.begin(), r.end());
+            return compare_text(begin, util::str_end(begin), r.begin(), r.end());
         }
 
     } // namespace detail

--- a/include/boost/locale/conversion.hpp
+++ b/include/boost/locale/conversion.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_CONVERTER_HPP_INCLUDED
 
 #include <boost/locale/config.hpp>
+#include <boost/locale/util/string.hpp>
 #include <locale>
 
 #ifdef BOOST_MSVC
@@ -127,45 +128,6 @@ namespace boost { namespace locale {
     } norm_type;
 
     ///
-    /// Normalize Unicode string \a str according to \ref norm_type "normalization form" \a n
-    ///
-    /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
-    /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
-    /// of a Unicode character set.
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-    template<typename CharType>
-    std::basic_string<CharType> normalize(const std::basic_string<CharType>& str,
-                                          norm_type n = norm_default,
-                                          const std::locale& loc = std::locale())
-    {
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::normalization,
-                                                                str.data(),
-                                                                str.data() + str.size(),
-                                                                n);
-    }
-
-    ///
-    /// Normalize NUL terminated Unicode string \a str according to \ref norm_type "normalization form" \a n
-    ///
-    /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
-    /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
-    /// of a Unicode character set.
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-    template<typename CharType>
-    std::basic_string<CharType>
-    normalize(const CharType* str, norm_type n = norm_default, const std::locale& loc = std::locale())
-    {
-        const CharType* end = str;
-        while(*end)
-            end++;
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::normalization, str, end, n);
-    }
-
-    ///
     /// Normalize Unicode string in range [begin,end) according to \ref norm_type "normalization form" \a n
     ///
     /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
@@ -183,35 +145,40 @@ namespace boost { namespace locale {
         return std::use_facet<converter<CharType>>(loc).convert(converter_base::normalization, begin, end, n);
     }
 
+    ///
+    /// Normalize Unicode string \a str according to \ref norm_type "normalization form" \a n
+    ///
+    /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
+    /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
+    /// of a Unicode character set.
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+    template<typename CharType>
+    std::basic_string<CharType> normalize(const std::basic_string<CharType>& str,
+                                          norm_type n = norm_default,
+                                          const std::locale& loc = std::locale())
+    {
+        return normalize(str.data(), str.data() + str.size(), n, loc);
+    }
+
+    ///
+    /// Normalize NULL terminated Unicode string \a str according to \ref norm_type "normalization form" \a n
+    ///
+    /// Note: This function receives only Unicode strings, i.e.: UTF-8, UTF-16 or UTF-32. It does not take
+    /// in account the locale encoding, because Unicode decomposition and composition are meaningless outside
+    /// of a Unicode character set.
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+    template<typename CharType>
+    std::basic_string<CharType>
+    normalize(const CharType* str, norm_type n = norm_default, const std::locale& loc = std::locale())
+    {
+        return normalize(str, util::str_end(str), n, loc);
+    }
+
     ///////////////////////////////////////////////////
-
-    ///
-    /// Convert a string \a str to upper case according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-
-    template<typename CharType>
-    std::basic_string<CharType> to_upper(const std::basic_string<CharType>& str, const std::locale& loc = std::locale())
-    {
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::upper_case,
-                                                                str.data(),
-                                                                str.data() + str.size());
-    }
-
-    ///
-    /// Convert a NUL terminated string \a str to upper case according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-    template<typename CharType>
-    std::basic_string<CharType> to_upper(const CharType* str, const std::locale& loc = std::locale())
-    {
-        const CharType* end = str;
-        while(*end)
-            end++;
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::upper_case, str, end);
-    }
 
     ///
     /// Convert a string in range [begin,end) to upper case according to locale \a loc
@@ -225,35 +192,30 @@ namespace boost { namespace locale {
         return std::use_facet<converter<CharType>>(loc).convert(converter_base::upper_case, begin, end);
     }
 
+    ///
+    /// Convert a string \a str to upper case according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+
+    template<typename CharType>
+    std::basic_string<CharType> to_upper(const std::basic_string<CharType>& str, const std::locale& loc = std::locale())
+    {
+        return to_upper(str.data(), str.data() + str.size(), loc);
+    }
+
+    ///
+    /// Convert a NULL terminated string \a str to upper case according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+    template<typename CharType>
+    std::basic_string<CharType> to_upper(const CharType* str, const std::locale& loc = std::locale())
+    {
+        return to_upper(str, util::str_end(str), loc);
+    }
+
     ///////////////////////////////////////////////////
-
-    ///
-    /// Convert a string \a str to lower case according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-
-    template<typename CharType>
-    std::basic_string<CharType> to_lower(const std::basic_string<CharType>& str, const std::locale& loc = std::locale())
-    {
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::lower_case,
-                                                                str.data(),
-                                                                str.data() + str.size());
-    }
-
-    ///
-    /// Convert a NUL terminated string \a str to lower case according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-    template<typename CharType>
-    std::basic_string<CharType> to_lower(const CharType* str, const std::locale& loc = std::locale())
-    {
-        const CharType* end = str;
-        while(*end)
-            end++;
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::lower_case, str, end);
-    }
 
     ///
     /// Convert a string in range [begin,end) to lower case according to locale \a loc
@@ -266,35 +228,31 @@ namespace boost { namespace locale {
     {
         return std::use_facet<converter<CharType>>(loc).convert(converter_base::lower_case, begin, end);
     }
+
+    ///
+    /// Convert a string \a str to lower case according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+
+    template<typename CharType>
+    std::basic_string<CharType> to_lower(const std::basic_string<CharType>& str, const std::locale& loc = std::locale())
+    {
+        return to_lower(str.data(), str.data() + str.size(), loc);
+    }
+
+    ///
+    /// Convert a NULL terminated string \a str to lower case according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+    template<typename CharType>
+    std::basic_string<CharType> to_lower(const CharType* str, const std::locale& loc = std::locale())
+    {
+        return to_lower(str, util::str_end(str), loc);
+    }
+
     ///////////////////////////////////////////////////
-
-    ///
-    /// Convert a string \a str to title case according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-
-    template<typename CharType>
-    std::basic_string<CharType> to_title(const std::basic_string<CharType>& str, const std::locale& loc = std::locale())
-    {
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::title_case,
-                                                                str.data(),
-                                                                str.data() + str.size());
-    }
-
-    ///
-    /// Convert a NUL terminated string \a str to title case according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-    template<typename CharType>
-    std::basic_string<CharType> to_title(const CharType* str, const std::locale& loc = std::locale())
-    {
-        const CharType* end = str;
-        while(*end)
-            end++;
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::title_case, str, end);
-    }
 
     ///
     /// Convert a string in range [begin,end) to title case according to locale \a loc
@@ -308,36 +266,30 @@ namespace boost { namespace locale {
         return std::use_facet<converter<CharType>>(loc).convert(converter_base::title_case, begin, end);
     }
 
+    ///
+    /// Convert a string \a str to title case according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+
+    template<typename CharType>
+    std::basic_string<CharType> to_title(const std::basic_string<CharType>& str, const std::locale& loc = std::locale())
+    {
+        return to_title(str.data(), str.data() + str.size(), loc);
+    }
+
+    ///
+    /// Convert a NULL terminated string \a str to title case according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+    template<typename CharType>
+    std::basic_string<CharType> to_title(const CharType* str, const std::locale& loc = std::locale())
+    {
+        return to_title(str, util::str_end(str), loc);
+    }
+
     ///////////////////////////////////////////////////
-
-    ///
-    /// Fold case of a string \a str according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-
-    template<typename CharType>
-    std::basic_string<CharType> fold_case(const std::basic_string<CharType>& str,
-                                          const std::locale& loc = std::locale())
-    {
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::case_folding,
-                                                                str.data(),
-                                                                str.data() + str.size());
-    }
-
-    ///
-    /// Fold case of a NUL terminated string \a str according to locale \a loc
-    ///
-    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
-    ///
-    template<typename CharType>
-    std::basic_string<CharType> fold_case(const CharType* str, const std::locale& loc = std::locale())
-    {
-        const CharType* end = str;
-        while(*end)
-            end++;
-        return std::use_facet<converter<CharType>>(loc).convert(converter_base::case_folding, str, end);
-    }
 
     ///
     /// Fold case of a string in range [begin,end) according to locale \a loc
@@ -349,6 +301,30 @@ namespace boost { namespace locale {
     fold_case(const CharType* begin, const CharType* end, const std::locale& loc = std::locale())
     {
         return std::use_facet<converter<CharType>>(loc).convert(converter_base::case_folding, begin, end);
+    }
+
+    ///
+    /// Fold case of a string \a str according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+
+    template<typename CharType>
+    std::basic_string<CharType> fold_case(const std::basic_string<CharType>& str,
+                                          const std::locale& loc = std::locale())
+    {
+        return fold_case(str.data(), str.data() + str.size(), loc);
+    }
+
+    ///
+    /// Fold case of a NULL terminated string \a str according to locale \a loc
+    ///
+    /// \note throws std::bad_cast if loc does not have \ref converter facet installed
+    ///
+    template<typename CharType>
+    std::basic_string<CharType> fold_case(const CharType* str, const std::locale& loc = std::locale())
+    {
+        return fold_case(str, util::str_end(str), loc);
     }
 
     ///

--- a/include/boost/locale/encoding.hpp
+++ b/include/boost/locale/encoding.hpp
@@ -11,6 +11,7 @@
 #include <boost/locale/encoding_errors.hpp>
 #include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/info.hpp>
+#include <boost/locale/util/string.hpp>
 
 #ifdef BOOST_MSVC
 #    pragma warning(push)
@@ -99,10 +100,7 @@ namespace boost { namespace locale {
         std::basic_string<CharType>
         to_utf(const char* text, const std::string& charset, method_type how = default_method)
         {
-            const char* text_end = text;
-            while(*text_end)
-                text_end++;
-            return to_utf<CharType>(text, text_end, charset, how);
+            return to_utf<CharType>(text, util::str_end(text), charset, how);
         }
 
         ///
@@ -111,10 +109,7 @@ namespace boost { namespace locale {
         template<typename CharType>
         std::string from_utf(const CharType* text, const std::string& charset, method_type how = default_method)
         {
-            const CharType* text_end = text;
-            while(*text_end)
-                text_end++;
-            return from_utf(text, text_end, charset, how);
+            return from_utf(text, util::str_end(text), charset, how);
         }
 
         ///
@@ -149,10 +144,7 @@ namespace boost { namespace locale {
         template<typename CharType>
         std::basic_string<CharType> to_utf(const char* text, const std::locale& loc, method_type how = default_method)
         {
-            const char* text_end = text;
-            while(*text_end)
-                text_end++;
-            return to_utf<CharType>(text, text_end, loc, how);
+            return to_utf<CharType>(text, util::str_end(text), loc, how);
         }
 
         ///
@@ -163,10 +155,7 @@ namespace boost { namespace locale {
         template<typename CharType>
         std::string from_utf(const CharType* text, const std::locale& loc, method_type how = default_method)
         {
-            const CharType* text_end = text;
-            while(*text_end)
-                text_end++;
-            return from_utf(text, text_end, loc, how);
+            return from_utf(text, util::str_end(text), loc, how);
         }
 
         ///
@@ -189,10 +178,7 @@ namespace boost { namespace locale {
                                    const std::string& from_encoding,
                                    method_type how = default_method)
         {
-            const char* end = text;
-            while(*end)
-                end++;
-            return boost::locale::conv::between(text, end, to_encoding, from_encoding, how);
+            return boost::locale::conv::between(text, util::str_end(text), to_encoding, from_encoding, how);
         }
 
         ///

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/locale/encoding_errors.hpp>
 #include <boost/locale/utf.hpp>
+#include <boost/locale/util/string.hpp>
 #include <iterator>
 
 #ifdef BOOST_MSVC
@@ -46,15 +47,12 @@ namespace boost { namespace locale { namespace conv {
     }
 
     ///
-    /// Convert a Unicode NUL terminated string \a str other Unicode encoding
+    /// Convert a Unicode NULL terminated string \a str other Unicode encoding
     ///
     template<typename CharOut, typename CharIn>
     std::basic_string<CharOut> utf_to_utf(const CharIn* str, method_type how = default_method)
     {
-        const CharIn* end = str;
-        while(*end)
-            end++;
-        return utf_to_utf<CharOut, CharIn>(str, end, how);
+        return utf_to_utf<CharOut, CharIn>(str, util::str_end(str), how);
     }
 
     ///

--- a/include/boost/locale/formatting.hpp
+++ b/include/boost/locale/formatting.hpp
@@ -9,6 +9,8 @@
 
 #include <boost/locale/config.hpp>
 #include <boost/locale/time_zone.hpp>
+#include <boost/locale/util/string.hpp>
+#include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
 #include <cstring>
 #include <istream>
@@ -221,14 +223,11 @@ namespace boost { namespace locale {
             template<typename Char>
             void set(const Char* s)
             {
+                BOOST_ASSERT(s);
                 delete[] ptr;
-                ptr = 0;
+                ptr = nullptr;
                 type = &typeid(Char);
-                const Char* end = s;
-                while(*end != 0)
-                    end++;
-                // if ptr = 0 it does not matter what is value of size
-                size = sizeof(Char) * (end - s + 1);
+                size = sizeof(Char) * (util::str_end(s) - s + 1);
                 ptr = new char[size];
                 memcpy(ptr, s, size);
             }

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_MESSAGE_HPP_INCLUDED
 
 #include <boost/locale/formatting.hpp>
+#include <boost/locale/util/string.hpp>
 #include <locale>
 #include <memory>
 #include <set>

--- a/include/boost/locale/util/string.hpp
+++ b/include/boost/locale/util/string.hpp
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2022 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_UTIL_STRING_HPP
+#define BOOST_LOCALE_UTIL_STRING_HPP
+
+#include <boost/locale/config.hpp>
+
+namespace boost { namespace locale { namespace util {
+    /// Return the end of a C-string, i.e. the pointer to the trailing NULL byte
+    template<typename Char>
+    Char* str_end(Char* str)
+    {
+        while(*str)
+            ++str;
+        return str;
+    }
+}}} // namespace boost::locale::util
+
+#endif

--- a/src/boost/locale/icu/uconv.hpp
+++ b/src/boost/locale/icu/uconv.hpp
@@ -91,10 +91,9 @@ namespace boost { namespace locale { namespace impl_icu {
         }
 
         struct uconv {
-            uconv(const uconv& other);
-            void operator=(const uconv& other);
+            uconv(const uconv& other) = delete;
+            void operator=(const uconv& other) = delete;
 
-        public:
             uconv(const std::string& charset, cpcvt_type cvt_type = cvt_skip)
             {
                 UErrorCode err = U_ZERO_ERROR;

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -20,6 +20,9 @@
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/locale/hold_ptr.hpp>
 #include <boost/locale/message.hpp>
+#include <boost/locale/util/string.hpp>
+#include "boost/locale/shared/mo_hash.hpp"
+#include "boost/locale/shared/mo_lambda.hpp"
 #include <boost/version.hpp>
 #include <algorithm>
 #include <cstdio>
@@ -29,9 +32,6 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
-
-#include "boost/locale/shared/mo_hash.hpp"
-#include "boost/locale/shared/mo_lambda.hpp"
 
 #ifdef BOOST_MSVC
 #    pragma warning(disable : 4996)
@@ -387,18 +387,14 @@ namespace boost { namespace locale { namespace gnu_gettext {
             pj_winberger_hash::state_type state = pj_winberger_hash::initial_state;
             const CharType* p = msg.context();
             if(*p != 0) {
-                const CharType* e = p;
-                while(*e)
-                    e++;
+                const CharType* e = util::str_end(p);
                 state = pj_winberger_hash::update_state(state,
                                                         reinterpret_cast<const char*>(p),
                                                         reinterpret_cast<const char*>(e));
                 state = pj_winberger_hash::update_state(state, '\4');
             }
             p = msg.key();
-            const CharType* e = p;
-            while(*e)
-                e++;
+            const CharType* e = util::str_end(p);
             state = pj_winberger_hash::update_state(state,
                                                     reinterpret_cast<const char*>(p),
                                                     reinterpret_cast<const char*>(e));

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -349,21 +349,15 @@ void test_to()
     test_with_0<Char>();
 }
 
-void test_skip(const char* enc, const char* utf, const char* name, const char* opt = 0)
+void test_convert(const char* enc, const char* utf, const char* name)
 {
-    if(opt != 0) {
-        if(boost::locale::conv::to_utf<char>(enc, name) == opt) {
-            test_skip(enc, opt, name);
-            return;
-        }
-    }
-    TEST(boost::locale::conv::to_utf<char>(enc, name) == utf);
-    TEST(boost::locale::conv::to_utf<wchar_t>(enc, name) == boost::locale::conv::utf_to_utf<wchar_t>(utf));
+    TEST_EQ(boost::locale::conv::to_utf<char>(enc, name), utf);
+    TEST_EQ(boost::locale::conv::to_utf<wchar_t>(enc, name), boost::locale::conv::utf_to_utf<wchar_t>(utf));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    TEST(boost::locale::conv::to_utf<char16_t>(enc, name) == boost::locale::conv::utf_to_utf<char16_t>(utf));
+    TEST_EQ(boost::locale::conv::to_utf<char16_t>(enc, name), boost::locale::conv::utf_to_utf<char16_t>(utf));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-    TEST(boost::locale::conv::to_utf<char32_t>(enc, name) == boost::locale::conv::utf_to_utf<char32_t>(utf));
+    TEST_EQ(boost::locale::conv::to_utf<char32_t>(enc, name), boost::locale::conv::utf_to_utf<char32_t>(utf));
 #endif
 }
 
@@ -373,19 +367,26 @@ void test_simple_conversions()
     std::cout << "- Testing correct invalid bytes skipping\n";
     try {
         std::cout << "-- ISO-8859-8" << std::endl;
-        test_skip("test \xE0\xE1\xFB-", "test \xd7\x90\xd7\x91-", "ISO-8859-8");
-        test_skip("\xFB", "", "ISO-8859-8");
-        test_skip("test \xE0\xE1\xFB", "test \xd7\x90\xd7\x91", "ISO-8859-8");
-        test_skip("\xFB-", "-", "ISO-8859-8");
+        test_convert("\xFB", "", "ISO-8859-8");
+        test_convert("\xFB-", "-", "ISO-8859-8");
+        test_convert("test \xE0\xE1\xFB", "test \xd7\x90\xd7\x91", "ISO-8859-8");
+        test_convert("test \xE0\xE1\xFB-", "test \xd7\x90\xd7\x91-", "ISO-8859-8");
     } catch(const blc::invalid_charset_error&) {
         std::cout << "--- not supported\n"; // LCOV_EXCL_LINE
     }
     try {
         std::cout << "-- cp932" << std::endl;
-        test_skip("test\xE0\xA0 \x83\xF8-", "test\xe7\x87\xbf -", "cp932", "test\xe7\x87\xbf ");
-        test_skip("\x83\xF8", "", "cp932");
-        test_skip("test\xE0\xA0 \x83\xF8", "test\xe7\x87\xbf ", "cp932");
-        test_skip("\x83\xF8-", "-", "cp932", "");
+        test_convert("\x83\xF8", "", "cp932");
+        test_convert("\x83\xF8-", "-", "cp932");
+        test_convert("test\xE0\xA0 \x83\xF8", "test\xe7\x87\xbf ", "cp932");
+        test_convert("test\xE0\xA0 \x83\xF8-", "test\xe7\x87\xbf -", "cp932");
+    } catch(const blc::invalid_charset_error&) {
+        std::cout << "--- not supported\n"; // LCOV_EXCL_LINE
+    }
+    try {
+        // Testing a codepage which may be an issue on Windows, see issue #121
+        std::cout << "-- iso-2022-jp" << std::endl;
+        test_convert("\x1b$BE_5(\x1b(B", "冬季", "iso-2022-jp");
     } catch(const blc::invalid_charset_error&) {
         std::cout << "--- not supported\n"; // LCOV_EXCL_LINE
     }

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -38,15 +38,6 @@ std::basic_string<char> to_utf(const std::string& s, locale_t)
     return s;
 }
 
-template<typename CharType>
-std::basic_string<CharType> conv_to_char(const char* p)
-{
-    std::basic_string<CharType> r;
-    while(*p)
-        r += CharType(*p++);
-    return r;
-}
-
 template<typename CharType, typename RefCharType>
 void test_by_char(const std::locale& l, locale_t lreal)
 {
@@ -135,9 +126,9 @@ void test_by_char(const std::locale& l, locale_t lreal)
         ss << as::time << a_datetime << CharType('\n');
         ss << as::datetime << a_datetime << CharType('\n');
         ss << as::time_zone("GMT+01:00");
-        ss << as::ftime(conv_to_char<CharType>("%H")) << a_datetime << CharType('\n');
+        ss << as::ftime(ascii_to<CharType>("%H")) << a_datetime << CharType('\n');
         ss << as::time_zone("GMT+00:15");
-        ss << as::ftime(conv_to_char<CharType>("%M")) << a_datetime << CharType('\n');
+        ss << as::ftime(ascii_to<CharType>("%M")) << a_datetime << CharType('\n');
 
         char buf[64]{};
 #ifndef BOOST_LOCALE_NO_POSIX_BACKEND

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -18,15 +18,6 @@
 #    pragma warning(disable : 4996)
 #endif
 
-template<typename CharType>
-std::basic_string<CharType> conv_to_char(const char* p)
-{
-    std::basic_string<CharType> r;
-    while(*p)
-        r += CharType(*p++);
-    return r;
-}
-
 template<typename CharType, typename RefCharType>
 void test_by_char(const std::locale& l, const std::locale& lreal)
 {
@@ -140,14 +131,14 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
         ss << as::time << a_datetime << CharType('\n');
         ss << as::datetime << a_datetime << CharType('\n');
         ss << as::time_zone("GMT+01:00");
-        ss << as::ftime(conv_to_char<CharType>("%H")) << a_datetime << CharType('\n');
+        ss << as::ftime(ascii_to<CharType>("%H")) << a_datetime << CharType('\n');
         ss << as::time_zone("GMT+00:15");
-        ss << as::ftime(conv_to_char<CharType>("%M")) << a_datetime << CharType('\n');
+        ss << as::ftime(ascii_to<CharType>("%M")) << a_datetime << CharType('\n');
 
         ss_ref_type ss_ref;
         ss_ref.imbue(lreal);
 
-        std::basic_string<RefCharType> rfmt(conv_to_char<RefCharType>("%x\n%X\n%c\n16\n48\n"));
+        std::basic_string<RefCharType> rfmt(ascii_to<RefCharType>("%x\n%X\n%c\n16\n48\n"));
 
         std::tm tm = *gmtime(&a_datetime);
 

--- a/test/test_utf.cpp
+++ b/test/test_utf.cpp
@@ -5,6 +5,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/utf.hpp>
+#include <boost/locale/util/string.hpp>
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 #include <boost/detail/workaround.hpp>
@@ -53,20 +54,11 @@ const char32_t* c32_seq(boost::uint32_t a)
     return buf;
 }
 
-// Get end of C-String, i.e. the NULL byte
-template<typename CharType>
-const CharType* str_end(const CharType* s)
-{
-    while(*s)
-        s++;
-    return s;
-}
-
 template<typename CharType>
 void test_from_utf(const CharType* const s, unsigned codepoint)
 {
     const CharType* cur = s;
-    const CharType* const end = str_end(s);
+    const CharType* const end = boost::locale::util::str_end(s);
 
     typedef utf_traits<CharType> tr;
 
@@ -104,7 +96,7 @@ void test_to_utf(const CharType* str, unsigned codepoint)
     CharType buf[5] = {1, 1, 1, 1, 1};
     CharType* p = buf;
     p = utf_traits<CharType>::template encode<CharType*>(codepoint, p);
-    const CharType* const end = str_end(str);
+    const CharType* const end = boost::locale::util::str_end(str);
     TEST(end - str == p - buf);
     TEST(*p);
     *p = 0;

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -24,15 +24,6 @@
 #include "boostLocale/test/unit_test.hpp"
 
 template<typename CharType>
-std::basic_string<CharType> conv_to_char(const char* p)
-{
-    std::basic_string<CharType> r;
-    while(*p)
-        r += CharType(*p++);
-    return r;
-}
-
-template<typename CharType>
 void test_by_char(const std::locale& l, std::string name, int lcid)
 {
     typedef std::basic_stringstream<CharType> ss_type;
@@ -114,9 +105,9 @@ void test_by_char(const std::locale& l, std::string name, int lcid)
         ss << as::time << a_datetime << CharType('\n');
         ss << as::datetime << a_datetime << CharType('\n');
         ss << as::time_zone("GMT+01:00");
-        ss << as::ftime(conv_to_char<CharType>("%H")) << a_datetime << CharType('\n');
+        ss << as::ftime(ascii_to<CharType>("%H")) << a_datetime << CharType('\n');
         ss << as::time_zone("GMT+00:15");
-        ss << as::ftime(conv_to_char<CharType>("%M")) << a_datetime << CharType('\n');
+        ss << as::ftime(ascii_to<CharType>("%M")) << a_datetime << CharType('\n');
 
 #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
         wchar_t time_buf[256];


### PR DESCRIPTION
E.g. iso-2022-jp requires `flags=0` to be passed to `MultiByteToWideChar`
according to https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
So catch the `ERROR_INVALID_FLAGS` and reset the flags to zero.

Fixes #121

Also some refactoring to reduce code duplication and improve readability of tests