### PR TITLE
Use enum classes for facet types

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -9,16 +9,19 @@
 \page changelog Changelog
 
 - 1.81.0
-    - Require C++11 or higher
-    - Modernize code (C++11 features instead of Boost replacements, consistent formatting)
-    - Error on use of `-sICU_LINK_LOCALE` and `-sICU_LINK`, use `-sICU_*_NAME` when `-sICU_PATH` is not enough
-    - Fix build on macOS with iconv
-    - Fix int-overflow on negative roll of years in `date_time`
-    - Assume and use UTF-16 encoding for Windows `wchar_t-codecvt`
-    - Fix rounding issues with calendar time
-    - Make `basic_format` movable allowing it to be returned from functions
-    - Fix conversion of e.g. codepage iso-2022-jp on Windows
-    - Add more Windows codepages, e.g. cp1025, and various ISO and IBM codepages
+    - Breaking changes
+        - Require C++11 or higher
+        - Modernize code (C++11 features instead of Boost replacements, consistent formatting)
+        - Error on use of `-sICU_LINK_LOCALE` and `-sICU_LINK`, use `-sICU_*_NAME` when `-sICU_PATH` is not enough
+        - Convert `character_facet_type` & `locale_category_type` to the enum classes `char_facet_t` & `category_t`
+    - Other improvements and fixes
+        - Fix build on macOS with iconv
+        - Fix int-overflow on negative roll of years in `date_time`
+        - Assume and use UTF-16 encoding for Windows `wchar_t-codecvt`
+        - Fix rounding issues with calendar time
+        - Make `basic_format` movable allowing it to be returned from functions
+    	- Fix conversion of e.g. codepage iso-2022-jp on Windows
+    	- Add more Windows codepages, e.g. cp1025, and various ISO and IBM codepages
 - 1.80.0
     - Deprecated support for C++03 and earlier, C++11 will be required in the next release
     - Provide `-sICU_LINK_LOCALE` as a temporary replacement for `-sICU_LINK` which is incompatible with Boost.Regex.

--- a/doc/locale_gen.txt
+++ b/doc/locale_gen.txt
@@ -63,7 +63,7 @@ For example:
 
 \code
     generator gen;
-    gen.characters(wchar_t_facet);
+    gen.characters(char_facet_t::wchar_f);
     gen.categories(collation_facet | formatting_facet);
     std::locale::global(gen("de_DE.UTF-8"));
 \endcode

