### PR TITLE
Test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,7 @@ jobs:
         run: |
             cd "$BOOST_ROOT"
             mkdir __build_cmake_test__ && cd __build_cmake_test__
-            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DBUILD_TESTING=ON -DBoost_VERBOSE=ON -DCMAKE_IGNORE_PREFIX_PATH="/c/Strawberry/c" ..
             cmake --build . --target tests --config ${{matrix.build_type}} -j$B2_JOBS
             ctest --output-on-failure --build-config ${{matrix.build_type}}
 
@@ -498,7 +498,7 @@ jobs:
             if [[ "$RUNNER_OS" == "Windows" ]] && [[ "${{matrix.build_shared}}" == "ON" ]]; then
                 extra_args="-DCMAKE_RUNTIME_OUTPUT_DIRECTORY='$(pwd)/bin'"
             fi
-            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} $extra_args ..
+            cmake -G "${{matrix.generator}}" -DBOOST_CI_INSTALL_TEST=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBUILD_SHARED_LIBS=${{matrix.build_shared}} $extra_args -DCMAKE_IGNORE_PREFIX_PATH="/c/Strawberry/c" ..
             cmake --build . --config ${{matrix.build_type}} -j$B2_JOBS
             ctest --output-on-failure --build-config ${{matrix.build_type}}
 
@@ -508,7 +508,7 @@ jobs:
             echo "BCM_INSTALL_PATH=$BCM_INSTALL_PATH" >> $GITHUB_ENV
             cd "$BOOST_ROOT"
             mkdir __build_cmake_install_test__ && cd __build_cmake_install_test__
-            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX="$BCM_INSTALL_PATH" -DBoost_VERBOSE=ON -DBoost_DEBUG=ON ..
+            cmake -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=${{matrix.build_shared}} -DCMAKE_INSTALL_PREFIX="$BCM_INSTALL_PATH" -DBoost_VERBOSE=ON -DBoost_DEBUG=ON -DCMAKE_IGNORE_PREFIX_PATH="/c/Strawberry/c" ..
             cmake --build . --target install --config ${{matrix.build_type}} -j$B2_JOBS
       - name: Run CMake install tests
         run: |

--- a/src/boost/locale/encoding/conv.hpp
+++ b/src/boost/locale/encoding/conv.hpp
@@ -9,37 +9,26 @@
 
 #include <boost/locale/config.hpp>
 #include <boost/locale/encoding.hpp>
+
 namespace boost { namespace locale { namespace conv { namespace impl {
 
     template<typename CharType>
     const char* utf_name()
     {
-        union {
-            char first;
-            uint16_t u16;
-            uint32_t u32;
-        } v;
-
-        if(sizeof(CharType) == 1) {
-            return "UTF-8";
-        } else if(sizeof(CharType) == 2) {
-            v.u16 = 1;
-            if(v.first == 1) {
-                return "UTF-16LE";
-            } else {
-                return "UTF-16BE";
+        switch(sizeof(CharType)) {
+            case 1: return "UTF-8";
+            case 2: {
+                const int16_t endianMark = 1;
+                const bool isLittleEndian = reinterpret_cast<const char*>(&endianMark)[0] == 1;
+                return isLittleEndian ? "UTF-16LE" : "UTF-16BE";
             }
-        } else if(sizeof(CharType) == 4) {
-            v.u32 = 1;
-            if(v.first == 1) {
-                return "UTF-32LE";
-            } else {
-                return "UTF-32BE";
+            case 4: {
+                const int32_t endianMark = 1;
+                const bool isLittleEndian = reinterpret_cast<const char*>(&endianMark)[0] == 1;
+                return isLittleEndian ? "UTF-32LE" : "UTF-32BE";
             }
-
-        } else {
-            return "Unknown Character Encoding";
         }
+        return "Unknown Character Encoding";
     }
 
     BOOST_LOCALE_DECL std::string normalize_encoding(const char* encoding);

--- a/test/boostLocale/test/unit_test.hpp
+++ b/test/boostLocale/test/unit_test.hpp
@@ -22,6 +22,9 @@
 #endif
 
 namespace boost { namespace locale { namespace test {
+    /// Name/path of current executable
+    std::string exe_name;
+
     struct test_result {
         test_result() : error_counter(0), test_counter(0)
         {
@@ -93,7 +96,13 @@ void test_main(int argc, char** argv);
 
 int main(int argc, char** argv)
 {
-    boost::locale::test::results(); // Instantiate
+    {
+        using namespace boost::locale::test;
+        exe_name = argv[0];
+        if(exe_name.substr(exe_name.length() - 4) == ".exe")
+            exe_name.resize(exe_name.length() - 4);
+        results(); // Instantiate
+    }
     try {
         test_main(argc, argv);
     } catch(const std::exception& e) {


### PR DESCRIPTION
Fix spurious test failures especially for parallel builds via B2 with multiple variants.

This is caused by access to files with fixed names, so different variants of the same test or even different tests using the same filename may interfere with each other.

Also fix a "constant condition" warning in `utf_name()` and a bit of refactoring to make the tests easier to read (almost only renaming with no actual change to behavior)