### PR TITLE
Test improvements

### DIFF
--- a/test/boostLocale/test/tools.hpp
+++ b/test/boostLocale/test/tools.hpp
@@ -103,10 +103,10 @@ inline std::string to_correct_string(const std::string& utf8_str, std::locale l)
     return boost::locale::conv::from_utf(utf8_str, l);
 }
 
-bool has_std_locale(const std::string& name)
+bool has_std_locale(const char* name)
 {
     try {
-        std::locale tmp(name.c_str());
+        std::locale tmp(name);
         return true;
     } catch(...) {
         return false;
@@ -141,7 +141,7 @@ inline bool test_std_supports_SJIS_codecvt(const std::string& locale_name)
 
 std::string get_std_name(const std::string& name, std::string* real_name = 0)
 {
-    if(has_std_locale(name)) {
+    if(has_std_locale(name.c_str())) {
         if(real_name)
             *real_name = name;
         return name;

--- a/test/boostLocale/test/unit_test.hpp
+++ b/test/boostLocale/test/unit_test.hpp
@@ -101,14 +101,16 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;                             // LCOV_EXCL_LINE
     }
     using boost::locale::test::results;
-    int passed = results().test_counter - results().error_counter;
-    std::cout << std::endl;
-    std::cout << "Passed " << passed << " tests\n";
-    if(results().error_counter > 0) {
-        std::cout << "Failed " << results().error_counter << " tests\n"; // LCOV_EXCL_LINE
+    if(results().test_counter > 0) {
+        int passed = results().test_counter - results().error_counter;
+        std::cout << std::endl;
+        std::cout << "Passed " << passed << " tests\n";
+        if(results().error_counter > 0) {
+            std::cout << "Failed " << results().error_counter << " tests\n"; // LCOV_EXCL_LINE
+        }
+        std::cout << " " << std::fixed << std::setprecision(1) << std::setw(5)
+                  << 100.0 * passed / results().test_counter << "% of tests completed successfully\n";
     }
-    std::cout << " " << std::fixed << std::setprecision(1) << std::setw(5) << 100.0 * passed / results().test_counter
-              << "% of tests completed successfully\n";
     return results().error_counter == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -33,22 +33,20 @@ const char* env(const char* s)
     return "";
 }
 
-void check_locale(const std::vector<const char*>& names)
+bool has_locale(const char* name)
 {
-    std::cout << "  " << std::setw(32) << "locale" << std::setw(4) << "C" << std::setw(4) << "C++\n";
+    const bool result = std::setlocale(LC_ALL, name) != nullptr;
+    std::setlocale(LC_ALL, "C");
+    return result;
+}
+
+void check_locales(const std::vector<const char*>& names)
+{
+    std::cout << "  " << std::setw(32) << "locale" << std::setw(4) << "C" << std::setw(4) << "C++" << std::endl;
     for(const char* name : names) {
-        std::cout << "  " << std::setw(32) << name << std::setw(4);
-        if(setlocale(LC_ALL, name) != 0)
-            std::cout << "Yes";
-        else
-            std::cout << "No";
-        std::cout << std::setw(4);
-        try {
-            std::locale l(name);
-            std::cout << "Yes";
-        } catch(const std::exception&) {
-            std::cout << "No";
-        }
+        std::cout << "  " << std::setw(32) << name;
+        std::cout << std::setw(4) << (has_locale(name) ? "Yes" : "No");
+        std::cout << std::setw(4) << (has_std_locale(name) ? "Yes" : "No");
         std::cout << std::endl;
     }
 }
@@ -112,9 +110,9 @@ void test_main(int /*argc*/, char** /*argv*/)
       "Japanese_Japan.932",
     };
     std::cout << "- Testing locales availability on the operation system:" << std::endl;
-    check_locale(locales_to_check);
-    std::cout << "--- Testing Japanese_Japan.932 is working: " << test_std_supports_SJIS_codecvt("Japanese_Japan.932")
-              << std::endl;
+    check_locales(locales_to_check);
+    std::cout << "--- Testing Japanese_Japan.932 is working: ";
+    std::cout << (test_std_supports_SJIS_codecvt("Japanese_Japan.932") ? "Yes" : "No") << std::endl;
 
     std::cout << "- Testing timezone and time " << std::endl;
     {

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -127,8 +127,8 @@ void test_main(int /*argc*/, char** /*argv*/)
     std::cout << "- Boost.Locale's locale: ";
     boost::locale::generator gen;
     std::locale l = gen("");
-    TEST_REQUIRE(std::has_facet<boost::locale::info>(l));
-    std::cout << std::use_facet<boost::locale::info>(l).name() << std::endl;
+    std::cout << (std::has_facet<boost::locale::info>(l) ? std::use_facet<boost::locale::info>(l).name() : "Unknown")
+              << std::endl;
 }
 
 // boostinspect:noascii

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -64,7 +64,7 @@ void test_ok(const std::string& content, const std::locale& l, std::basic_string
         }
         stream_type testi("testi.txt", stream_type::in);
         testi.imbue(l);
-        TEST(read_file<Char>(testi) == cmp);
+        TEST_EQ(read_file<Char>(testi), cmp);
     }
 
     {
@@ -75,7 +75,7 @@ void test_ok(const std::string& content, const std::locale& l, std::basic_string
             testo << cmp;
         }
         std::ifstream testo("testo.txt");
-        TEST(read_file<char>(testo) == content);
+        TEST_EQ(read_file<char>(testo), content);
     }
 }
 
@@ -184,21 +184,21 @@ void test_pos(std::string source, std::basic_string<Char> target, std::string en
     using namespace boost::locale::conv;
     boost::locale::generator g;
     std::locale l = encoding == "ISO8859-8" ? g("he_IL." + encoding) : g("en_US." + encoding);
-    TEST(to_utf<Char>(source, encoding) == target);
-    TEST(to_utf<Char>(source.c_str(), encoding) == target);
-    TEST(to_utf<Char>(source.c_str(), source.c_str() + source.size(), encoding) == target);
+    TEST_EQ(to_utf<Char>(source, encoding), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), encoding), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), source.c_str() + source.size(), encoding), target);
 
