### PR TITLE
Fix some MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(boost_locale
 target_compile_definitions(boost_locale
   PUBLIC BOOST_LOCALE_NO_LIB
   PRIVATE _CRT_SECURE_NO_WARNINGS
+  PRIVATE _SCL_SECURE_NO_WARNINGS
 )
 
 if(BUILD_SHARED_LIBS)

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -423,6 +423,7 @@ boost-lib locale
       <include>$(TOP)/src
       <threading>multi
       <target-os>windows:<define>_CRT_SECURE_NO_WARNINGS
+      <target-os>windows:<define>_SCL_SECURE_NO_WARNINGS
       # Meanwhile remove this
       <conditional>@configure
     : : $(cxx_requirements)

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -33,10 +33,6 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef BOOST_MSVC
-#    pragma warning(disable : 4996)
-#endif
-
 namespace boost { namespace locale { namespace gnu_gettext {
 
     class c_file {

--- a/src/boost/locale/std/converter.cpp
+++ b/src/boost/locale/std/converter.cpp
@@ -16,10 +16,6 @@
 
 #include "boost/locale/std/all_generator.hpp"
 
-#ifdef BOOST_MSVC
-#    pragma warning(disable : 4996)
-#endif
-
 namespace boost { namespace locale { namespace impl_std {
 
     template<typename CharType>

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -16,7 +16,7 @@
 #include "boost/locale/encoding/conv.hpp"
 
 #ifdef BOOST_MSVC
-#    pragma warning(disable : 4244 4996) // loose data
+#    pragma warning(disable : 4244) // loose data
 #endif
 
 namespace boost { namespace locale { namespace util {

--- a/src/boost/locale/util/default_locale.cpp
+++ b/src/boost/locale/util/default_locale.cpp
@@ -16,10 +16,6 @@
 #    define BOOST_LOCALE_USE_WIN32_API
 #endif
 
-#ifdef BOOST_MSVC
-#    pragma warning(disable : 4996)
-#endif
-
 namespace boost { namespace locale { namespace util {
     std::string get_system_locale(bool use_utf8)
     {

--- a/src/boost/locale/util/gregorian.cpp
+++ b/src/boost/locale/util/gregorian.cpp
@@ -20,10 +20,6 @@
 #include <memory>
 #include <string>
 
-#ifdef BOOST_MSVC
-#    pragma warning(disable : 4996)
-#endif
-
 namespace boost { namespace locale { namespace util {
     namespace {
 

--- a/src/boost/locale/util/numeric.hpp
+++ b/src/boost/locale/util/numeric.hpp
@@ -19,11 +19,6 @@
 
 #include "boost/locale/util/timezone.hpp"
 
-// This is internal header so disable crappy "unsecure functions" for all
-#ifdef BOOST_MSVC
-#    pragma warning(disable : 4996)
-#endif
-
 namespace boost { namespace locale { namespace util {
 
     template<typename CharType>

--- a/test/boostLocale/test/tools.hpp
+++ b/test/boostLocale/test/tools.hpp
@@ -10,6 +10,7 @@
 #include <boost/locale/encoding.hpp>
 #include "boostLocale/test/posix_tools.hpp"
 #include <cstdio>
+#include <ctime>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -222,5 +223,23 @@ public:
     explicit remove_file_on_exit(const std::string& filename) : filename_(filename) {}
     ~remove_file_on_exit() { std::remove(filename_.c_str()); }
 };
+
+#ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4996) //"This function or variable may be unsafe"
+#endif
+/// Wrapper for std::gmtime avoiding warning 4996 on MSVC/clang-cl:
+inline std::tm* gmtime_wrap(const std::time_t* time)
+{
+    return std::gmtime(time);
+}
+/// Wrapper for std::localtime avoiding warning 4996 on MSVC/clang-cl
+inline std::tm* localtime_wrap(const std::time_t* time)
+{
+    return std::localtime(time);
+}
+#ifdef _MSC_VER
+#    pragma warning(pop)
+#endif
 
 #endif

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -4,10 +4,6 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifdef _MSC_VER
-#    define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <boost/locale.hpp>
 #include <clocale>
 #include <cstdlib>
@@ -27,7 +23,14 @@
 
 const char* env(const char* s)
 {
+#ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4996)
+#endif
     const char* r = getenv(s);
+#ifdef _MSC_VER
+#    pragma warning(pop)
+#endif
     if(r)
         return r;
     return "";
@@ -121,9 +124,9 @@ void test_main(int /*argc*/, char** /*argv*/)
         setlocale(LC_ALL, "C");
         time_t now = time(0);
         char buf[1024];
-        strftime(buf, sizeof(buf), "%%c=%c; %%Z=%Z; %%z=%z", localtime(&now));
+        strftime(buf, sizeof(buf), "%%c=%c; %%Z=%Z; %%z=%z", localtime_wrap(&now));
         std::cout << "  Local Time    :" << buf << std::endl;
-        strftime(buf, sizeof(buf), "%%c=%c; %%Z=%Z; %%z=%z", gmtime(&now));
+        strftime(buf, sizeof(buf), "%%c=%c; %%Z=%Z; %%z=%z", gmtime_wrap(&now));
         std::cout << "  Universal Time:" << buf << std::endl;
     }
     std::cout << "- Boost.Locale's locale: ";

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -4,14 +4,11 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifdef _MSC_VER
-#    define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <boost/locale/date_time.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/localization_backend.hpp>
+#include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 #include <ctime>
 #include <iomanip>
@@ -509,7 +506,7 @@ void test_main(int /*argc*/, char** /*argv*/)
                 TEST_GE(time_point_time, current_time);
                 TEST_EQ(static_cast<time_t>(time_point_time / 3600), current_time / 3600); // Roughly match
                 // However at least the date should match
-                const tm current_time_gmt = *std::gmtime(&current_time);
+                const tm current_time_gmt = *gmtime_wrap(&current_time);
                 TEST_EQ(time_point_default.get(year()), current_time_gmt.tm_year + 1900);
                 TEST_EQ(time_point_default.get(month()), current_time_gmt.tm_mon);
                 TEST_EQ(time_point_default.get(day()), current_time_gmt.tm_mday);

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -5,16 +5,13 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifdef _MSC_VER
-#    define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <boost/locale/date_time.hpp>
 #include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/format.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
 #include <cstdint>
+#include <ctime>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -454,7 +451,7 @@ void test_manip(std::string e_charset = "UTF-8")
         ss.imbue(loc);
         // By default the globally set (local) time zone is used
         ss << as::ftime(format_string) << now;
-        strftime(time_str, sizeof(time_str), format.c_str(), gmtime(&local_now));
+        strftime(time_str, sizeof(time_str), format.c_str(), gmtime_wrap(&local_now));
         TEST_EQ(ss.str(), to<CharType>(time_str));
         ss.str(string_type()); // Clear
         // We can manually tell it to use the local time zone
@@ -463,7 +460,7 @@ void test_manip(std::string e_charset = "UTF-8")
         ss.str(string_type()); // Clear
         // Or e.g. GMT
         ss << as::ftime(format_string) << as::gmt << now;
-        strftime(time_str, sizeof(time_str), format.c_str(), gmtime(&now));
+        strftime(time_str, sizeof(time_str), format.c_str(), gmtime_wrap(&now));
         TEST_EQ(ss.str(), to<CharType>(time_str));
     }
     const std::pair<std::string, std::string> format_string_test_cases[] = {
@@ -634,9 +631,9 @@ void test_format_class(std::string charset = "UTF-8")
         time_t now = time(0);
         char local_time_str[256], local_time_str_gmt2[256];
         time_t local_now = now + 3600 * 4;
-        strftime(local_time_str, sizeof(local_time_str), "'%H:%M:%S'", gmtime(&local_now));
+        strftime(local_time_str, sizeof(local_time_str), "'%H:%M:%S'", gmtime_wrap(&local_now));
         local_now = now + 3600 * 2;
-        strftime(local_time_str_gmt2, sizeof(local_time_str_gmt2), "'%H:%M:%S'", gmtime(&local_now));
+        strftime(local_time_str_gmt2, sizeof(local_time_str_gmt2), "'%H:%M:%S'", gmtime_wrap(&local_now));
 
         TEST_FORMAT_CLS("{1,ftime='''%H:%M:%S'''}", now, local_time_str);
         TEST_FORMAT_CLS("{1,strftime='''%H:%M:%S'''}", now, local_time_str);

--- a/test/test_icu_vs_os_timezone.cpp
+++ b/test/test_icu_vs_os_timezone.cpp
@@ -4,11 +4,6 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#ifdef _MSC_VER
-#    define _CRT_SECURE_NO_WARNINGS
-// Disable this "security crap"
-#endif
-
 #include <boost/locale/format.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
@@ -37,7 +32,7 @@ void test_main(int /*argc*/, char** /*argv*/)
         ss << boost::locale::format("{1,ftime='%H %M %S'}") % point;
         int icu_hour = 0, icu_min = 0, icu_sec = 0;
         ss >> icu_hour >> icu_min >> icu_sec;
-        std::tm* tm = localtime(&point);
+        std::tm* tm = localtime_wrap(&point);
         TEST(icu_hour == tm->tm_hour);
         TEST(icu_min == tm->tm_min);
         TEST(icu_sec == tm->tm_sec);

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -132,7 +132,7 @@ void test_by_char(const std::locale& l, locale_t lreal)
 
         char buf[64]{};
 #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-        std::tm tm = *gmtime(&a_datetime);
+        std::tm tm = *gmtime_wrap(&a_datetime);
         TEST(strftime_l(buf, sizeof(buf), "%x\n%X\n%c\n16\n48\n", &tm, lreal) > 0);
 #endif
         TEST_EQ(ss.str(), to_utf<CharType>(buf, lreal));

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -8,15 +8,12 @@
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/localization_backend.hpp>
+#include <ctime>
 #include <iomanip>
 #include <iostream>
 
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
-
-#ifdef BOOST_MSVC
-#    pragma warning(disable : 4996)
-#endif
 
 template<typename CharType, typename RefCharType>
 void test_by_char(const std::locale& l, const std::locale& lreal)
@@ -141,7 +138,7 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
 
         std::basic_string<RefCharType> rfmt(ascii_to<RefCharType>("%x\n%X\n%c\n16\n48\n"));
 
-        std::tm tm = *gmtime(&a_datetime);
+        std::tm tm = *gmtime_wrap(&a_datetime);
 
         std::use_facet<std::time_put<RefCharType>>(lreal)
           .put(ss_ref, ss_ref, RefCharType(' '), &tm, rfmt.c_str(), rfmt.c_str() + rfmt.size());


### PR DESCRIPTION
Define `_SCL_SECURE_NO_WARNINGS` for building the library to avoid "Call to 'std::copy' with parameters that may be unsafe" in `src\boost\locale\std\converter.cpp`
This also allows to remove the multiple suppressions of C4996

Introduce wrappers with suppressed warning in test code so that the public headers will still throw the warning if there is any (which must not be the case as headers are supposed to be warning-free)

Closes #136