--- a/include/boost/locale/boundary/types.hpp
+++ b/include/boost/locale/boundary/types.hpp
@@ -109,8 +109,8 @@ namespace boost { namespace locale {
                 case word: return word_mask;
                 case sentence: return sentence_mask;
                 case line: return line_mask;
-                default: return 0;
             }
+            return 0;
         }
 
         ///

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -26,22 +26,23 @@ namespace boost { namespace locale {
     ///
     /// @{
 
-    ///
-    /// \brief a base class that includes collation level flags
-    ///
+    /// Unicode collation level types
+    enum class collate_level {
+        primary = 0,    ///< 1st collation level: base letters
+        secondary = 1,  ///< 2nd collation level: letters and accents
+        tertiary = 2,   ///< 3rd collation level: letters, accents and case
+        quaternary = 3, ///< 4th collation level: letters, accents, case and punctuation
+        identical = 4   ///< identical collation level: include code-point comparison
+    };
 
-    class collator_base {
+    class BOOST_DEPRECATED("Use collate_level") collator_base {
     public:
-        ///
-        /// Unicode collation level types
-        ///
-        typedef enum {
-            primary = 0,    ///< 1st collation level: base letters
-            secondary = 1,  ///< 2nd collation level: letters and accents
-            tertiary = 2,   ///< 3rd collation level: letters, accents and case
-            quaternary = 3, ///< 4th collation level: letters, accents, case and punctuation
-            identical = 4   ///< identical collation level: include code-point comparison
-        } level_type;
+        using level_type = collate_level;
+        static constexpr auto primary = collate_level::primary;
+        static constexpr auto secondary = collate_level::secondary;
+        static constexpr auto tertiary = collate_level::tertiary;
+        static constexpr auto quaternary = collate_level::quaternary;
+        static constexpr auto identical = collate_level::identical;
     };
 
     ///
@@ -51,7 +52,7 @@ namespace boost { namespace locale {
     /// allowing usage of std::locale for direct string comparison
     ///
     template<typename CharType>
-    class collator : public std::collate<CharType>, public collator_base {
+    class collator : public std::collate<CharType> {
     public:
         ///
         /// Type of the underlying character
@@ -68,7 +69,7 @@ namespace boost { namespace locale {
         /// Returns -1 if the first of the two strings sorts before the seconds, returns 1 if sorts after and 0 if
         /// they considered equal.
         ///
-        int compare(level_type level,
+        int compare(collate_level level,
                     const char_type* b1,
                     const char_type* e1,
                     const char_type* b2,
@@ -87,7 +88,7 @@ namespace boost { namespace locale {
         ///
         /// Calls do_transform
         ///
-        string_type transform(level_type level, const char_type* b, const char_type* e) const
+        string_type transform(collate_level level, const char_type* b, const char_type* e) const
         {
             return do_transform(level, b, e);
         }
@@ -99,7 +100,7 @@ namespace boost { namespace locale {
         ///
         /// Calls do_hash
         ///
-        long hash(level_type level, const char_type* b, const char_type* e) const { return do_hash(level, b, e); }
+        long hash(collate_level level, const char_type* b, const char_type* e) const { return do_hash(level, b, e); }
 
         ///
         /// Compare two strings \a l and \a r using collation level \a level
@@ -108,7 +109,7 @@ namespace boost { namespace locale {
         /// they considered equal.
         ///
         ///
-        int compare(level_type level, const string_type& l, const string_type& r) const
+        int compare(collate_level level, const string_type& l, const string_type& r) const
         {
             return do_compare(level, l.data(), l.data() + l.size(), r.data(), r.data() + r.size());
         }
@@ -119,7 +120,7 @@ namespace boost { namespace locale {
         /// If compare(level,s1,s2) == 0 then hash(level,s1) == hash(level,s2)
         ///
 
-        long hash(level_type level, const string_type& s) const
+        long hash(collate_level level, const string_type& s) const
         {
             return do_hash(level, s.data(), s.data() + s.size());
         }
@@ -132,7 +133,7 @@ namespace boost { namespace locale {
         ///   compare(level,s1,s2) == sign( transform(level,s1).compare(transform(level,s2)) );
         /// \endcode
         ///
-        string_type transform(level_type level, const string_type& s) const
+        string_type transform(collate_level level, const string_type& s) const
         {
             return do_transform(level, s.data(), s.data() + s.size());
         }
@@ -150,7 +151,7 @@ namespace boost { namespace locale {
         int
         do_compare(const char_type* b1, const char_type* e1, const char_type* b2, const char_type* e2) const override
         {
-            return do_compare(identical, b1, e1, b2, e2);
+            return do_compare(collate_level::identical, b1, e1, b2, e2);
         }
         ///
         /// This function is used to override default collation function that does not take in account collation level.
@@ -158,19 +159,22 @@ namespace boost { namespace locale {
         ///
         string_type do_transform(const char_type* b, const char_type* e) const override
         {
-            return do_transform(identical, b, e);
+            return do_transform(collate_level::identical, b, e);
         }
         ///
         /// This function is used to override default collation function that does not take in account collation level.
         /// Uses primary level
         ///
-        long do_hash(const char_type* b, const char_type* e) const override { return do_hash(identical, b, e); }
+        long do_hash(const char_type* b, const char_type* e) const override
+        {
+            return do_hash(collate_level::identical, b, e);
+        }
 
         ///
         /// Actual function that performs comparison between the strings. For details see compare member function. Can
         /// be overridden.
         ///
-        virtual int do_compare(level_type level,
+        virtual int do_compare(collate_level level,
                                const char_type* b1,
                                const char_type* e1,
                                const char_type* b2,
@@ -178,11 +182,11 @@ namespace boost { namespace locale {
         ///
         /// Actual function that performs transformation. For details see transform member function. Can be overridden.
         ///
-        virtual string_type do_transform(level_type level, const char_type* b, const char_type* e) const = 0;
+        virtual string_type do_transform(collate_level level, const char_type* b, const char_type* e) const = 0;
         ///
         /// Actual function that calculates hash. For details see hash member function. Can be overridden.
         ///
-        virtual long do_hash(level_type level, const char_type* b, const char_type* e) const = 0;
+        virtual long do_hash(collate_level level, const char_type* b, const char_type* e) const = 0;
     };
 
     ///
@@ -192,12 +196,12 @@ namespace boost { namespace locale {
     /// For example:
     ///
     /// \code
-    ///  std::map<std::string,std::string,comparator<char,collator_base::secondary> > data;
+    ///  std::map<std::string,std::string,comparator<char,collate_level::secondary> > data;
     /// \endcode
     ///
     /// Would create a map the keys of which are sorted using secondary collation level
     ///
-    template<typename CharType, collator_base::level_type default_level = collator_base::identical>
+    template<typename CharType, collate_level default_level = collate_level::identical>
     struct comparator {
     public:
         ///
@@ -205,7 +209,7 @@ namespace boost { namespace locale {
         ///
         /// \note throws std::bad_cast if l does not have \ref collator facet installed
         ///
-        comparator(const std::locale& l = std::locale(), collator_base::level_type level = default_level) :
+        comparator(const std::locale& l = std::locale(), collate_level level = default_level) :
             locale_(l), level_(level)
         {}
 
@@ -219,7 +223,7 @@ namespace boost { namespace locale {
 
     private:
         std::locale locale_;
-        collator_base::level_type level_;
+        collate_level level_;
     };
 
     ///

--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -28,47 +28,60 @@ namespace locale {
     class localization_backend;
     class localization_backend_manager;
 
-    constexpr uint32_t nochar_facet = 0;        ///< Unspecified character category for character independent facets
-    constexpr uint32_t char_facet = 1 << 0;     ///< 8-bit character facets
-    constexpr uint32_t wchar_t_facet = 1 << 1;  ///< wide character facets
-    constexpr uint32_t char16_t_facet = 1 << 2; ///< C++11 char16_t facets
-    constexpr uint32_t char32_t_facet = 1 << 3; ///< C++11 char32_t facets
-
-    constexpr uint32_t character_first_facet = char_facet;    ///< First facet specific for character type
-    constexpr uint32_t character_last_facet = char32_t_facet; ///< Last facet specific for character type
-    constexpr uint32_t all_characters = 0xFFFF;               ///< Special mask -- generate all
-
-    typedef uint32_t character_facet_type; ///< type that specifies the character type that locales can be generated for
-
-    constexpr uint32_t convert_facet = 1 << 0;    ///< Generate conversion facets
-    constexpr uint32_t collation_facet = 1 << 1;  ///< Generate collation facets
-    constexpr uint32_t formatting_facet = 1 << 2; ///< Generate numbers, currency, date-time formatting facets
-    constexpr uint32_t parsing_facet = 1 << 3;    ///< Generate numbers, currency, date-time formatting facets
-    constexpr uint32_t message_facet = 1 << 4;    ///< Generate message facets
-    constexpr uint32_t codepage_facet = 1
-                                        << 5; ///< Generate character set conversion facets (derived from std::codecvt)
-    constexpr uint32_t boundary_facet = 1 << 6; ///< Generate boundary analysis facet
-
-    constexpr uint32_t per_character_facet_first = convert_facet; ///< First facet specific for character
-    constexpr uint32_t per_character_facet_last = boundary_facet; ///< Last facet specific for character
-
-    constexpr uint32_t calendar_facet = 1 << 16;    ///< Generate boundary analysis facet
-    constexpr uint32_t information_facet = 1 << 17; ///< Generate general locale information facet
-
-    constexpr uint32_t non_character_facet_first = calendar_facet;   ///< First character independent facet
-    constexpr uint32_t non_character_facet_last = information_facet; ///< Last character independent facet
-
-    constexpr uint32_t all_categories = 0xFFFFFFFFu; ///< Generate all of them
-
-    typedef uint32_t locale_category_type; ///< a type used for more fine grained generation of facets
-
+    /// Type that specifies the character type that locales can be generated for
     ///
+    /// Supports bitwise OR and bitwise AND (the latter returning if the type is set)
+    enum class char_facet_t : uint32_t {
+        nochar = 0,        ///< Unspecified character category for character independent facets
+        char_f = 1 << 0,   ///< 8-bit character facets
+        wchar_f = 1 << 1,  ///< wide character facets
+        char16_f = 1 << 2, ///< C++11 char16_t facets
+        char32_f = 1 << 3, ///< C++11 char32_t facets
+    };
+    typedef BOOST_DEPRECATED("Use char_facet_t") char_facet_t character_facet_type;
+
+    /// First facet specific for character type
+    constexpr char_facet_t character_facet_first = char_facet_t::char_f;
+    /// Last facet specific for character type
+    constexpr char_facet_t character_facet_last = char_facet_t::char32_f;
+    /// Special mask -- generate all
+    constexpr char_facet_t all_characters = char_facet_t(0xFFFFFFFFu);
+
+    /// Type used for more fine grained generation of facets
+    ///
+    /// Supports bitwise OR and bitwise AND (the latter returning if the type is set)
+    enum class category_t : uint32_t {
+        convert = 1 << 0,      ///< Generate conversion facets
+        collation = 1 << 1,    ///< Generate collation facets
+        formatting = 1 << 2,   ///< Generate numbers, currency, date-time formatting facets
+        parsing = 1 << 3,      ///< Generate numbers, currency, date-time formatting facets
+        message = 1 << 4,      ///< Generate message facets
+        codepage = 1 << 5,     ///< Generate character set conversion facets (derived from std::codecvt)
+        boundary = 1 << 6,     ///< Generate boundary analysis facet
+        calendar = 1 << 16,    ///< Generate boundary analysis facet
+        information = 1 << 17, ///< Generate general locale information facet
+    };
+    typedef BOOST_DEPRECATED("Use category_t") category_t locale_category_type;
+
+    /// First facet specific for character
+    constexpr category_t per_character_facet_first = category_t::convert;
+    /// Last facet specific for character
+    constexpr category_t per_character_facet_last = category_t::boundary;
+    /// First character independent facet
+    constexpr category_t non_character_facet_first = category_t::calendar;
+    /// Last character independent facet
+    constexpr category_t non_character_facet_last = category_t::information;
+    /// First category facet
+    constexpr category_t category_first = category_t::convert;
+    /// Last category facet
+    constexpr category_t category_last = category_t::information;
+    /// Generate all of them
+    constexpr category_t all_categories = category_t(0xFFFFFFFFu);
+
     /// \brief the major class used for locale generation
     ///
     /// This class is used for specification of all parameters required for locale generation and
     /// caching. This class const member functions are thread safe if locale class implementation is thread safe.
-    ///
-
     class BOOST_LOCALE_DECL generator {
     public:
         ///
@@ -85,20 +98,20 @@ namespace locale {
         ///
         /// Set types of facets that should be generated, default all
         ///
-        void categories(locale_category_type cats);
+        void categories(category_t cats);
         ///
         /// Get types of facets that should be generated, default all
         ///
-        locale_category_type categories() const;
+        category_t categories() const;
 
         ///
         /// Set the characters type for which the facets should be generated, default all supported
         ///
-        void characters(character_facet_type chars);
+        void characters(char_facet_t chars);
         ///
         /// Get the characters type for which the facets should be generated, default all supported
         ///
-        character_facet_type characters() const;
+        char_facet_t characters() const;
 
         ///
         /// Add a new domain of messages that would be generated. It should be set in order to enable
@@ -216,6 +229,41 @@ namespace locale {
         hold_ptr<data> d;
     };
 
+    constexpr char_facet_t operator|(const char_facet_t lhs, const char_facet_t rhs)
+    {
+        return char_facet_t(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+    }
+    constexpr char_facet_t operator^(const char_facet_t lhs, const char_facet_t rhs)
+    {
+        return char_facet_t(static_cast<uint32_t>(lhs) ^ static_cast<uint32_t>(rhs));
+    }
+    constexpr bool operator&(const char_facet_t lhs, const char_facet_t rhs)
+    {
+        return (static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs)) != 0u;
+    }
+    // Prefix increment: Return the next value
+    BOOST_CXX14_CONSTEXPR inline char_facet_t& operator++(char_facet_t& v)
+    {
+        return v = char_facet_t(static_cast<uint32_t>(v) ? static_cast<uint32_t>(v) << 1 : 1);
+    }
+
+    constexpr category_t operator|(const category_t lhs, const category_t rhs)
+    {
+        return category_t(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+    }
+    constexpr category_t operator^(const category_t lhs, const category_t rhs)
+    {
+        return category_t(static_cast<uint32_t>(lhs) ^ static_cast<uint32_t>(rhs));
+    }
+    constexpr bool operator&(const category_t lhs, const category_t rhs)
+    {
+        return (static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs)) != 0u;
+    }
+    // Prefix increment: Return the next value
+    BOOST_CXX14_CONSTEXPR inline category_t& operator++(category_t& v)
+    {
+        return v = category_t(static_cast<uint32_t>(v) << 1);
+    }
 } // namespace locale
 } // namespace boost
 #ifdef BOOST_MSVC

--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -32,18 +32,29 @@ namespace locale {
     ///
     /// Supports bitwise OR and bitwise AND (the latter returning if the type is set)
     enum class char_facet_t : uint32_t {
-        nochar = 0,        ///< Unspecified character category for character independent facets
-        char_f = 1 << 0,   ///< 8-bit character facets
-        wchar_f = 1 << 1,  ///< wide character facets
+        nochar = 0,       ///< Unspecified character category for character independent facets
+        char_f = 1 << 0,  ///< 8-bit character facets
+        wchar_f = 1 << 1, ///< wide character facets
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
         char16_f = 1 << 2, ///< C++11 char16_t facets
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
         char32_f = 1 << 3, ///< C++11 char32_t facets
+#endif
     };
     typedef BOOST_DEPRECATED("Use char_facet_t") char_facet_t character_facet_type;
 
     /// First facet specific for character type
     constexpr char_facet_t character_facet_first = char_facet_t::char_f;
     /// Last facet specific for character type
-    constexpr char_facet_t character_facet_last = char_facet_t::char32_f;
+    constexpr char_facet_t character_facet_last =
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+      char_facet_t::char32_f;
+#elif defined BOOST_LOCALE_ENABLE_CHAR16_T
+      char_facet_t::char16_f;
+#else
+      char_facet_t::wchar_f;
+#endif
     /// Special mask -- generate all
     constexpr char_facet_t all_characters = char_facet_t(0xFFFFFFFFu);
 

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -68,8 +68,7 @@ namespace boost { namespace locale {
         ///
         /// Create a facet for category \a category and character type \a type
         ///
-        virtual std::locale
-        install(const std::locale& base, locale_category_type category, character_facet_type type = nochar_facet) = 0;
+        virtual std::locale install(const std::locale& base, category_t category, char_facet_t type) = 0;
 
     }; // localization_backend
 
@@ -139,7 +138,7 @@ namespace boost { namespace locale {
         /// Select specific backend by name for a category \a category. It allows combining different
         /// backends for user preferences.
         ///
-        void select(const std::string& backend_name, locale_category_type category = all_categories);
+        void select(const std::string& backend_name, category_t category = all_categories);
 
         ///
         /// Set new global backend manager, the old one is returned.

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -202,12 +202,10 @@ namespace boost { namespace locale {
         /// of wide encoding type
         ///
         BOOST_LOCALE_DECL
-        std::locale
-        create_codecvt(const std::locale& in, std::unique_ptr<base_converter> cvt, character_facet_type type);
+        std::locale create_codecvt(const std::locale& in, std::unique_ptr<base_converter> cvt, char_facet_t type);
 
         BOOST_DEPRECATED("This function is deprecated, use 'create_codecvt()'")
-        inline std::locale
-        create_codecvt_from_pointer(const std::locale& in, base_converter* cvt, character_facet_type type)
+        inline std::locale create_codecvt_from_pointer(const std::locale& in, base_converter* cvt, char_facet_t type)
         {
             return create_codecvt(in, std::unique_ptr<base_converter>(cvt), type);
         }
@@ -231,7 +229,7 @@ namespace boost { namespace locale {
         /// new locale that is based on \a in and uses new facet.
         ///
         BOOST_LOCALE_DECL
-        std::locale create_utf8_codecvt(const std::locale& in, character_facet_type type);
+        std::locale create_utf8_codecvt(const std::locale& in, char_facet_t type);
 
         ///
         /// This function installs codecvt that can be used for conversion between single byte
@@ -240,8 +238,7 @@ namespace boost { namespace locale {
         /// Throws boost::locale::conv::invalid_charset_error if the chacater set is not supported or isn't single byte
         /// character set
         BOOST_LOCALE_DECL
-        std::locale
-        create_simple_codecvt(const std::locale& in, const std::string& encoding, character_facet_type type);
+        std::locale create_simple_codecvt(const std::locale& in, const std::string& encoding, char_facet_t type);
     } // namespace util
 }}    // namespace boost::locale
 

--- a/src/boost/locale/icu/all_generator.hpp
+++ b/src/boost/locale/icu/all_generator.hpp
@@ -11,13 +11,13 @@
 
 namespace boost { namespace locale { namespace impl_icu {
     struct cdata;
-    std::locale create_convert(const std::locale&, const cdata&, character_facet_type);                // ok
-    std::locale create_collate(const std::locale&, const cdata&, character_facet_type);                // ok
-    std::locale create_formatting(const std::locale&, const cdata&, character_facet_type);             // ok
-    std::locale create_parsing(const std::locale&, const cdata&, character_facet_type);                // ok
-    std::locale create_codecvt(const std::locale&, const std::string& encoding, character_facet_type); // ok
-    std::locale create_boundary(const std::locale&, const cdata&, character_facet_type);               // ok
-    std::locale create_calendar(const std::locale&, const cdata&);                                     // ok
+    std::locale create_convert(const std::locale&, const cdata&, char_facet_t);                // ok
+    std::locale create_collate(const std::locale&, const cdata&, char_facet_t);                // ok
+    std::locale create_formatting(const std::locale&, const cdata&, char_facet_t);             // ok
+    std::locale create_parsing(const std::locale&, const cdata&, char_facet_t);                // ok
+    std::locale create_codecvt(const std::locale&, const std::string& encoding, char_facet_t); // ok
+    std::locale create_boundary(const std::locale&, const cdata&, char_facet_t);               // ok
+    std::locale create_calendar(const std::locale&, const cdata&);                             // ok
 
 }}} // namespace boost::locale::impl_icu
 

--- a/src/boost/locale/icu/boundary.cpp
+++ b/src/boost/locale/icu/boundary.cpp
@@ -8,7 +8,6 @@
 #define BOOST_LOCALE_SOURCE
 #include <boost/locale/boundary.hpp>
 #include <boost/locale/generator.hpp>
-#include <boost/locale/hold_ptr.hpp>
 #include "boost/locale/icu/all_generator.hpp"
 #include "boost/locale/icu/cdata.hpp"
 #include "boost/locale/icu/icu_util.hpp"
@@ -16,6 +15,7 @@
 #if BOOST_LOCALE_ICU_VERSION >= 306
 #    include <unicode/utext.h>
 #endif
+#include <memory>
 #include <unicode/brkiter.h>
 #include <unicode/rbbi.h>
 #include <vector>
@@ -94,7 +94,7 @@ namespace boost { namespace locale {
                                 else if(UBRK_SENTENCE_SEP <= buf[i] && buf[i] < UBRK_SENTENCE_SEP_LIMIT)
                                     indx.back().rule |= sentence_sep;
                                 break;
-                            default:;
+                            case character: BOOST_UNREACHABLE_RETURN(0);
                         }
                     }
                 } else {
@@ -104,21 +104,20 @@ namespace boost { namespace locale {
             return indx;
         }
 
-        icu::BreakIterator* get_iterator(boundary_type t, const icu::Locale& loc)
+        std::unique_ptr<icu::BreakIterator> get_iterator(boundary_type t, const icu::Locale& loc)
         {
             UErrorCode err = U_ZERO_ERROR;
-            hold_ptr<icu::BreakIterator> bi;
+            std::unique_ptr<icu::BreakIterator> bi;
             switch(t) {
                 case character: bi.reset(icu::BreakIterator::createCharacterInstance(loc, err)); break;
                 case word: bi.reset(icu::BreakIterator::createWordInstance(loc, err)); break;
                 case sentence: bi.reset(icu::BreakIterator::createSentenceInstance(loc, err)); break;
                 case line: bi.reset(icu::BreakIterator::createLineInstance(loc, err)); break;
-                default: throw std::runtime_error("Invalid iteration type");
             }
             check_and_throw_icu_error(err);
-            if(!bi.get())
+            if(!bi)
                 throw std::runtime_error("Failed to create break iterator");
-            return bi.release();
+            return bi;
         }
 
         template<typename CharType>
@@ -129,7 +128,7 @@ namespace boost { namespace locale {
                           const std::string& encoding)
         {
             index_type indx;
-            hold_ptr<icu::BreakIterator> bi(get_iterator(t, loc));
+            std::unique_ptr<icu::BreakIterator> bi = get_iterator(t, loc);
 
 #if BOOST_LOCALE_ICU_VERSION >= 306
             UErrorCode err = U_ZERO_ERROR;
@@ -197,6 +196,7 @@ namespace boost { namespace locale {
         {
             using namespace boost::locale::boundary::impl_icu;
             switch(type) {
+                case char_facet_t::nochar: break;
                 case char_facet_t::char_f: return std::locale(in, new boundary_indexing_impl<char>(cd));
                 case char_facet_t::wchar_f: return std::locale(in, new boundary_indexing_impl<wchar_t>(cd));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -205,8 +205,8 @@ namespace boost { namespace locale {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
                 case char_facet_t::char32_f: return std::locale(in, new boundary_indexing_impl<char32_t>(cd));
 #endif
-                default: return in;
             }
+            return in;
         }
     } // namespace impl_icu
 

--- a/src/boost/locale/icu/boundary.cpp
+++ b/src/boost/locale/icu/boundary.cpp
@@ -193,17 +193,17 @@ namespace boost { namespace locale {
     }} // namespace boundary::impl_icu
 
     namespace impl_icu {
-        std::locale create_boundary(const std::locale& in, const cdata& cd, character_facet_type type)
+        std::locale create_boundary(const std::locale& in, const cdata& cd, char_facet_t type)
         {
             using namespace boost::locale::boundary::impl_icu;
             switch(type) {
-                case char_facet: return std::locale(in, new boundary_indexing_impl<char>(cd));
-                case wchar_t_facet: return std::locale(in, new boundary_indexing_impl<wchar_t>(cd));
+                case char_facet_t::char_f: return std::locale(in, new boundary_indexing_impl<char>(cd));
+                case char_facet_t::wchar_f: return std::locale(in, new boundary_indexing_impl<wchar_t>(cd));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                case char16_t_facet: return std::locale(in, new boundary_indexing_impl<char16_t>(cd));
+                case char_facet_t::char16_f: return std::locale(in, new boundary_indexing_impl<char16_t>(cd));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                case char32_t_facet: return std::locale(in, new boundary_indexing_impl<char32_t>(cd));
+                case char_facet_t::char32_f: return std::locale(in, new boundary_indexing_impl<char32_t>(cd));
 #endif
                 default: return in;
             }

--- a/src/boost/locale/icu/codecvt.cpp
+++ b/src/boost/locale/icu/codecvt.cpp
@@ -108,7 +108,7 @@ namespace boost { namespace locale { namespace impl_icu {
         }
     }
 
-    std::locale create_codecvt(const std::locale& in, const std::string& encoding, character_facet_type type)
+    std::locale create_codecvt(const std::locale& in, const std::string& encoding, char_facet_t type)
     {
         if(conv::impl::normalize_encoding(encoding.c_str()) == "utf8")
             return util::create_utf8_codecvt(in, type);

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -177,6 +177,7 @@ namespace boost { namespace locale { namespace impl_icu {
     std::locale create_collate(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new collate_impl<char>(cd));
             case char_facet_t::wchar_f: return std::locale(in, new collate_impl<wchar_t>(cd));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -185,8 +186,8 @@ namespace boost { namespace locale { namespace impl_icu {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new collate_impl<char32_t>(cd));
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_icu

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -174,16 +174,16 @@ namespace boost { namespace locale { namespace impl_icu {
     }
 #endif
 
-    std::locale create_collate(const std::locale& in, const cdata& cd, character_facet_type type)
+    std::locale create_collate(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return std::locale(in, new collate_impl<char>(cd));
-            case wchar_t_facet: return std::locale(in, new collate_impl<wchar_t>(cd));
+            case char_facet_t::char_f: return std::locale(in, new collate_impl<char>(cd));
+            case char_facet_t::wchar_f: return std::locale(in, new collate_impl<wchar_t>(cd));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: return std::locale(in, new collate_impl<char16_t>(cd));
+            case char_facet_t::char16_f: return std::locale(in, new collate_impl<char16_t>(cd));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: return std::locale(in, new collate_impl<char32_t>(cd));
+            case char_facet_t::char32_f: return std::locale(in, new collate_impl<char32_t>(cd));
 #endif
             default: return in;
         }

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -32,18 +32,18 @@ namespace boost { namespace locale { namespace impl_icu {
     template<typename CharType>
     class collate_impl : public collator<CharType> {
     public:
-        typedef typename collator<CharType>::level_type level_type;
-        level_type limit(level_type level) const
+        int level_to_int(collate_level level) const
         {
-            if(level < 0)
-                level = collator_base::primary;
-            else if(level >= level_count)
-                level = static_cast<level_type>(level_count - 1);
-            return level;
+            const auto res = static_cast<int>(level);
+            if(res < 0)
+                return 0;
+            if(res >= level_count)
+                return level_count - 1;
+            return res;
         }
 
 #if BOOST_LOCALE_WITH_STRINGPIECE
-        int do_utf8_compare(level_type level,
+        int do_utf8_compare(collate_level level,
                             const char* b1,
                             const char* e1,
                             const char* b2,
@@ -56,7 +56,7 @@ namespace boost { namespace locale { namespace impl_icu {
         }
 #endif
 
-        int do_ustring_compare(level_type level,
+        int do_ustring_compare(collate_level level,
                                const CharType* b1,
                                const CharType* e1,
                                const CharType* b2,
@@ -68,7 +68,7 @@ namespace boost { namespace locale { namespace impl_icu {
             return get_collator(level)->compare(left, right, status);
         }
 
-        int do_real_compare(level_type level,
+        int do_real_compare(collate_level level,
                             const CharType* b1,
                             const CharType* e1,
                             const CharType* b2,
@@ -78,7 +78,7 @@ namespace boost { namespace locale { namespace impl_icu {
             return do_ustring_compare(level, b1, e1, b2, e2, status);
         }
 
-        int do_compare(level_type level,
+        int do_compare(collate_level level,
                        const CharType* b1,
                        const CharType* e1,
                        const CharType* b2,
@@ -97,7 +97,7 @@ namespace boost { namespace locale { namespace impl_icu {
             return 0;
         }
 
-        std::vector<uint8_t> do_basic_transform(level_type level, const CharType* b, const CharType* e) const
+        std::vector<uint8_t> do_basic_transform(collate_level level, const CharType* b, const CharType* e) const
         {
             icu::UnicodeString str = cvt_.icu(b, e);
             std::vector<uint8_t> tmp;
@@ -111,13 +111,14 @@ namespace boost { namespace locale { namespace impl_icu {
                 tmp.resize(len);
             return tmp;
         }
-        std::basic_string<CharType> do_transform(level_type level, const CharType* b, const CharType* e) const override
+        std::basic_string<CharType>
+        do_transform(collate_level level, const CharType* b, const CharType* e) const override
         {
             std::vector<uint8_t> tmp = do_basic_transform(level, b, e);
             return std::basic_string<CharType>(tmp.begin(), tmp.end());
         }
 
-        long do_hash(level_type level, const CharType* b, const CharType* e) const override
+        long do_hash(collate_level level, const CharType* b, const CharType* e) const override
         {
             std::vector<uint8_t> tmp = do_basic_transform(level, b, e);
             tmp.push_back(0);
@@ -126,32 +127,32 @@ namespace boost { namespace locale { namespace impl_icu {
 
         collate_impl(const cdata& d) : cvt_(d.encoding), locale_(d.locale), is_utf8_(d.utf8) {}
 
-        icu::Collator* get_collator(level_type ilevel) const
+        icu::Collator* get_collator(collate_level level) const
         {
-            int l = limit(ilevel);
+            const int lvl_idx = level_to_int(level);
             constexpr icu::Collator::ECollationStrength levels[level_count] = {icu::Collator::PRIMARY,
                                                                                icu::Collator::SECONDARY,
                                                                                icu::Collator::TERTIARY,
                                                                                icu::Collator::QUATERNARY,
                                                                                icu::Collator::IDENTICAL};
 
-            icu::Collator* col = collates_[l].get();
+            icu::Collator* col = collates_[lvl_idx].get();
             if(col)
                 return col;
 
             UErrorCode status = U_ZERO_ERROR;
 
-            collates_[l].reset(icu::Collator::createInstance(locale_, status));
+            collates_[lvl_idx].reset(icu::Collator::createInstance(locale_, status));
 
             if(U_FAILURE(status))
                 throw std::runtime_error(std::string("Creation of collate failed:") + u_errorName(status));
 
-            collates_[l]->setStrength(levels[l]);
-            return collates_[l].get();
+            collates_[lvl_idx]->setStrength(levels[lvl_idx]);
+            return collates_[lvl_idx].get();
         }
 
     private:
-        static constexpr int level_count = 5;
+        static constexpr int level_count = static_cast<int>(collate_level::identical) + 1;
         icu_std_converter<CharType> cvt_;
         icu::Locale locale_;
         mutable boost::thread_specific_ptr<icu::Collator> collates_[level_count];
@@ -160,7 +161,7 @@ namespace boost { namespace locale { namespace impl_icu {
 
 #if BOOST_LOCALE_WITH_STRINGPIECE
     template<>
-    int collate_impl<char>::do_real_compare(level_type level,
+    int collate_impl<char>::do_real_compare(collate_level level,
                                             const char* b1,
                                             const char* e1,
                                             const char* b2,

--- a/src/boost/locale/icu/conversion.cpp
+++ b/src/boost/locale/icu/conversion.cpp
@@ -165,21 +165,21 @@ namespace boost { namespace locale { namespace impl_icu {
 
 #endif // BOOST_LOCALE_WITH_CASEMAP
 
-    std::locale create_convert(const std::locale& in, const cdata& cd, character_facet_type type)
+    std::locale create_convert(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
-            case char_facet:
+            case char_facet_t::char_f:
 #ifdef BOOST_LOCALE_WITH_CASEMAP
                 if(cd.utf8)
                     return std::locale(in, new utf8_converter_impl(cd));
 #endif
                 return std::locale(in, new converter_impl<char>(cd));
-            case wchar_t_facet: return std::locale(in, new converter_impl<wchar_t>(cd));
+            case char_facet_t::wchar_f: return std::locale(in, new converter_impl<wchar_t>(cd));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: return std::locale(in, new converter_impl<char16_t>(cd));
+            case char_facet_t::char16_f: return std::locale(in, new converter_impl<char16_t>(cd));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: return std::locale(in, new converter_impl<char32_t>(cd));
+            case char_facet_t::char32_f: return std::locale(in, new converter_impl<char32_t>(cd));
 #endif
             default: return in;
         }

--- a/src/boost/locale/icu/conversion.cpp
+++ b/src/boost/locale/icu/conversion.cpp
@@ -63,7 +63,6 @@ namespace boost { namespace locale { namespace impl_icu {
                 case converter_base::lower_case: str.toLower(locale_); break;
                 case converter_base::title_case: str.toTitle(0, locale_); break;
                 case converter_base::case_folding: str.foldCase(); break;
-                default:;
             }
             return cvt.std(str);
         }
@@ -138,13 +137,6 @@ namespace boost { namespace locale { namespace impl_icu {
         std::string
         convert(converter_base::conversion_type how, const char* begin, const char* end, int flags = 0) const override
         {
-            if(how == converter_base::normalization) {
-                icu_std_converter<char> cvt("UTF-8");
-                icu::UnicodeString str = cvt.icu(begin, end);
-                normalize_string(str, flags);
-                return cvt.std(str);
-            }
-
             switch(how) {
                 case converter_base::upper_case: return map_.convert(ucasemap_utf8ToUpper, begin, end);
                 case converter_base::lower_case: return map_.convert(ucasemap_utf8ToLower, begin, end);
@@ -154,8 +146,14 @@ namespace boost { namespace locale { namespace impl_icu {
                     return map.convert(ucasemap_utf8ToTitle, begin, end);
                 }
                 case converter_base::case_folding: return map_.convert(ucasemap_utf8FoldCase, begin, end);
-                default: return std::string(begin, end - begin);
+                case converter_base::normalization: {
+                    icu_std_converter<char> cvt("UTF-8");
+                    icu::UnicodeString str = cvt.icu(begin, end);
+                    normalize_string(str, flags);
+                    return cvt.std(str);
+                }
             }
+            return std::string(begin, end - begin);
         }
 
     private:
@@ -168,6 +166,7 @@ namespace boost { namespace locale { namespace impl_icu {
     std::locale create_convert(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f:
 #ifdef BOOST_LOCALE_WITH_CASEMAP
                 if(cd.utf8)
@@ -181,8 +180,8 @@ namespace boost { namespace locale { namespace impl_icu {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new converter_impl<char32_t>(cd));
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_icu

--- a/src/boost/locale/icu/date_time.cpp
+++ b/src/boost/locale/icu/date_time.cpp
@@ -53,8 +53,10 @@ namespace boost { namespace locale { namespace impl_icu {
             case second: return UCAL_SECOND;
             case week_of_year: return UCAL_WEEK_OF_YEAR;
             case week_of_month: return UCAL_WEEK_OF_MONTH;
-            default: throw std::invalid_argument("Invalid date_time period type");
+            case first_day_of_week:
+            case invalid: break;
         }
+        throw std::invalid_argument("Invalid date_time period type");
     }
 
     class calendar_impl : public abstract_calendar {
@@ -151,7 +153,6 @@ namespace boost { namespace locale { namespace impl_icu {
             switch(opt) {
                 case is_gregorian: throw date_time_error("is_gregorian is not settable options for calendar");
                 case is_dst: throw date_time_error("is_dst is not settable options for calendar");
-                default:;
             }
         }
         int get_option(calendar_option_type opt) const override
@@ -165,8 +166,8 @@ namespace boost { namespace locale { namespace impl_icu {
                     check_and_throw_dt(err);
                     return res;
                 }
-                default: return 0;
             }
+            return 0;
         }
         void adjust_value(period::marks::period_mark p, update_type u, int difference) override
         {

--- a/src/boost/locale/icu/formatter.cpp
+++ b/src/boost/locale/icu/formatter.cpp
@@ -16,6 +16,7 @@
 #include "boost/locale/icu/uconv.hpp"
 #include <boost/core/ignore_unused.hpp>
 #include <limits>
+#include <memory>
 #include <unicode/datefmt.h>
 #include <unicode/decimfmt.h>
 #include <unicode/numfmt.h>

--- a/src/boost/locale/icu/icu_backend.cpp
+++ b/src/boost/locale/icu/icu_backend.cpp
@@ -91,6 +91,7 @@ namespace boost { namespace locale { namespace impl_icu {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
+                        case char_facet_t::nochar: break;
                         case char_facet_t::char_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
                         case char_facet_t::wchar_f:
@@ -103,14 +104,14 @@ namespace boost { namespace locale { namespace impl_icu {
                         case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
-                        default: return base;
                     }
+                    return base;
                 }
                 case category_t::boundary: return create_boundary(base, data_, type);
                 case category_t::calendar: return create_calendar(base, data_);
                 case category_t::information: return util::create_info(base, real_id_);
-                default: return base;
             }
+            return base;
         }
 
     private:

--- a/src/boost/locale/icu/icu_backend.cpp
+++ b/src/boost/locale/icu/icu_backend.cpp
@@ -70,19 +70,17 @@ namespace boost { namespace locale { namespace impl_icu {
             variant_ = d.variant;
         }
 
-        std::locale install(const std::locale& base,
-                            locale_category_type category,
-                            character_facet_type type = nochar_facet) override
+        std::locale install(const std::locale& base, category_t category, char_facet_t type) override
         {
             prepare_data();
 
             switch(category) {
-                case convert_facet: return create_convert(base, data_, type);
-                case collation_facet: return create_collate(base, data_, type);
-                case formatting_facet: return create_formatting(base, data_, type);
-                case parsing_facet: return create_parsing(base, data_, type);
-                case codepage_facet: return create_codecvt(base, data_.encoding, type);
-                case message_facet: {
+                case category_t::convert: return create_convert(base, data_, type);
+                case category_t::collation: return create_collate(base, data_, type);
+                case category_t::formatting: return create_formatting(base, data_, type);
+                case category_t::parsing: return create_parsing(base, data_, type);
+                case category_t::codepage: return create_codecvt(base, data_.encoding, type);
+                case category_t::message: {
                     gnu_gettext::messages_info minf;
                     minf.language = language_;
                     minf.country = country_;
@@ -93,22 +91,24 @@ namespace boost { namespace locale { namespace impl_icu {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
-                        case char_facet: return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
-                        case wchar_t_facet: return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
+                        case char_facet_t::char_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
+                        case char_facet_t::wchar_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                        case char16_t_facet:
+                        case char_facet_t::char16_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char16_t>(minf));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                        case char32_t_facet:
+                        case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
                         default: return base;
                     }
                 }
-                case boundary_facet: return create_boundary(base, data_, type);
-                case calendar_facet: return create_calendar(base, data_);
-                case information_facet: return util::create_info(base, real_id_);
+                case category_t::boundary: return create_boundary(base, data_, type);
+                case category_t::calendar: return create_calendar(base, data_);
+                case category_t::information: return util::create_info(base, real_id_);
                 default: return base;
             }
         }

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -336,31 +336,31 @@ namespace boost { namespace locale { namespace impl_icu {
         return tmp;
     }
 
-    std::locale create_formatting(const std::locale& in, const cdata& cd, character_facet_type type)
+    std::locale create_formatting(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return install_formatting_facets<char>(in, cd);
-            case wchar_t_facet: return install_formatting_facets<wchar_t>(in, cd);
+            case char_facet_t::char_f: return install_formatting_facets<char>(in, cd);
+            case char_facet_t::wchar_f: return install_formatting_facets<wchar_t>(in, cd);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: return install_formatting_facets<char16_t>(in, cd);
+            case char_facet_t::char16_f: return install_formatting_facets<char16_t>(in, cd);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: return install_formatting_facets<char32_t>(in, cd);
+            case char_facet_t::char32_f: return install_formatting_facets<char32_t>(in, cd);
 #endif
             default: return in;
         }
     }
 
-    std::locale create_parsing(const std::locale& in, const cdata& cd, character_facet_type type)
+    std::locale create_parsing(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return install_parsing_facets<char>(in, cd);
-            case wchar_t_facet: return install_parsing_facets<wchar_t>(in, cd);
+            case char_facet_t::char_f: return install_parsing_facets<char>(in, cd);
+            case char_facet_t::wchar_f: return install_parsing_facets<wchar_t>(in, cd);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: return install_parsing_facets<char16_t>(in, cd);
+            case char_facet_t::char16_f: return install_parsing_facets<char16_t>(in, cd);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: return install_parsing_facets<char32_t>(in, cd);
+            case char_facet_t::char32_f: return install_parsing_facets<char32_t>(in, cd);
 #endif
             default: return in;
         }

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -339,6 +339,7 @@ namespace boost { namespace locale { namespace impl_icu {
     std::locale create_formatting(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return install_formatting_facets<char>(in, cd);
             case char_facet_t::wchar_f: return install_formatting_facets<wchar_t>(in, cd);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -347,13 +348,14 @@ namespace boost { namespace locale { namespace impl_icu {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return install_formatting_facets<char32_t>(in, cd);
 #endif
-            default: return in;
         }
+        return in;
     }
 
     std::locale create_parsing(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return install_parsing_facets<char>(in, cd);
             case char_facet_t::wchar_f: return install_parsing_facets<wchar_t>(in, cd);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -362,8 +364,8 @@ namespace boost { namespace locale { namespace impl_icu {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return install_parsing_facets<char32_t>(in, cd);
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_icu

--- a/src/boost/locale/posix/all_generator.hpp
+++ b/src/boost/locale/posix/all_generator.hpp
@@ -18,14 +18,14 @@
 
 namespace boost { namespace locale { namespace impl_posix {
 
-    std::locale create_convert(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type);
+    std::locale create_convert(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type);
 
-    std::locale create_collate(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type);
+    std::locale create_collate(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type);
 
-    std::locale create_formatting(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type);
+    std::locale create_formatting(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type);
 
-    std::locale create_parsing(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type);
-    std::locale create_codecvt(const std::locale& in, const std::string& encoding, character_facet_type type);
+    std::locale create_parsing(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type);
+    std::locale create_codecvt(const std::locale& in, const std::string& encoding, char_facet_t type);
 
 }}} // namespace boost::locale::impl_posix
 

--- a/src/boost/locale/posix/codecvt.cpp
+++ b/src/boost/locale/posix/codecvt.cpp
@@ -198,7 +198,7 @@ namespace boost { namespace locale { namespace impl_posix {
     }
 #endif
 
-    std::locale create_codecvt(const std::locale& in, const std::string& encoding, character_facet_type type)
+    std::locale create_codecvt(const std::locale& in, const std::string& encoding, char_facet_t type)
     {
         if(conv::impl::normalize_encoding(encoding.c_str()) == "utf8")
             return util::create_utf8_codecvt(in, type);

--- a/src/boost/locale/posix/collate.cpp
+++ b/src/boost/locale/posix/collate.cpp
@@ -80,11 +80,17 @@ namespace boost { namespace locale { namespace impl_posix {
         std::shared_ptr<locale_t> lc_;
     };
 
-    std::locale create_collate(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type)
+    std::locale create_collate(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return std::locale(in, new collator<char>(std::move(lc)));
-            case wchar_t_facet: return std::locale(in, new collator<wchar_t>(std::move(lc)));
+            case char_facet_t::char_f: return std::locale(in, new collator<char>(std::move(lc)));
+            case char_facet_t::wchar_f: return std::locale(in, new collator<wchar_t>(std::move(lc)));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return std::locale(in, new collator<char16_t>(std::move(lc)));
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return std::locale(in, new collator<char32_t>(std::move(lc)));
+#endif
             default: return in;
         }
     }

--- a/src/boost/locale/posix/collate.cpp
+++ b/src/boost/locale/posix/collate.cpp
@@ -83,6 +83,7 @@ namespace boost { namespace locale { namespace impl_posix {
     std::locale create_collate(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new collator<char>(std::move(lc)));
             case char_facet_t::wchar_f: return std::locale(in, new collator<wchar_t>(std::move(lc)));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -91,8 +92,8 @@ namespace boost { namespace locale { namespace impl_posix {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new collator<char32_t>(std::move(lc)));
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_posix

--- a/src/boost/locale/posix/converter.cpp
+++ b/src/boost/locale/posix/converter.cpp
@@ -68,8 +68,10 @@ namespace boost { namespace locale { namespace impl_posix {
                     }
                     return res;
                 }
-                default: return string_type(begin, end - begin);
+                case converter_base::normalization:
+                case converter_base::title_case: break;
             }
+            return string_type(begin, end - begin);
         }
 
     private:
@@ -103,8 +105,10 @@ namespace boost { namespace locale { namespace impl_posix {
                         wres += towlower_l(tmp[i], *lc_);
                     return conv::from_utf<wchar_t>(wres, "UTF-8");
                 }
-                default: return std::string(begin, end - begin);
+                case normalization:
+                case title_case: break;
             }
+            return std::string(begin, end - begin);
         }
 
     private:
@@ -114,6 +118,7 @@ namespace boost { namespace locale { namespace impl_posix {
     std::locale create_convert(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: {
                 std::string encoding = nl_langinfo_l(CODESET, *lc);
                 for(unsigned i = 0; i < encoding.size(); i++)
@@ -131,8 +136,8 @@ namespace boost { namespace locale { namespace impl_posix {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new std_converter<char32_t>(std::move(lc)));
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_posix

--- a/src/boost/locale/posix/converter.cpp
+++ b/src/boost/locale/posix/converter.cpp
@@ -111,10 +111,10 @@ namespace boost { namespace locale { namespace impl_posix {
         std::shared_ptr<locale_t> lc_;
     };
 
-    std::locale create_convert(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type)
+    std::locale create_convert(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: {
+            case char_facet_t::char_f: {
                 std::string encoding = nl_langinfo_l(CODESET, *lc);
                 for(unsigned i = 0; i < encoding.size(); i++)
                     if('A' <= encoding[i] && encoding[i] <= 'Z')
@@ -124,7 +124,13 @@ namespace boost { namespace locale { namespace impl_posix {
                 }
                 return std::locale(in, new std_converter<char>(std::move(lc)));
             }
-            case wchar_t_facet: return std::locale(in, new std_converter<wchar_t>(std::move(lc)));
+            case char_facet_t::wchar_f: return std::locale(in, new std_converter<wchar_t>(std::move(lc)));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return std::locale(in, new std_converter<char16_t>(std::move(lc)));
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return std::locale(in, new std_converter<char32_t>(std::move(lc)));
+#endif
             default: return in;
         }
     }

--- a/src/boost/locale/posix/numeric.cpp
+++ b/src/boost/locale/posix/numeric.cpp
@@ -407,20 +407,32 @@ namespace boost { namespace locale { namespace impl_posix {
         return tmp;
     }
 
-    std::locale create_formatting(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type)
+    std::locale create_formatting(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return create_formatting_impl<char>(in, std::move(lc));
-            case wchar_t_facet: return create_formatting_impl<wchar_t>(in, std::move(lc));
+            case char_facet_t::char_f: return create_formatting_impl<char>(in, std::move(lc));
+            case char_facet_t::wchar_f: return create_formatting_impl<wchar_t>(in, std::move(lc));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return create_formatting_impl<char16_t>(in, lc);
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return create_formatting_impl<char32_t>(in, lc);
+#endif
             default: return in;
         }
     }
 
-    std::locale create_parsing(const std::locale& in, std::shared_ptr<locale_t> lc, character_facet_type type)
+    std::locale create_parsing(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return create_parsing_impl<char>(in, std::move(lc));
-            case wchar_t_facet: return create_parsing_impl<wchar_t>(in, std::move(lc));
+            case char_facet_t::char_f: return create_parsing_impl<char>(in, std::move(lc));
+            case char_facet_t::wchar_f: return create_parsing_impl<wchar_t>(in, std::move(lc));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return create_parsing_impl<char16_t>(in, lc);
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return create_parsing_impl<char32_t>(in, lc);
+#endif
             default: return in;
         }
     }

--- a/src/boost/locale/posix/numeric.cpp
+++ b/src/boost/locale/posix/numeric.cpp
@@ -410,6 +410,7 @@ namespace boost { namespace locale { namespace impl_posix {
     std::locale create_formatting(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return create_formatting_impl<char>(in, std::move(lc));
             case char_facet_t::wchar_f: return create_formatting_impl<wchar_t>(in, std::move(lc));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -418,13 +419,14 @@ namespace boost { namespace locale { namespace impl_posix {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return create_formatting_impl<char32_t>(in, lc);
 #endif
-            default: return in;
         }
+        return in;
     }
 
     std::locale create_parsing(const std::locale& in, std::shared_ptr<locale_t> lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return create_parsing_impl<char>(in, std::move(lc));
             case char_facet_t::wchar_f: return create_parsing_impl<wchar_t>(in, std::move(lc));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -433,8 +435,8 @@ namespace boost { namespace locale { namespace impl_posix {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return create_parsing_impl<char32_t>(in, lc);
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_posix

--- a/src/boost/locale/posix/posix_backend.cpp
+++ b/src/boost/locale/posix/posix_backend.cpp
@@ -117,6 +117,7 @@ namespace boost { namespace locale { namespace impl_posix {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
+                        case char_facet_t::nochar: break;
                         case char_facet_t::char_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
                         case char_facet_t::wchar_f:
@@ -129,12 +130,13 @@ namespace boost { namespace locale { namespace impl_posix {
                         case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
-                        default: return base;
                     }
+                    return base;
                 }
                 case category_t::information: return util::create_info(base, real_id_);
-                default: return base;
+                case category_t::boundary: break; // Not implemented
             }
+            return base;
         }
 
     private:

--- a/src/boost/locale/posix/posix_backend.cpp
+++ b/src/boost/locale/posix/posix_backend.cpp
@@ -89,24 +89,22 @@ namespace boost { namespace locale { namespace impl_posix {
             lc_ = std::shared_ptr<locale_t>(tmp_p, free_locale_by_ptr);
         }
 
-        std::locale install(const std::locale& base,
-                            locale_category_type category,
-                            character_facet_type type = nochar_facet) override
+        std::locale install(const std::locale& base, category_t category, char_facet_t type) override
         {
             prepare_data();
 
             switch(category) {
-                case convert_facet: return create_convert(base, lc_, type);
-                case collation_facet: return create_collate(base, lc_, type);
-                case formatting_facet: return create_formatting(base, lc_, type);
-                case parsing_facet: return create_parsing(base, lc_, type);
-                case codepage_facet: return create_codecvt(base, nl_langinfo_l(CODESET, *lc_), type);
-                case calendar_facet: {
+                case category_t::convert: return create_convert(base, lc_, type);
+                case category_t::collation: return create_collate(base, lc_, type);
+                case category_t::formatting: return create_formatting(base, lc_, type);
+                case category_t::parsing: return create_parsing(base, lc_, type);
+                case category_t::codepage: return create_codecvt(base, nl_langinfo_l(CODESET, *lc_), type);
+                case category_t::calendar: {
                     util::locale_data inf;
                     inf.parse(real_id_);
                     return util::install_gregorian_calendar(base, inf.country);
                 }
-                case message_facet: {
+                case category_t::message: {
                     gnu_gettext::messages_info minf;
                     util::locale_data inf;
                     inf.parse(real_id_);
@@ -119,20 +117,22 @@ namespace boost { namespace locale { namespace impl_posix {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
-                        case char_facet: return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
-                        case wchar_t_facet: return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
+                        case char_facet_t::char_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
+                        case char_facet_t::wchar_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                        case char16_t_facet:
+                        case char_facet_t::char16_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char16_t>(minf));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                        case char32_t_facet:
+                        case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
                         default: return base;
                     }
                 }
-                case information_facet: return util::create_info(base, real_id_);
+                case category_t::information: return util::create_info(base, real_id_);
                 default: return base;
             }
         }

--- a/src/boost/locale/shared/format.cpp
+++ b/src/boost/locale/shared/format.cpp
@@ -152,7 +152,7 @@ namespace boost { namespace locale { namespace detail {
 
             std::string encoding = std::use_facet<info>(d->saved_locale).encoding();
             generator gen;
-            gen.categories(formatting_facet);
+            gen.categories(category_t::formatting);
 
             std::locale new_loc;
             if(value.find('.') == std::string::npos)

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -67,16 +67,17 @@ namespace boost { namespace locale {
             }
         }
 
-        void select(const std::string& backend_name, locale_category_type category = all_categories)
+        void select(const std::string& backend_name, category_t category = all_categories)
         {
             unsigned id;
-            for(id = 0; id < all_backends_.size(); id++) {
+            for(id = 0; id < all_backends_.size(); ++id) {
                 if(all_backends_[id].first == backend_name)
                     break;
             }
             if(id == all_backends_.size())
                 return;
-            for(unsigned flag = 1, i = 0; i < default_backends_.size(); flag <<= 1, i++) {
+            category_t flag = category_first;
+            for(unsigned i = 0; i < default_backends_.size(); ++flag, ++i) {
                 if(category & flag) {
                     default_backends_[i] = id;
                 }
@@ -123,21 +124,14 @@ namespace boost { namespace locale {
                 for(unsigned i = 0; i < backends_.size(); i++)
                     backends_[i]->clear_options();
             }
-            std::locale install(const std::locale& l,
-                                locale_category_type category,
-                                character_facet_type type = nochar_facet) override
+            std::locale install(const std::locale& l, category_t category, char_facet_t type) override
             {
-                int id;
-                unsigned v;
-                for(v = 1, id = 0; v != 0; v <<= 1, id++) {
-                    if(category == v)
-                        break;
+                unsigned id = 0;
+                for(category_t v = category_first; v != category; ++v, ++id) {
+                    if(v == category_last)
+                        return l;
                 }
-                if(v == 0)
-                    return l;
-                if(unsigned(id) >= index_.size())
-                    return l;
-                if(index_[id] == -1)
+                if(id >= index_.size() || index_[id] == -1)
                     return l;
                 return backends_[index_[id]]->install(l, category, type);
             }
@@ -193,7 +187,7 @@ namespace boost { namespace locale {
     {
         return pimpl_->get_all_backends();
     }
-    void localization_backend_manager::select(const std::string& backend_name, locale_category_type category)
+    void localization_backend_manager::select(const std::string& backend_name, category_t category)
     {
         pimpl_->select(backend_name, category);
     }

--- a/src/boost/locale/std/all_generator.hpp
+++ b/src/boost/locale/std/all_generator.hpp
@@ -16,27 +16,27 @@ namespace boost { namespace locale { namespace impl_std {
 
     std::locale create_convert(const std::locale& in,
                                const std::string& locale_name,
-                               character_facet_type type,
+                               char_facet_t type,
                                utf8_support utf = utf8_none);
 
     std::locale create_collate(const std::locale& in,
                                const std::string& locale_name,
-                               character_facet_type type,
+                               char_facet_t type,
                                utf8_support utf = utf8_none);
 
     std::locale create_formatting(const std::locale& in,
                                   const std::string& locale_name,
-                                  character_facet_type type,
+                                  char_facet_t type,
                                   utf8_support utf = utf8_none);
 
     std::locale create_parsing(const std::locale& in,
                                const std::string& locale_name,
-                               character_facet_type type,
+                               char_facet_t type,
                                utf8_support utf = utf8_none);
 
     std::locale create_codecvt(const std::locale& in,
                                const std::string& locale_name,
-                               character_facet_type type,
+                               char_facet_t type,
                                utf8_support utf = utf8_none);
 
 }}} // namespace boost::locale::impl_std

--- a/src/boost/locale/std/codecvt.cpp
+++ b/src/boost/locale/std/codecvt.cpp
@@ -17,19 +17,19 @@ namespace boost { namespace locale { namespace impl_std {
     }
 
     std::locale
-    create_codecvt(const std::locale& in, const std::string& locale_name, character_facet_type type, utf8_support utf)
+    create_codecvt(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         if(utf == utf8_from_wide) {
             return util::create_utf8_codecvt(in, type);
         }
         switch(type) {
-            case char_facet: return codecvt_bychar<char>(in, locale_name);
-            case wchar_t_facet: return codecvt_bychar<wchar_t>(in, locale_name);
+            case char_facet_t::char_f: return codecvt_bychar<char>(in, locale_name);
+            case char_facet_t::wchar_f: return codecvt_bychar<wchar_t>(in, locale_name);
 #if defined(BOOST_LOCALE_ENABLE_CHAR16_T)
-            case char16_t_facet: return codecvt_bychar<char16_t>(in, locale_name);
+            case char_facet_t::char16_f: return codecvt_bychar<char16_t>(in, locale_name);
 #endif
 #if defined(BOOST_LOCALE_ENABLE_CHAR32_T)
-            case char32_t_facet: return codecvt_bychar<char32_t>(in, locale_name);
+            case char_facet_t::char32_f: return codecvt_bychar<char32_t>(in, locale_name);
 #endif
             default: return in;
         }

--- a/src/boost/locale/std/codecvt.cpp
+++ b/src/boost/locale/std/codecvt.cpp
@@ -23,6 +23,7 @@ namespace boost { namespace locale { namespace impl_std {
             return util::create_utf8_codecvt(in, type);
         }
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return codecvt_bychar<char>(in, locale_name);
             case char_facet_t::wchar_f: return codecvt_bychar<wchar_t>(in, locale_name);
 #if defined(BOOST_LOCALE_ENABLE_CHAR16_T)
@@ -31,8 +32,8 @@ namespace boost { namespace locale { namespace impl_std {
 #if defined(BOOST_LOCALE_ENABLE_CHAR32_T)
             case char_facet_t::char32_f: return codecvt_bychar<char32_t>(in, locale_name);
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_std

--- a/src/boost/locale/std/collate.cpp
+++ b/src/boost/locale/std/collate.cpp
@@ -66,6 +66,7 @@ namespace boost { namespace locale { namespace impl_std {
     create_collate(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: {
                 if(utf == utf8_from_wide) {
                     std::locale base =
@@ -85,8 +86,8 @@ namespace boost { namespace locale { namespace impl_std {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new std::collate_byname<char32_t>(locale_name.c_str()));
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_std

--- a/src/boost/locale/std/collate.cpp
+++ b/src/boost/locale/std/collate.cpp
@@ -63,10 +63,10 @@ namespace boost { namespace locale { namespace impl_std {
     };
 
     std::locale
-    create_collate(const std::locale& in, const std::string& locale_name, character_facet_type type, utf8_support utf)
+    create_collate(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
-            case char_facet: {
+            case char_facet_t::char_f: {
                 if(utf == utf8_from_wide) {
                     std::locale base =
                       std::locale(std::locale::classic(), new std::collate_byname<wchar_t>(locale_name.c_str()));
@@ -76,14 +76,14 @@ namespace boost { namespace locale { namespace impl_std {
                 }
             }
 
-            case wchar_t_facet: return std::locale(in, new std::collate_byname<wchar_t>(locale_name.c_str()));
+            case char_facet_t::wchar_f: return std::locale(in, new std::collate_byname<wchar_t>(locale_name.c_str()));
 
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: return std::locale(in, new std::collate_byname<char16_t>(locale_name.c_str()));
+            case char_facet_t::char16_f: return std::locale(in, new std::collate_byname<char16_t>(locale_name.c_str()));
 #endif
 
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: return std::locale(in, new std::collate_byname<char32_t>(locale_name.c_str()));
+            case char_facet_t::char32_f: return std::locale(in, new std::collate_byname<char32_t>(locale_name.c_str()));
 #endif
             default: return in;
         }

--- a/src/boost/locale/std/converter.cpp
+++ b/src/boost/locale/std/converter.cpp
@@ -49,8 +49,10 @@ namespace boost { namespace locale { namespace impl_std {
                         ct.tolower(lbegin, lbegin + len);
                     return string_type(lbegin, len);
                 }
-                default: return string_type(begin, end - begin);
+                case converter_base::normalization:
+                case converter_base::title_case: break;
             }
+            return string_type(begin, end - begin);
         }
 
     private:
@@ -83,8 +85,10 @@ namespace boost { namespace locale { namespace impl_std {
                         ct.tolower(lbegin, lbegin + len);
                     return conv::from_utf<wchar_t>(lbegin, lbegin + len, "UTF-8");
                 }
-                default: return std::string(begin, end - begin);
+                case title_case:
+                case normalization: break;
             }
+            return std::string(begin, end - begin);
         }
 
     private:
@@ -95,6 +99,7 @@ namespace boost { namespace locale { namespace impl_std {
     create_convert(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: {
                 if(utf == utf8_native_with_wide || utf == utf8_from_wide) {
                     std::locale base(std::locale::classic(), new std::ctype_byname<wchar_t>(locale_name.c_str()));
@@ -119,8 +124,8 @@ namespace boost { namespace locale { namespace impl_std {
                 return std::locale(in, new std_converter<char32_t>(base));
             }
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_std

--- a/src/boost/locale/std/converter.cpp
+++ b/src/boost/locale/std/converter.cpp
@@ -92,10 +92,10 @@ namespace boost { namespace locale { namespace impl_std {
     };
 
     std::locale
-    create_convert(const std::locale& in, const std::string& locale_name, character_facet_type type, utf8_support utf)
+    create_convert(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
-            case char_facet: {
+            case char_facet_t::char_f: {
                 if(utf == utf8_native_with_wide || utf == utf8_from_wide) {
                     std::locale base(std::locale::classic(), new std::ctype_byname<wchar_t>(locale_name.c_str()));
                     return std::locale(in, new utf8_converter(base));
@@ -103,18 +103,18 @@ namespace boost { namespace locale { namespace impl_std {
                 std::locale base(std::locale::classic(), new std::ctype_byname<char>(locale_name.c_str()));
                 return std::locale(in, new std_converter<char>(base));
             }
-            case wchar_t_facet: {
+            case char_facet_t::wchar_f: {
                 std::locale base(std::locale::classic(), new std::ctype_byname<wchar_t>(locale_name.c_str()));
                 return std::locale(in, new std_converter<wchar_t>(base));
             }
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: {
+            case char_facet_t::char16_f: {
                 std::locale base(std::locale::classic(), new std::ctype_byname<char16_t>(locale_name.c_str()));
                 return std::locale(in, new std_converter<char16_t>(base));
             }
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: {
+            case char_facet_t::char32_f: {
                 std::locale base(std::locale::classic(), new std::ctype_byname<char32_t>(locale_name.c_str()));
                 return std::locale(in, new std_converter<char32_t>(base));
             }

--- a/src/boost/locale/std/numeric.cpp
+++ b/src/boost/locale/std/numeric.cpp
@@ -254,6 +254,7 @@ namespace boost { namespace locale { namespace impl_std {
     create_formatting(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: {
                 if(utf == utf8_from_wide) {
                     std::locale base = std::locale(locale_name.c_str());
@@ -304,14 +305,15 @@ namespace boost { namespace locale { namespace impl_std {
                 return tmp;
             }
 #endif
-            default: return in;
         }
+        return in;
     }
 
     std::locale
     create_parsing(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: {
                 if(utf == utf8_from_wide) {
                     std::locale base = std::locale::classic();
@@ -361,8 +363,8 @@ namespace boost { namespace locale { namespace impl_std {
                 return tmp;
             }
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_std

--- a/src/boost/locale/std/numeric.cpp
+++ b/src/boost/locale/std/numeric.cpp
@@ -250,13 +250,11 @@ namespace boost { namespace locale { namespace impl_std {
         return tmp;
     }
 
-    std::locale create_formatting(const std::locale& in,
-                                  const std::string& locale_name,
-                                  character_facet_type type,
-                                  utf8_support utf)
+    std::locale
+    create_formatting(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
-            case char_facet: {
+            case char_facet_t::char_f: {
                 if(utf == utf8_from_wide) {
                     std::locale base = std::locale(locale_name.c_str());
 
@@ -287,20 +285,20 @@ namespace boost { namespace locale { namespace impl_std {
                     return tmp;
                 }
             }
-            case wchar_t_facet: {
+            case char_facet_t::wchar_f: {
                 std::locale tmp = create_basic_formatting<wchar_t>(in, locale_name);
                 tmp = std::locale(tmp, new util::base_num_format<wchar_t>());
                 return tmp;
             }
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: {
+            case char_facet_t::char16_f: {
                 std::locale tmp = create_basic_formatting<char16_t>(in, locale_name);
                 tmp = std::locale(tmp, new util::base_num_format<char16_t>());
                 return tmp;
             }
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: {
+            case char_facet_t::char32_f: {
                 std::locale tmp = create_basic_formatting<char32_t>(in, locale_name);
                 tmp = std::locale(tmp, new util::base_num_format<char32_t>());
                 return tmp;
@@ -311,10 +309,10 @@ namespace boost { namespace locale { namespace impl_std {
     }
 
     std::locale
-    create_parsing(const std::locale& in, const std::string& locale_name, character_facet_type type, utf8_support utf)
+    create_parsing(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
         switch(type) {
-            case char_facet: {
+            case char_facet_t::char_f: {
                 if(utf == utf8_from_wide) {
                     std::locale base = std::locale::classic();
 
@@ -344,20 +342,20 @@ namespace boost { namespace locale { namespace impl_std {
                     return tmp;
                 }
             }
-            case wchar_t_facet: {
+            case char_facet_t::wchar_f: {
                 std::locale tmp = create_basic_parsing<wchar_t>(in, locale_name);
                 tmp = std::locale(in, new util::base_num_parse<wchar_t>());
                 return tmp;
             }
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char16_t_facet: {
+            case char_facet_t::char16_f: {
                 std::locale tmp = create_basic_parsing<char16_t>(in, locale_name);
                 tmp = std::locale(in, new util::base_num_parse<char16_t>());
                 return tmp;
             }
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char32_t_facet: {
+            case char_facet_t::char32_f: {
                 std::locale tmp = create_basic_parsing<char32_t>(in, locale_name);
                 tmp = std::locale(in, new util::base_num_parse<char32_t>());
                 return tmp;

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -166,6 +166,7 @@ namespace boost { namespace locale { namespace impl_std {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
+                        case char_facet_t::nochar: break;
                         case char_facet_t::char_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
                         case char_facet_t::wchar_f:
@@ -178,12 +179,13 @@ namespace boost { namespace locale { namespace impl_std {
                         case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
-                        default: return base;
                     }
+                    return base;
                 }
                 case category_t::information: return util::create_info(base, in_use_id_);
-                default: return base;
+                case category_t::boundary: break; // Not implemented
             }
+            return base;
         }
 
     private:

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -144,20 +144,18 @@ namespace boost { namespace locale { namespace impl_std {
             }
         }
 
-        std::locale install(const std::locale& base,
-                            locale_category_type category,
-                            character_facet_type type = nochar_facet) override
+        std::locale install(const std::locale& base, category_t category, char_facet_t type) override
         {
             prepare_data();
 
             switch(category) {
-                case convert_facet: return create_convert(base, name_, type, utf_mode_);
-                case collation_facet: return create_collate(base, name_, type, utf_mode_);
-                case formatting_facet: return create_formatting(base, name_, type, utf_mode_);
-                case parsing_facet: return create_parsing(base, name_, type, utf_mode_);
-                case codepage_facet: return create_codecvt(base, name_, type, utf_mode_);
-                case calendar_facet: return util::install_gregorian_calendar(base, data_.country);
-                case message_facet: {
+                case category_t::convert: return create_convert(base, name_, type, utf_mode_);
+                case category_t::collation: return create_collate(base, name_, type, utf_mode_);
+                case category_t::formatting: return create_formatting(base, name_, type, utf_mode_);
+                case category_t::parsing: return create_parsing(base, name_, type, utf_mode_);
+                case category_t::codepage: return create_codecvt(base, name_, type, utf_mode_);
+                case category_t::calendar: return util::install_gregorian_calendar(base, data_.country);
+                case category_t::message: {
                     gnu_gettext::messages_info minf;
                     minf.language = data_.language;
                     minf.country = data_.country;
@@ -168,20 +166,22 @@ namespace boost { namespace locale { namespace impl_std {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
-                        case char_facet: return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
-                        case wchar_t_facet: return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
+                        case char_facet_t::char_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
+                        case char_facet_t::wchar_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                        case char16_t_facet:
+                        case char_facet_t::char16_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char16_t>(minf));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                        case char32_t_facet:
+                        case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
                         default: return base;
                     }
                 }
-                case information_facet: return util::create_info(base, in_use_id_);
+                case category_t::information: return util::create_info(base, in_use_id_);
                 default: return base;
             }
         }

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -267,6 +267,7 @@ namespace boost { namespace locale { namespace util {
         if(!cvt)
             cvt.reset(new base_converter());
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new code_converter<char>(std::move(cvt)));
             case char_facet_t::wchar_f: return std::locale(in, new code_converter<wchar_t>(std::move(cvt)));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -275,8 +276,8 @@ namespace boost { namespace locale { namespace util {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new code_converter<char32_t>(std::move(cvt)));
 #endif
-            default: return in;
         }
+        return in;
     }
 
     ///
@@ -286,6 +287,7 @@ namespace boost { namespace locale { namespace util {
     std::locale create_utf8_codecvt(const std::locale& in, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new utf8_codecvt<char>());
             case char_facet_t::wchar_f: return std::locale(in, new utf8_codecvt<wchar_t>());
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -294,8 +296,8 @@ namespace boost { namespace locale { namespace util {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new utf8_codecvt<char32_t>());
 #endif
-            default: return in;
         }
+        return in;
     }
 
     ///
@@ -310,6 +312,7 @@ namespace boost { namespace locale { namespace util {
             throw boost::locale::conv::invalid_charset_error("Invalid simple encoding " + encoding);
 
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new simple_codecvt<char>(encoding));
             case char_facet_t::wchar_f: return std::locale(in, new simple_codecvt<wchar_t>(encoding));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -318,8 +321,8 @@ namespace boost { namespace locale { namespace util {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return std::locale(in, new simple_codecvt<char32_t>(encoding));
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::util

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -262,18 +262,18 @@ namespace boost { namespace locale { namespace util {
         bool thread_safe_;
     };
 
-    std::locale create_codecvt(const std::locale& in, std::unique_ptr<base_converter> cvt, character_facet_type type)
+    std::locale create_codecvt(const std::locale& in, std::unique_ptr<base_converter> cvt, char_facet_t type)
     {
         if(!cvt)
             cvt.reset(new base_converter());
         switch(type) {
-            case char_facet: return std::locale(in, new code_converter<char>(std::move(cvt)));
-            case wchar_t_facet: return std::locale(in, new code_converter<wchar_t>(std::move(cvt)));
-#if defined(BOOST_LOCALE_ENABLE_CHAR16_T)
-            case char16_t_facet: return std::locale(in, new code_converter<char16_t>(std::move(cvt)));
+            case char_facet_t::char_f: return std::locale(in, new code_converter<char>(std::move(cvt)));
+            case char_facet_t::wchar_f: return std::locale(in, new code_converter<wchar_t>(std::move(cvt)));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return std::locale(in, new code_converter<char16_t>(std::move(cvt)));
 #endif
-#if defined(BOOST_LOCALE_ENABLE_CHAR32_T)
-            case char32_t_facet: return std::locale(in, new code_converter<char32_t>(std::move(cvt)));
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return std::locale(in, new code_converter<char32_t>(std::move(cvt)));
 #endif
             default: return in;
         }
@@ -283,16 +283,16 @@ namespace boost { namespace locale { namespace util {
     /// Install utf8 codecvt to UTF-16 or UTF-32 into locale \a in and return
     /// new locale that is based on \a in and uses new facet.
     ///
-    std::locale create_utf8_codecvt(const std::locale& in, character_facet_type type)
+    std::locale create_utf8_codecvt(const std::locale& in, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return std::locale(in, new utf8_codecvt<char>());
-            case wchar_t_facet: return std::locale(in, new utf8_codecvt<wchar_t>());
-#if defined(BOOST_LOCALE_ENABLE_CHAR16_T)
-            case char16_t_facet: return std::locale(in, new utf8_codecvt<char16_t>());
+            case char_facet_t::char_f: return std::locale(in, new utf8_codecvt<char>());
+            case char_facet_t::wchar_f: return std::locale(in, new utf8_codecvt<wchar_t>());
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return std::locale(in, new utf8_codecvt<char16_t>());
 #endif
-#if defined(BOOST_LOCALE_ENABLE_CHAR32_T)
-            case char32_t_facet: return std::locale(in, new utf8_codecvt<char32_t>());
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return std::locale(in, new utf8_codecvt<char32_t>());
 #endif
             default: return in;
         }
@@ -302,21 +302,21 @@ namespace boost { namespace locale { namespace util {
     /// This function installs codecvt that can be used for conversion between single byte
     /// character encodings like ISO-8859-1, koi8-r, windows-1255 and Unicode code points,
     ///
-    /// Throws invalid_charset_error if the chacater set is not supported or isn't single byte character
+    /// Throws invalid_charset_error if the character set is not supported or isn't single byte character
     /// set
-    std::locale create_simple_codecvt(const std::locale& in, const std::string& encoding, character_facet_type type)
+    std::locale create_simple_codecvt(const std::locale& in, const std::string& encoding, char_facet_t type)
     {
         if(!check_is_simple_encoding(encoding))
             throw boost::locale::conv::invalid_charset_error("Invalid simple encoding " + encoding);
 
         switch(type) {
-            case char_facet: return std::locale(in, new simple_codecvt<char>(encoding));
-            case wchar_t_facet: return std::locale(in, new simple_codecvt<wchar_t>(encoding));
-#if defined(BOOST_LOCALE_ENABLE_CHAR16_T)
-            case char16_t_facet: return std::locale(in, new simple_codecvt<char16_t>(encoding));
+            case char_facet_t::char_f: return std::locale(in, new simple_codecvt<char>(encoding));
+            case char_facet_t::wchar_f: return std::locale(in, new simple_codecvt<wchar_t>(encoding));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return std::locale(in, new simple_codecvt<char16_t>(encoding));
 #endif
-#if defined(BOOST_LOCALE_ENABLE_CHAR32_T)
-            case char32_t_facet: return std::locale(in, new simple_codecvt<char32_t>(encoding));
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return std::locale(in, new simple_codecvt<char32_t>(encoding));
 #endif
             default: return in;
         }

--- a/src/boost/locale/util/gregorian.cpp
+++ b/src/boost/locale/util/gregorian.cpp
@@ -202,7 +202,7 @@ namespace boost { namespace locale { namespace util {
                     tm_updated_.tm_mday += diff;
                 } break;
                 case period::marks::first_day_of_week: ///< For example Sunday in US, Monday in France
-                default: return;
+                case invalid: return;
             }
             normalized_ = false;
         }
@@ -477,9 +477,9 @@ namespace boost { namespace locale { namespace util {
                             }
                             return 5;
                         case current: return (tm_.tm_mday - 1) / 7 + 1;
-                        default:;
                     }
-                default:;
+                    break;
+                case invalid: BOOST_ASSERT_MSG(false, "Shouldn't use 'invalid' value."); break;
             }
             return 0;
         }
@@ -509,7 +509,6 @@ namespace boost { namespace locale { namespace util {
             switch(opt) {
                 case is_gregorian: throw date_time_error("is_gregorian is not settable options for calendar");
                 case is_dst: throw date_time_error("is_dst is not settable options for calendar");
-                default:;
             }
         }
         ///
@@ -520,8 +519,8 @@ namespace boost { namespace locale { namespace util {
             switch(opt) {
                 case is_gregorian: return 1;
                 case is_dst: return tm_.tm_isdst == 1;
-                default: return 0;
-            };
+            }
+            return 0;
         }
 
         ///
@@ -563,7 +562,9 @@ namespace boost { namespace locale { namespace util {
                         case day_of_week_in_month: ///< Original number of the day of the week in month.
                             tm_updated_.tm_mday += difference * 7;
                             break;
-                        default:; // Not all values are adjustable
+                        case era:
+                        case period::marks::first_day_of_week:
+                        case invalid: break; // Not adjustable and ignored
                     }
                     normalized_ = false;
                     normalize();
@@ -584,7 +585,6 @@ namespace boost { namespace locale { namespace util {
                     set_value(m, value + cur_min);
                     normalize();
                 }
-                default:;
             }
         }
 
@@ -652,8 +652,10 @@ namespace boost { namespace locale { namespace util {
                 case hour_12: return static_cast<int>((other->time_ - time_) / 3600);
                 case minute: return static_cast<int>((other->time_ - time_) / 60);
                 case second: return static_cast<int>(other->time_ - time_);
-                default: return 0;
-            };
+                case invalid:
+                case period::marks::first_day_of_week: break; // Not adjustable
+            }
+            return 0;
         }
 
         ///

--- a/src/boost/locale/util/info.cpp
+++ b/src/boost/locale/util/info.cpp
@@ -29,16 +29,16 @@ namespace boost { namespace locale { namespace util {
                 case variant_property: return d.variant;
                 case encoding_property: return d.encoding;
                 case name_property: return name_;
-                default: return "";
-            };
+            }
+            return "";
         }
 
         int get_integer_property(integer_property v) const override
         {
             switch(v) {
                 case utf8_property: return d.utf8;
-                default: return 0;
             }
+            return 0;
         }
 
     private:

--- a/src/boost/locale/util/numeric.hpp
+++ b/src/boost/locale/util/numeric.hpp
@@ -128,9 +128,9 @@ namespace boost { namespace locale { namespace util {
                 case flags::number:
                 case flags::percent:
                 case flags::spellout:
-                case flags::ordinal:
-                default: return super::do_put(out, ios, fill, val);
+                case flags::ordinal: break;
             }
+            return super::do_put(out, ios, fill, val);
         }
 
         virtual iter_type
@@ -358,9 +358,9 @@ namespace boost { namespace locale { namespace util {
                 case flags::number:
                 case flags::percent:
                 case flags::spellout:
-                case flags::ordinal:
-                default: return super::do_get(in, end, ios, err, val);
+                case flags::ordinal: break;
             }
+            return super::do_get(in, end, ios, err, val);
         }
 
         template<bool intl>

--- a/src/boost/locale/win32/all_generator.hpp
+++ b/src/boost/locale/win32/all_generator.hpp
@@ -14,15 +14,15 @@ namespace boost { namespace locale { namespace impl_win {
 
     class winlocale;
 
-    std::locale create_convert(const std::locale& in, const winlocale& lc, character_facet_type type);
+    std::locale create_convert(const std::locale& in, const winlocale& lc, char_facet_t type);
 
-    std::locale create_collate(const std::locale& in, const winlocale& lc, character_facet_type type);
+    std::locale create_collate(const std::locale& in, const winlocale& lc, char_facet_t type);
 
-    std::locale create_formatting(const std::locale& in, const winlocale& lc, character_facet_type type);
+    std::locale create_formatting(const std::locale& in, const winlocale& lc, char_facet_t type);
 
-    std::locale create_parsing(const std::locale& in, const winlocale& lc, character_facet_type type);
+    std::locale create_parsing(const std::locale& in, const winlocale& lc, char_facet_t type);
 
-    std::locale create_codecvt(const std::locale& in, character_facet_type type);
+    std::locale create_codecvt(const std::locale& in, char_facet_t type);
 
 }}} // namespace boost::locale::impl_win
 

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -42,8 +42,10 @@ namespace boost { namespace locale { namespace impl_win {
             case collator_base::primary: return NORM_IGNORESYMBOLS | NORM_IGNORECASE | NORM_IGNORENONSPACE;
             case collator_base::secondary: return NORM_IGNORESYMBOLS | NORM_IGNORECASE;
             case collator_base::tertiary: return NORM_IGNORESYMBOLS;
-            default: return 0;
+            case collator_base::quaternary:
+            case collator_base::identical: return 0;
         }
+        return 0;
     }
 
     class winlocale {
@@ -203,13 +205,12 @@ namespace boost { namespace locale { namespace impl_win {
     {
         // We use FoldString, under Vista it actually does normalization;
         // under XP and below it does something similar, half job, better then nothing
-        unsigned flags = 0;
+        unsigned flags = MAP_PRECOMPOSED;
         switch(norm) {
             case norm_nfd: flags = MAP_COMPOSITE; break;
             case norm_nfc: flags = MAP_PRECOMPOSED; break;
             case norm_nfkd: flags = MAP_FOLDCZONE; break;
             case norm_nfkc: flags = MAP_FOLDCZONE | MAP_COMPOSITE; break;
-            default: flags = MAP_PRECOMPOSED;
         }
 
         if(end - begin > std::numeric_limits<int>::max())

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -36,14 +36,14 @@ namespace boost { namespace locale { namespace impl_win {
         std::string grouping;
     };
 
-    inline DWORD collation_level_to_flag(collator_base::level_type level)
+    inline DWORD collation_level_to_flag(collate_level level)
     {
         switch(level) {
-            case collator_base::primary: return NORM_IGNORESYMBOLS | NORM_IGNORECASE | NORM_IGNORENONSPACE;
-            case collator_base::secondary: return NORM_IGNORESYMBOLS | NORM_IGNORECASE;
-            case collator_base::tertiary: return NORM_IGNORESYMBOLS;
-            case collator_base::quaternary:
-            case collator_base::identical: return 0;
+            case collate_level::primary: return NORM_IGNORESYMBOLS | NORM_IGNORECASE | NORM_IGNORENONSPACE;
+            case collate_level::secondary: return NORM_IGNORESYMBOLS | NORM_IGNORECASE;
+            case collate_level::tertiary: return NORM_IGNORESYMBOLS;
+            case collate_level::quaternary:
+            case collate_level::identical: return 0;
         }
         return 0;
     }
@@ -135,7 +135,7 @@ namespace boost { namespace locale { namespace impl_win {
     ///
     ////////////////////////////////////////////////////////////////////////
 
-    inline int wcscoll_l(collator_base::level_type level,
+    inline int wcscoll_l(collate_level level,
                          const wchar_t* lb,
                          const wchar_t* le,
                          const wchar_t* rb,
@@ -225,8 +225,7 @@ namespace boost { namespace locale { namespace impl_win {
         return std::wstring(&v.front(), len);
     }
 
-    inline std::wstring
-    wcsxfrm_l(collator_base::level_type level, const wchar_t* begin, const wchar_t* end, const winlocale& l)
+    inline std::wstring wcsxfrm_l(collate_level level, const wchar_t* begin, const wchar_t* end, const winlocale& l)
     {
         int flag = LCMAP_SORTKEY | collation_level_to_flag(level);
 

--- a/src/boost/locale/win32/collate.cpp
+++ b/src/boost/locale/win32/collate.cpp
@@ -92,17 +92,23 @@ namespace boost { namespace locale { namespace impl_win {
         winlocale lc_;
     };
 
-    std::locale create_collate(const std::locale& in, const winlocale& lc, character_facet_type type)
+    std::locale create_collate(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         if(lc.is_c()) {
             switch(type) {
-                case char_facet: return std::locale(in, new std::collate_byname<char>("C"));
-                case wchar_t_facet: return std::locale(in, new std::collate_byname<wchar_t>("C"));
+                case char_facet_t::char_f: return std::locale(in, new std::collate_byname<char>("C"));
+                case char_facet_t::wchar_f: return std::locale(in, new std::collate_byname<wchar_t>("C"));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+                case char_facet_t::char16_f: return std::locale(in, new collate_byname<char16_t>("C"));
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+                case char_facet_t::char32_f: return std::locale(in, new collate_byname<char32_t>("C"));
+#endif
             }
         } else {
             switch(type) {
-                case char_facet: return std::locale(in, new utf8_collator(lc));
-                case wchar_t_facet: return std::locale(in, new utf16_collator(lc));
+                case char_facet_t::char_f: return std::locale(in, new utf8_collator(lc));
+                case char_facet_t::wchar_f: return std::locale(in, new utf16_collator(lc));
             }
         }
         return in;

--- a/src/boost/locale/win32/collate.cpp
+++ b/src/boost/locale/win32/collate.cpp
@@ -18,22 +18,19 @@ namespace boost { namespace locale { namespace impl_win {
     class utf8_collator : public collator<char> {
     public:
         utf8_collator(winlocale lc, size_t refs = 0) : collator<char>(refs), lc_(lc) {}
-        int do_compare(collator_base::level_type level,
-                       const char* lb,
-                       const char* le,
-                       const char* rb,
-                       const char* re) const override
+        int
+        do_compare(collate_level level, const char* lb, const char* le, const char* rb, const char* re) const override
         {
             std::wstring l = conv::to_utf<wchar_t>(lb, le, "UTF-8");
             std::wstring r = conv::to_utf<wchar_t>(rb, re, "UTF-8");
             return wcscoll_l(level, l.c_str(), l.c_str() + l.size(), r.c_str(), r.c_str() + r.size(), lc_);
         }
-        long do_hash(collator_base::level_type level, const char* b, const char* e) const override
+        long do_hash(collate_level level, const char* b, const char* e) const override
         {
             std::string key = do_transform(level, b, e);
             return gnu_gettext::pj_winberger_hash_function(key.c_str(), key.c_str() + key.size());
         }
-        std::string do_transform(collator_base::level_type level, const char* b, const char* e) const override
+        std::string do_transform(collate_level level, const char* b, const char* e) const override
         {
             std::wstring tmp = conv::to_utf<wchar_t>(b, e, "UTF-8");
             std::wstring wkey = wcsxfrm_l(level, tmp.c_str(), tmp.c_str() + tmp.size(), lc_);
@@ -68,7 +65,7 @@ namespace boost { namespace locale { namespace impl_win {
     public:
         typedef std::collate<wchar_t> wfacet;
         utf16_collator(winlocale lc, size_t refs = 0) : collator<wchar_t>(refs), lc_(lc) {}
-        int do_compare(collator_base::level_type level,
+        int do_compare(collate_level level,
                        const wchar_t* lb,
                        const wchar_t* le,
                        const wchar_t* rb,
@@ -76,14 +73,14 @@ namespace boost { namespace locale { namespace impl_win {
         {
             return wcscoll_l(level, lb, le, rb, re, lc_);
         }
-        long do_hash(collator_base::level_type level, const wchar_t* b, const wchar_t* e) const override
+        long do_hash(collate_level level, const wchar_t* b, const wchar_t* e) const override
         {
             std::wstring key = do_transform(level, b, e);
             const char* begin = reinterpret_cast<const char*>(key.c_str());
             const char* end = begin + key.size() * sizeof(wchar_t);
             return gnu_gettext::pj_winberger_hash_function(begin, end);
         }
-        std::wstring do_transform(collator_base::level_type level, const wchar_t* b, const wchar_t* e) const override
+        std::wstring do_transform(collate_level level, const wchar_t* b, const wchar_t* e) const override
         {
             return wcsxfrm_l(level, b, e, lc_);
         }

--- a/src/boost/locale/win32/collate.cpp
+++ b/src/boost/locale/win32/collate.cpp
@@ -96,6 +96,7 @@ namespace boost { namespace locale { namespace impl_win {
     {
         if(lc.is_c()) {
             switch(type) {
+                case char_facet_t::nochar: break;
                 case char_facet_t::char_f: return std::locale(in, new std::collate_byname<char>("C"));
                 case char_facet_t::wchar_f: return std::locale(in, new std::collate_byname<wchar_t>("C"));
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -107,8 +108,15 @@ namespace boost { namespace locale { namespace impl_win {
             }
         } else {
             switch(type) {
+                case char_facet_t::nochar: break;
                 case char_facet_t::char_f: return std::locale(in, new utf8_collator(lc));
                 case char_facet_t::wchar_f: return std::locale(in, new utf16_collator(lc));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+                case char_facet_t::char16_f: break;
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+                case char_facet_t::char32_f: break;
+#endif
             }
         }
         return in;

--- a/src/boost/locale/win32/converter.cpp
+++ b/src/boost/locale/win32/converter.cpp
@@ -64,11 +64,11 @@ namespace boost { namespace locale { namespace impl_win {
         winlocale lc_;
     };
 
-    std::locale create_convert(const std::locale& in, const winlocale& lc, character_facet_type type)
+    std::locale create_convert(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return std::locale(in, new utf8_converter(lc));
-            case wchar_t_facet: return std::locale(in, new utf16_converter(lc));
+            case char_facet_t::char_f: return std::locale(in, new utf8_converter(lc));
+            case char_facet_t::wchar_f: return std::locale(in, new utf16_converter(lc));
             default: return in;
         }
     }

--- a/src/boost/locale/win32/converter.cpp
+++ b/src/boost/locale/win32/converter.cpp
@@ -30,8 +30,9 @@ namespace boost { namespace locale { namespace impl_win {
                 case converter_base::lower_case: return towlower_l(begin, end, lc_);
                 case converter_base::case_folding: return wcsfold(begin, end);
                 case converter_base::normalization: return wcsnormalize(static_cast<norm_type>(flags), begin, end);
-                default: return std::wstring(begin, end - begin);
+                case converter_base::title_case: break;
             }
+            return std::wstring(begin, end - begin);
         }
 
     private:
@@ -55,7 +56,7 @@ namespace boost { namespace locale { namespace impl_win {
                 case lower_case: res = towlower_l(wb, we, lc_); break;
                 case case_folding: res = wcsfold(wb, we); break;
                 case normalization: res = wcsnormalize(static_cast<norm_type>(flags), wb, we); break;
-                default: res = tmp; // make gcc happy
+                case title_case: break;
             }
             return conv::from_utf(res, "UTF-8");
         }
@@ -67,10 +68,17 @@ namespace boost { namespace locale { namespace impl_win {
     std::locale create_convert(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new utf8_converter(lc));
             case char_facet_t::wchar_f: return std::locale(in, new utf16_converter(lc));
-            default: return in;
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: break;
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: break;
+#endif
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_win

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -179,6 +179,7 @@ namespace boost { namespace locale { namespace impl_win {
     std::locale create_formatting(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return create_formatting_impl<char>(in, lc);
             case char_facet_t::wchar_f: return create_formatting_impl<wchar_t>(in, lc);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -187,13 +188,14 @@ namespace boost { namespace locale { namespace impl_win {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return create_formatting_impl<char32_t>(in, lc);
 #endif
-            default: return in;
         }
+        return in;
     }
 
     std::locale create_parsing(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         switch(type) {
+            case char_facet_t::nochar: break;
             case char_facet_t::char_f: return create_parsing_impl<char>(in, lc);
             case char_facet_t::wchar_f: return create_parsing_impl<wchar_t>(in, lc);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -202,8 +204,8 @@ namespace boost { namespace locale { namespace impl_win {
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
             case char_facet_t::char32_f: return create_parsing_impl<char32_t>(in, lc);
 #endif
-            default: return in;
         }
+        return in;
     }
 
 }}} // namespace boost::locale::impl_win

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -176,20 +176,32 @@ namespace boost { namespace locale { namespace impl_win {
         return tmp;
     }
 
-    std::locale create_formatting(const std::locale& in, const winlocale& lc, character_facet_type type)
+    std::locale create_formatting(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return create_formatting_impl<char>(in, lc);
-            case wchar_t_facet: return create_formatting_impl<wchar_t>(in, lc);
+            case char_facet_t::char_f: return create_formatting_impl<char>(in, lc);
+            case char_facet_t::wchar_f: return create_formatting_impl<wchar_t>(in, lc);
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return create_formatting_impl<char16_t>(in, lc);
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return create_formatting_impl<char32_t>(in, lc);
+#endif
             default: return in;
         }
     }
 
-    std::locale create_parsing(const std::locale& in, const winlocale& lc, character_facet_type type)
+    std::locale create_parsing(const std::locale& in, const winlocale& lc, char_facet_t type)
     {
         switch(type) {
-            case char_facet: return create_parsing_impl<char>(in, lc);
-            case wchar_t_facet: return create_parsing_impl<wchar_t>(in, lc);
+            case char_facet_t::char_f: return create_parsing_impl<char>(in, lc);
+            case char_facet_t::wchar_f: return create_parsing_impl<wchar_t>(in, lc);
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+            case char_facet_t::char16_f: return create_parsing_impl<char16_t>(in, lc);
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+            case char_facet_t::char32_f: return create_parsing_impl<char32_t>(in, lc);
+#endif
             default: return in;
         }
     }

--- a/src/boost/locale/win32/win_backend.cpp
+++ b/src/boost/locale/win32/win_backend.cpp
@@ -94,6 +94,7 @@ namespace boost { namespace locale { namespace impl_win {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
+                        case char_facet_t::nochar: break;
                         case char_facet_t::char_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
                         case char_facet_t::wchar_f:
@@ -106,13 +107,14 @@ namespace boost { namespace locale { namespace impl_win {
                         case char_facet_t::char32_f:
                             return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
 #endif
-                        default: return base;
                     }
+                    return base;
                 }
                 case category_t::information: return util::create_info(base, real_id_);
                 case category_t::codepage: return util::create_utf8_codecvt(base, type);
-                default: return base;
+                case category_t::boundary: break; // Not implemented
             }
+            return base;
         }
 
     private:

--- a/src/boost/locale/win32/win_backend.cpp
+++ b/src/boost/locale/win32/win_backend.cpp
@@ -67,23 +67,21 @@ namespace boost { namespace locale { namespace impl_win {
             }
         }
 
-        std::locale install(const std::locale& base,
-                            locale_category_type category,
-                            character_facet_type type = nochar_facet) override
+        std::locale install(const std::locale& base, category_t category, char_facet_t type) override
         {
             prepare_data();
 
             switch(category) {
-                case convert_facet: return create_convert(base, lc_, type);
-                case collation_facet: return create_collate(base, lc_, type);
-                case formatting_facet: return create_formatting(base, lc_, type);
-                case parsing_facet: return create_parsing(base, lc_, type);
-                case calendar_facet: {
+                case category_t::convert: return create_convert(base, lc_, type);
+                case category_t::collation: return create_collate(base, lc_, type);
+                case category_t::formatting: return create_formatting(base, lc_, type);
+                case category_t::parsing: return create_parsing(base, lc_, type);
+                case category_t::calendar: {
                     util::locale_data inf;
                     inf.parse(real_id_);
                     return util::install_gregorian_calendar(base, inf.country);
                 }
-                case message_facet: {
+                case category_t::message: {
                     gnu_gettext::messages_info minf;
                     std::locale tmp = util::create_info(std::locale::classic(), real_id_);
                     const boost::locale::info& inf = std::use_facet<boost::locale::info>(tmp);
@@ -96,13 +94,23 @@ namespace boost { namespace locale { namespace impl_win {
                               std::back_inserter<gnu_gettext::messages_info::domains_type>(minf.domains));
                     minf.paths = paths_;
                     switch(type) {
-                        case char_facet: return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
-                        case wchar_t_facet: return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
+                        case char_facet_t::char_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<char>(minf));
+                        case char_facet_t::wchar_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<wchar_t>(minf));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+                        case char_facet_t::char16_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<char16_t>(minf));
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+                        case char_facet_t::char32_f:
+                            return std::locale(base, gnu_gettext::create_messages_facet<char32_t>(minf));
+#endif
                         default: return base;
                     }
                 }
-                case information_facet: return util::create_info(base, real_id_);
-                case codepage_facet: return util::create_utf8_codecvt(base, type);
+                case category_t::information: return util::create_info(base, real_id_);
+                case category_t::codepage: return util::create_utf8_codecvt(base, type);
                 default: return base;
             }
         }

--- a/test/test_collate.cpp
+++ b/test/test_collate.cpp
@@ -15,7 +15,7 @@ template<typename Char>
 void test_comp(std::locale l, std::basic_string<Char> left, std::basic_string<Char> right, int ilevel, int expected)
 {
     typedef std::basic_string<Char> string_type;
-    boost::locale::collator_base::level_type level = static_cast<boost::locale::collator_base::level_type>(ilevel);
+    boost::locale::collate_level level = static_cast<boost::locale::collate_level>(ilevel);
     TEST(boost::locale::comparator<Char>(l, level)(left, right) == (expected < 0));
     if(ilevel == 4) {
         const std::collate<Char>& coll = std::use_facet<std::collate<Char>>(l);

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -4,11 +4,11 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include <boost/locale/generator.hpp>
-#include <boost/locale/info.hpp>
-#include <boost/locale/message.hpp>
+#include <boost/locale.hpp>
 #include "boostLocale/test/unit_test.hpp"
 #include <iomanip>
+#include <string>
+#include <vector>
 
 bool has_message(const std::locale& l)
 {
@@ -22,51 +22,117 @@ struct test_facet : public std::locale::facet {
 
 std::locale::id test_facet::id;
 
+template<typename CharType>
+using codecvt_by_char_type = std::codecvt<CharType, char, std::mbstate_t>;
+
 void test_main(int /*argc*/, char** /*argv*/)
 {
-    boost::locale::generator g;
+    std::vector<std::string> backends;
+#ifdef BOOST_LOCALE_WITH_ICU
+    backends.push_back("icu");
+#endif
+#ifndef BOOST_LOCALE_NO_STD_BACKEND
+    backends.push_back("std");
+#endif
+#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
+    backends.push_back("winapi");
+#endif
+#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
+    backends.push_back("posix");
+#endif
+
+    namespace bl = boost::locale;
+    const bl::localization_backend_manager orig_backend = bl::localization_backend_manager::global();
+    for(const std::string& backendName : backends) {
+        std::cout << "Backend: " << backendName << '\n';
+        bl::localization_backend_manager tmp_backend = bl::localization_backend_manager::global();
+        tmp_backend.select(backendName);
+        bl::localization_backend_manager::global(tmp_backend);
+        bl::generator g;
+        const std::locale l = g("en_US.UTF-8");
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+#    define TEST_HAS_FACET_CHAR16(facet, l) TEST(std::has_facet<facet<char16_t>>(l))
+#else
+#    define TEST_HAS_FACET_CHAR16(facet, l) (void)0
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+#    define TEST_HAS_FACET_CHAR32(facet, l) TEST(std::has_facet<facet<char32_t>>(l))
+#else
+#    define TEST_HAS_FACET_CHAR32(facet, l) (void)0
+#endif
+#define TEST_HAS_FACETS(facet, l)            \
+    TEST(std::has_facet<facet<char>>(l));    \
+    TEST(std::has_facet<facet<wchar_t>>(l)); \
+    TEST_HAS_FACET_CHAR16(facet, l);         \
+    TEST_HAS_FACET_CHAR32(facet, l)
+
+        // Convert
+        TEST_HAS_FACETS(bl::converter, l);
+        TEST_HAS_FACETS(std::collate, l);
+        // Formatting
+        TEST_HAS_FACETS(std::num_put, l);
+        TEST_HAS_FACETS(std::time_put, l);
+        TEST_HAS_FACETS(std::numpunct, l);
+        TEST_HAS_FACETS(std::moneypunct, l);
+        // Parsing
+        TEST_HAS_FACETS(std::num_get, l);
+        // Message
+        TEST_HAS_FACETS(bl::message_format, l);
+        // Codepage
+        TEST_HAS_FACETS(codecvt_by_char_type, l);
+        // Boundary
+        if(backendName == "icu") {
+            TEST_HAS_FACETS(bl::boundary::boundary_indexing, l);
+        }
+        // calendar
+        TEST(std::has_facet<bl::calendar_facet>(l));
+        // information
+        TEST(std::has_facet<bl::info>(l));
+    }
+    bl::localization_backend_manager::global(orig_backend);
+
+    bl::generator g;
     std::locale l = g("en_US.UTF-8");
     TEST(has_message(l));
-
-    g.categories(g.categories() ^ boost::locale::message_facet);
+    g.categories(g.categories() ^ bl::category_t::message);
     g.locale_cache_enabled(true);
     g("en_US.UTF-8");
-    g.categories(g.categories() | boost::locale::message_facet);
+    g.categories(g.categories() | bl::category_t::message);
     l = g("en_US.UTF-8");
     TEST(!has_message(l));
     g.clear_cache();
     g.locale_cache_enabled(false);
     l = g("en_US.UTF-8");
     TEST(has_message(l));
-    g.characters(g.characters() ^ boost::locale::char_facet);
+    g.characters(g.characters() ^ bl::char_facet_t::char_f);
     l = g("en_US.UTF-8");
     TEST(!has_message(l));
-    g.characters(g.characters() | boost::locale::char_facet);
+    g.characters(g.characters() | bl::char_facet_t::char_f);
     l = g("en_US.UTF-8");
     TEST(has_message(l));
 
     l = g("en_US.ISO8859-1");
-    TEST(std::use_facet<boost::locale::info>(l).language() == "en");
-    TEST(std::use_facet<boost::locale::info>(l).country() == "US");
-    TEST(!std::use_facet<boost::locale::info>(l).utf8());
-    TEST(std::use_facet<boost::locale::info>(l).encoding() == "iso8859-1");
+    TEST(std::use_facet<bl::info>(l).language() == "en");
+    TEST(std::use_facet<bl::info>(l).country() == "US");
+    TEST(!std::use_facet<bl::info>(l).utf8());
+    TEST(std::use_facet<bl::info>(l).encoding() == "iso8859-1");
 
     l = g("en_US.UTF-8");
-    TEST(std::use_facet<boost::locale::info>(l).language() == "en");
-    TEST(std::use_facet<boost::locale::info>(l).country() == "US");
-    TEST(std::use_facet<boost::locale::info>(l).utf8());
+    TEST(std::use_facet<bl::info>(l).language() == "en");
+    TEST(std::use_facet<bl::info>(l).country() == "US");
+    TEST(std::use_facet<bl::info>(l).utf8());
 
     l = g("en_US.ISO8859-1");
-    TEST(std::use_facet<boost::locale::info>(l).language() == "en");
-    TEST(std::use_facet<boost::locale::info>(l).country() == "US");
-    TEST(!std::use_facet<boost::locale::info>(l).utf8());
-    TEST(std::use_facet<boost::locale::info>(l).encoding() == "iso8859-1");
+    TEST(std::use_facet<bl::info>(l).language() == "en");
+    TEST(std::use_facet<bl::info>(l).country() == "US");
+    TEST(!std::use_facet<bl::info>(l).utf8());
+    TEST(std::use_facet<bl::info>(l).encoding() == "iso8859-1");
 
     l = g("en_US.ISO8859-1");
-    TEST(std::use_facet<boost::locale::info>(l).language() == "en");
-    TEST(std::use_facet<boost::locale::info>(l).country() == "US");
-    TEST(!std::use_facet<boost::locale::info>(l).utf8());
-    TEST(std::use_facet<boost::locale::info>(l).encoding() == "iso8859-1");
+    TEST(std::use_facet<bl::info>(l).language() == "en");
+    TEST(std::use_facet<bl::info>(l).country() == "US");
+    TEST(!std::use_facet<bl::info>(l).utf8());
+    TEST(std::use_facet<bl::info>(l).encoding() == "iso8859-1");
 
     std::locale l_wt(std::locale::classic(), new test_facet);
 
@@ -80,8 +146,8 @@ void test_main(int /*argc*/, char** /*argv*/)
     g.generate(l_wt, "en_US.ISO8859-1");
     TEST(std::has_facet<test_facet>(g("en_US.UTF-8")));
     TEST(std::has_facet<test_facet>(g("en_US.ISO8859-1")));
-    TEST(std::use_facet<boost::locale::info>(g("en_US.UTF-8")).utf8());
-    TEST(!std::use_facet<boost::locale::info>(g("en_US.ISO8859-1")).utf8());
+    TEST(std::use_facet<bl::info>(g("en_US.UTF-8")).utf8());
+    TEST(!std::use_facet<bl::info>(g("en_US.ISO8859-1")).utf8());
 }
 
 // boostinspect:noascii

--- a/test/test_winapi_collate.cpp
+++ b/test/test_winapi_collate.cpp
@@ -15,7 +15,7 @@ template<typename Char>
 void test_comp(std::locale l, std::basic_string<Char> left, std::basic_string<Char> right, int ilevel, int expected)
 {
     typedef std::basic_string<Char> string_type;
-    boost::locale::collator_base::level_type level = static_cast<boost::locale::collator_base::level_type>(ilevel);
+    boost::locale::collate_level level = static_cast<boost::locale::collate_level>(ilevel);
     TEST(boost::locale::comparator<Char>(l, level)(left, right) == (expected < 0));
     if(ilevel == 4) {
         const std::collate<Char>& coll = std::use_facet<std::collate<Char>>(l);


### PR DESCRIPTION
Changes `character_facet_type` & `locale_category_type` to the enum classes `char_facet_t` & `category_t` This avoids a name clash with e.g. `calendar_facet` but is a breaking change