-    TEST(to_utf<Char>(source, l) == target);
-    TEST(to_utf<Char>(source.c_str(), l) == target);
-    TEST(to_utf<Char>(source.c_str(), source.c_str() + source.size(), l) == target);
+    TEST_EQ(to_utf<Char>(source, l), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), l), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), source.c_str() + source.size(), l), target);
 
-    TEST(from_utf<Char>(target, encoding) == source);
-    TEST(from_utf<Char>(target.c_str(), encoding) == source);
-    TEST(from_utf<Char>(target.c_str(), target.c_str() + target.size(), encoding) == source);
+    TEST_EQ(from_utf<Char>(target, encoding), source);
+    TEST_EQ(from_utf<Char>(target.c_str(), encoding), source);
+    TEST_EQ(from_utf<Char>(target.c_str(), target.c_str() + target.size(), encoding), source);
 
-    TEST(from_utf<Char>(target, l) == source);
-    TEST(from_utf<Char>(target.c_str(), l) == source);
-    TEST(from_utf<Char>(target.c_str(), target.c_str() + target.size(), l) == source);
+    TEST_EQ(from_utf<Char>(target, l), source);
+    TEST_EQ(from_utf<Char>(target.c_str(), l), source);
+    TEST_EQ(from_utf<Char>(target.c_str(), target.c_str() + target.size(), l), source);
 }
 
 #define TESTF(X) TEST_THROWS(X, boost::locale::conv::conversion_error)
