### PR TITLE
Add Latin1 codepage to Windows backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,11 @@ jobs:
 
       - name: Run tests
         if: '!matrix.coverage'
-        run: ci\build.bat
+        run: |
+          set B2_FLAGS=boost.locale.icu=off boost.locale.iconv=off
+          ci\build.bat
+          set B2_FLAGS=-a
+          ci\build.bat
         env:
           B2_TOOLSET: ${{matrix.toolset}}
           B2_CXXSTD: ${{matrix.cxxstd}}

--- a/src/boost/locale/encoding/win_codepages.hpp
+++ b/src/boost/locale/encoding/win_codepages.hpp
@@ -109,6 +109,8 @@ namespace boost { namespace locale { namespace conv { namespace impl {
       {"koi8r", 20866, 0},
       {"koi8u", 21866, 0},
       {"ksc56011987", 949, 0},
+      {"latin1", 28591, 0},
+      {"latin1", 1252, 0},
       {"macintosh", 10000, 0},
       {"ms936", 936, 0},
       {"shiftjis", 932, 0},

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -364,6 +364,21 @@ void test_convert(const char* enc, const char* utf, const char* name)
 
 void test_simple_conversions()
 {
+    std::cout << "- Testing Latin1 conversion\n";
+    {
+        using namespace boost::locale::conv;
+        const std::string utf8_string = "A-Za-z0-9grüße";
+        const std::string latin1_string = to<char>(utf8_string);
+        const std::wstring wide_string = to<wchar_t>(utf8_string);
+
+        TEST_EQ(to_utf<char>(latin1_string, "Latin1"), utf8_string);
+        TEST_EQ(to_utf<wchar_t>(latin1_string, "Latin1"), wide_string);
+        TEST_EQ(from_utf(utf8_string, "Latin1"), latin1_string);
+        TEST_EQ(from_utf(wide_string, "Latin1"), latin1_string);
+        TEST_EQ(utf_to_utf<char>(wide_string), utf8_string);
+        TEST_EQ(utf_to_utf<wchar_t>(utf8_string), wide_string);
+    }
+
     namespace blc = boost::locale::conv;
     std::cout << "- Testing correct invalid bytes skipping\n";
     try {


### PR DESCRIPTION
Map "Latin1" to iso8859-1 with windows-1252 as fallback.

Fixes #61