@@ -210,12 +210,12 @@ void test_to_neg(std::string source, std::basic_string<Char> target, std::string
     boost::locale::generator g;
     std::locale l = g("en_US." + encoding);
 
-    TEST(to_utf<Char>(source, encoding) == target);
-    TEST(to_utf<Char>(source.c_str(), encoding) == target);
-    TEST(to_utf<Char>(source.c_str(), source.c_str() + source.size(), encoding) == target);
-    TEST(to_utf<Char>(source, l) == target);
-    TEST(to_utf<Char>(source.c_str(), l) == target);
-    TEST(to_utf<Char>(source.c_str(), source.c_str() + source.size(), l) == target);
+    TEST_EQ(to_utf<Char>(source, encoding), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), encoding), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), source.c_str() + source.size(), encoding), target);
+    TEST_EQ(to_utf<Char>(source, l), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), l), target);
+    TEST_EQ(to_utf<Char>(source.c_str(), source.c_str() + source.size(), l), target);
 
     TESTF(to_utf<Char>(source, encoding, stop));
     TESTF(to_utf<Char>(source.c_str(), encoding, stop));
@@ -232,12 +232,12 @@ void test_from_neg(std::basic_string<Char> source, std::string target, std::stri
     boost::locale::generator g;
     std::locale l = g("en_US." + encoding);
 
-    TEST(from_utf<Char>(source, encoding) == target);
-    TEST(from_utf<Char>(source.c_str(), encoding) == target);
-    TEST(from_utf<Char>(source.c_str(), source.c_str() + source.size(), encoding) == target);
-    TEST(from_utf<Char>(source, l) == target);
-    TEST(from_utf<Char>(source.c_str(), l) == target);
-    TEST(from_utf<Char>(source.c_str(), source.c_str() + source.size(), l) == target);
+    TEST_EQ(from_utf<Char>(source, encoding), target);
+    TEST_EQ(from_utf<Char>(source.c_str(), encoding), target);
+    TEST_EQ(from_utf<Char>(source.c_str(), source.c_str() + source.size(), encoding), target);
+    TEST_EQ(from_utf<Char>(source, l), target);
+    TEST_EQ(from_utf<Char>(source.c_str(), l), target);
+    TEST_EQ(from_utf<Char>(source.c_str(), source.c_str() + source.size(), l), target);
 
     TESTF(from_utf<Char>(source, encoding, stop));
     TESTF(from_utf<Char>(source.c_str(), encoding, stop));

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -50,11 +50,9 @@ void test_by_char(const std::locale& l, locale_t lreal)
         ss_type ss;
         ss.imbue(l);
 
-        ss << 1045.45;
-        TEST(ss);
+        TEST(ss << 1045.45);
         double n;
-        ss >> n;
-        TEST(ss);
+        TEST(ss >> n);
         TEST_EQ(n, 1045.45);
         TEST_EQ(ss.str(), ascii_to<CharType>("1045.45"));
     }
@@ -65,11 +63,9 @@ void test_by_char(const std::locale& l, locale_t lreal)
         ss.imbue(l);
 
         ss << as::number;
-        ss << 1045.45;
-        TEST(ss);
+        TEST(ss << 1045.45);
         double n;
-        ss >> n;
-        TEST(ss);
+        TEST(ss >> n);
         TEST(n == 1045.45);
 
         if(std::use_facet<boost::locale::info>(l).country() == "US")
@@ -88,8 +84,7 @@ void test_by_char(const std::locale& l, locale_t lreal)
         ss.imbue(l);
 
         ss << as::currency;
-        ss << 1043.34;
-        TEST(ss);
+        TEST(ss << 1043.34);
 
         TEST_EQ(ss.str(), to_utf<CharType>(buf, lreal));
     }
@@ -104,8 +99,7 @@ void test_by_char(const std::locale& l, locale_t lreal)
         ss.imbue(l);
 
         ss << as::currency << as::currency_iso;
-        ss << 1043.34;
-        TEST(ss);
+        TEST(ss << 1043.34);
 
         TEST_EQ(ss.str(), to_utf<CharType>(buf, lreal));
     }

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -31,11 +31,9 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
         ss_type ss;
         ss.imbue(l);
 
-        ss << 1045.45;
-        TEST(ss);
+        TEST(ss << 1045.45);
         double n;
-        ss >> n;
-        TEST(ss);
+        TEST(ss >> n);
         TEST_EQ(n, 1045.45);
         TEST_EQ(ss.str(), ascii_to<CharType>("1045.45"));
     }
@@ -45,18 +43,16 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
         ss_type ss;
         ss.imbue(l);
 
-        ss << as::number;
-        ss << 1045.45;
-        TEST(ss);
+        TEST(ss << as::number);
+        TEST(ss << 1045.45);
         double n;
-        ss >> n;
-        TEST(ss);
+        TEST(ss >> n);
         TEST_EQ(n, 1045.45);
 
         ss_ref_type ss_ref;
         ss_ref.imbue(lreal);
 
-        ss_ref << 1045.45;
+        TEST(ss_ref << 1045.45);
 
         TEST_EQ(to_utf8(ss.str()), to_utf8(ss_ref.str()));
     }
@@ -83,10 +79,9 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
         ss_type ss;
         ss.imbue(l);
 
-        ss << as::currency;
-        ss << 1043.34;
+        TEST(ss << as::currency);
+        TEST(ss << 1043.34);
         if(!bad_parsing) {
-            TEST(ss);
             double v1;
             TEST(ss >> v1);
             TEST_EQ(v1, 1043.34);
@@ -101,11 +96,9 @@ void test_by_char(const std::locale& l, const std::locale& lreal)
         ss.imbue(l);
 
         ss << as::currency << as::currency_iso;
-        ss << 1043.34;
-        TEST(ss);
+        TEST(ss << 1043.34);
         double v1;
-        ss >> v1;
-        TEST(ss);
+        TEST(ss >> v1);
         TEST_EQ(v1, 1043.34);
 
         ss_ref_type ss_ref;
@@ -170,7 +163,10 @@ void test_main(int /*argc*/, char** /*argv*/)
         if(name.empty()) {
             std::cout << lName << " not supported" << std::endl;
         } else {
-            std::locale l1 = gen(name), l2(real_name.c_str());
+            std::cout << "\tstd name: " << name << std::endl;
+            std::locale l1 = gen(name);
+            std::cout << "\treal name: " << real_name << std::endl;
+            std::locale l2(real_name.c_str());
             if(lName.find(".UTF-8") != std::string::npos) {
                 std::cout << "\tUTF-8" << std::endl;
                 if(name == real_name)

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -35,11 +35,9 @@ void test_by_char(const std::locale& l, std::string name, int lcid)
         ss_type ss;
         ss.imbue(l);
 
-        ss << 1045.45;
-        TEST(ss);
+        TEST(ss << 1045.45);
         double n;
-        ss >> n;
-        TEST(ss);
+        TEST(ss >> n);
         TEST(n == 1045.45);
         TEST_EQ(to_utf8(ss.str()), "1045.45");
     }
@@ -50,11 +48,9 @@ void test_by_char(const std::locale& l, std::string name, int lcid)
         ss.imbue(l);
 
         ss << as::number;
-        ss << 1045.45;
-        TEST(ss);
+        TEST(ss << 1045.45);
         double n;
-        ss >> n;
-        TEST(ss);
+        TEST(ss >> n);
         TEST_EQ(n, 1045.45);
 
         if(name == "ru_RU.UTF-8") {
@@ -77,8 +73,7 @@ void test_by_char(const std::locale& l, std::string name, int lcid)
         ss.imbue(l);
 
         ss << as::currency;
-        ss << 1043.34;
-        TEST(ss);
+        TEST(ss << 1043.34);
 
 #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
         wchar_t buf[256];


### PR DESCRIPTION
Improve output in case of test failures by calling `TEST` on the input/output operation of the stream and using `TEST_EQ` more often