### PR TITLE
Fix order of environment variables when getting system default locale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,7 @@ jobs:
           - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
 
     runs-on: ${{matrix.os}}
+    env: {ICU_VERSION: '71.1'}
 
     steps:
       - uses: actions/checkout@v3
@@ -343,13 +344,21 @@ jobs:
       - name: Setup Boost
         run: ci\github\install.bat
 
-      - name: Get ICU
+      - name: Get cached ICU
+        uses: actions/cache@v3
+        id: cache-icu
+        with:
+          path: ICU
+          key: ICU-${{env.ICU_VERSION}}
+
+      - name: Download ICU
+        if: steps.cache-icu.outputs.cache-hit != 'true'
         shell: pwsh
-        run: |
-            $ICU_ROOT = "$($pwd.Path)\ICU"
-            cmake -DICU_ROOT="$ICU_ROOT" -DICU_VERSION="71.1" -P tools/download_icu.cmake
-            Add-Content $Env:BOOST_ROOT/project-config.jam "path-constant ICU_PATH : `"$ICU_ROOT`" ;"
-            Get-Content $Env:BOOST_ROOT/project-config.jam
+        run: cmake -DICU_ROOT="$($pwd.Path)\ICU" -DICU_VERSION="$Env:ICU_VERSION" -P tools/download_icu.cmake
+
+      - name: Setup ICU
+        shell: pwsh
+        run: 'Add-Content $Env:BOOST_ROOT/project-config.jam "path-constant ICU_PATH : `"$($pwd.Path)\ICU`" ;"'
 
       - name: Run tests
         if: '!matrix.coverage'

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -8,6 +8,9 @@
 /*!
 \page changelog Changelog
 
+- Unreleased
+    - Breaking changes
+        - `get_system_locale` and dependents will now correctly favor `$LC_ALL` over `LC_CTYPE` as defined by POSIX
 - 1.81.0
     - Breaking changes
         - Require C++11 or higher

--- a/doc/locale_gen.txt
+++ b/doc/locale_gen.txt
@@ -46,8 +46,8 @@ Of course we can also specify the locale manually
 -   Even if your application uses wide strings everywhere, you should specify the
     8-bit encoding to use for 8-bit stream IO operations like \c cout or \c fstream.
     \n
--   The default locale is defined by the environment variables \c LC_CTYPE , \c LC_ALL , and \c LANG
-    in that order (i.e. \c LC_CTYPE first and \c LANG last). On Windows, the library
+-   The default locale is defined by the environment variables \c LC_ALL , \c LC_CTYPE , and \c LANG
+    in that order (i.e. \c LC_ALL first and \c LANG last). On Windows, the library
     also queries the \c LOCALE_USER_DEFAULT option in the Win32 API when these variables
     are not set.
 

--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -568,7 +568,7 @@ namespace boost { namespace locale {
         /// Copy a date_time
         date_time(const date_time& other);
         // Move construct a new date_time
-        date_time(date_time&& other) = default;
+        date_time(date_time&&) = default;
 
         /// copy date_time and change some fields according to the \a set
         date_time(const date_time& other, const date_time_period_set& set);
@@ -576,7 +576,7 @@ namespace boost { namespace locale {
         /// assign the date_time
         date_time& operator=(const date_time& other);
         // Move assign a date_time
-        date_time& operator=(date_time&& other) = default;
+        date_time& operator=(date_time&&) = default;
 
         /// Create a date_time object using POSIX time \a time and default calendar
         ///

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -38,10 +38,10 @@ namespace boost { namespace locale {
 
             formattible() : pointer_(0), writer_(&formattible::void_write) {}
 
-            formattible(const formattible& other) = default;
-            formattible(formattible&& other) = default;
-            formattible& operator=(const formattible& other) = default;
-            formattible& operator=(formattible&& other) = default;
+            formattible(const formattible&) = default;
+            formattible(formattible&&) = default;
+            formattible& operator=(const formattible&) = default;
+            formattible& operator=(formattible&&) = default;
 
             template<typename Type>
             explicit formattible(const Type& value)

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -202,12 +202,12 @@ namespace boost { namespace locale {
         {}
 
         /// Copy an object
-        basic_message(const basic_message& other) = default;
-        basic_message(basic_message&& other) = default;
+        basic_message(const basic_message&) = default;
+        basic_message(basic_message&&) = default;
 
         /// Assign other message object to this one
-        basic_message& operator=(const basic_message& other) = default;
-        basic_message& operator=(basic_message&& other) = default;
+        basic_message& operator=(const basic_message&) = default;
+        basic_message& operator=(basic_message&&) = default;
 
         /// Swap two message objects
         void swap(basic_message& other)

--- a/include/boost/locale/util.hpp
+++ b/include/boost/locale/util.hpp
@@ -22,15 +22,14 @@ namespace boost { namespace locale {
 
         /// \brief Return default system locale name in POSIX format.
         ///
-        /// This function tries to detect the locale using, LC_CTYPE, LC_ALL and LANG environment
-        /// variables in this order and if all of them unset, in POSIX platforms it returns "C"
-        ///
-        /// On Windows additionally to check the above environment variables, this function
-        /// tries to creates locale name from ISO-339 and ISO-3199 country codes defined
-        /// for user default locale.
-        /// If \a use_utf8_on_windows is true it sets the encoding to UTF-8, otherwise, if system
-        /// locale supports ANSI code-page it defines the ANSI encoding like windows-1252, otherwise it fall-backs
-        /// to UTF-8 encoding if ANSI code-page is not available.
+        /// This function tries to detect the locale using LC_ALL, LC_CTYPE and LANG environment
+        /// variables in this order and if all of them are unset, on POSIX platforms it returns "C".
+        /// On Windows additionally to the above environment variables, this function
+        /// tries to create the locale name from ISO-339 and ISO-3199 country codes defined
+        /// for the users default locale.
+        /// If \a use_utf8_on_windows is true it sets the encoding to UTF-8,
+        /// otherwise, if the system locale supports ANSI codepages it defines the ANSI encoding, e.g. windows-1252,
+        /// otherwise (if ANSI codepage is not available) it uses UTF-8 encoding.
         BOOST_LOCALE_DECL
         std::string get_system_locale(bool use_utf8_on_windows = false);
 

--- a/src/boost/locale/shared/formatting.cpp
+++ b/src/boost/locale/shared/formatting.cpp
@@ -49,8 +49,8 @@ namespace boost { namespace locale {
 
     ios_info::~ios_info() = default;
 
-    ios_info::ios_info(const ios_info& other) = default;
-    ios_info& ios_info::operator=(const ios_info& other) = default;
+    ios_info::ios_info(const ios_info&) = default;
+    ios_info& ios_info::operator=(const ios_info&) = default;
 
     void ios_info::display_flags(uint64_t f)
     {

--- a/src/boost/locale/util/default_locale.cpp
+++ b/src/boost/locale/util/default_locale.cpp
@@ -17,24 +17,24 @@
 #endif
 
 namespace boost { namespace locale { namespace util {
-    std::string get_system_locale(bool use_utf8)
+    std::string get_system_locale(bool use_utf8_on_windows)
     {
         const char* lang = 0;
         if(!lang || !*lang)
-            lang = getenv("LC_CTYPE");
-        if(!lang || !*lang)
             lang = getenv("LC_ALL");
+        if(!lang || !*lang)
+            lang = getenv("LC_CTYPE");
         if(!lang || !*lang)
             lang = getenv("LANG");
 #ifndef BOOST_LOCALE_USE_WIN32_API
-        (void)use_utf8; // not relevant for non-windows
+        (void)use_utf8_on_windows; // not relevant for non-windows
         if(!lang || !*lang)
             lang = "C";
         return lang;
 #else
-        if(lang && *lang) {
+        if(lang && *lang)
             return lang;
-        }
+
         char buf[10];
         if(GetLocaleInfoA(LOCALE_USER_DEFAULT, LOCALE_SISO639LANGNAME, buf, sizeof(buf)) == 0)
             return "C";
@@ -43,7 +43,9 @@ namespace boost { namespace locale { namespace util {
             lc_name += "_";
             lc_name += buf;
         }
-        if(!use_utf8) {
+        if(use_utf8_on_windows)
+            lc_name += ".UTF-8";
+        else {
             if(GetLocaleInfoA(LOCALE_USER_DEFAULT, LOCALE_IDEFAULTANSICODEPAGE, buf, sizeof(buf)) != 0) {
                 if(atoi(buf) == 0)
                     lc_name += ".UTF-8";
@@ -51,11 +53,8 @@ namespace boost { namespace locale { namespace util {
                     lc_name += ".windows-";
                     lc_name += buf;
                 }
-            } else {
-                lc_name += "UTF-8";
-            }
-        } else {
-            lc_name += ".UTF-8";
+            } else
+                lc_name += ".UTF-8";
         }
         return lc_name;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -36,6 +36,7 @@ project : requirements
 run show_config.cpp : : : <test-info>always_show_run_output ;
 # Shared
 run test_utf.cpp ;
+run test_util.cpp test_helpers.cpp ;
 run test_date_time.cpp ;
 run test_ios_info.cpp ;
 run test_ios_prop.cpp ;

--- a/test/boostLocale/test/test_helpers.hpp
+++ b/test/boostLocale/test/test_helpers.hpp
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2022 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/locale/config.hpp>
+
+namespace boost { namespace locale { namespace test {
+    // POSIX setenv/unsetenv for all platforms and with ISO C++ compiler setting
+    int setenv(const char* key, const char* value);
+    int unsetenv(const char* key);
+}}} // namespace boost::locale::test

--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2022 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+// setenv etc. are an extension, so we need this for Cygwin and MinGW
+#if defined(__CYGWIN__) && !defined(_GNU_SOURCE)
+// The setenv family of functions is an extension on Cygwin
+#    define _GNU_SOURCE 1
+#endif
+#if defined(__MINGW32__) && defined(__STRICT_ANSI__)
+// On MinGW-w64 the workaround is not needed and leads to warnings
+#    include <_mingw.h>
+#    ifndef __MINGW64_VERSION_MAJOR
+#        undef __STRICT_ANSI__
+#    endif
+#endif
+
+#include <boostLocale/test/test_helpers.hpp>
+#include <cstdlib>
+#ifdef BOOST_WINDOWS
+#    include <list>
+#    include <string>
+#endif
+
+namespace boost { namespace locale { namespace test {
+#ifdef BOOST_WINDOWS
+    // Needed as strings become part of the environment
+    static std::list<std::string> env_values;
+
+    int setenv(const char* key, const char* value)
+    {
+        env_values.push_back(key + std::string("=") + value);
+        return _putenv(env_values.back().c_str());
+    }
+
+    int unsetenv(const char* key)
+    {
+        return setenv(key, "");
+    }
+
+#else
+    int setenv(const char* key, const char* value)
+    {
+        return ::setenv(key, value, 1);
+    }
+
+    int unsetenv(const char* key)
+    {
+        return ::unsetenv(key);
+    }
+#endif
+}}} // namespace boost::locale::test

--- a/test/test_ios_prop.cpp
+++ b/test/test_ios_prop.cpp
@@ -19,7 +19,7 @@ struct test_property {
         counter++;
         x = other.x;
     }
-    test_property& operator=(const test_property& other) = default;
+    test_property& operator=(const test_property&) = default;
     ~test_property() { counter--; }
     void on_imbue() { imbued++; }
 

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -32,14 +32,14 @@ void test_get_system_locale()
             TEST_EQ(enc, ".UTF-8");
     }
 #endif
-    // LC_CTYPE, LC_ALL and LANG variables used in this order
+    // LC_ALL, LC_CTYPE and LANG variables used in this order
     using boost::locale::test::setenv;
     setenv("LANG", "mylang.foo");
     TEST_EQ(get_system_locale(true), "mylang.foo");
-    setenv("LC_ALL", "barlang.bar");
-    TEST_EQ(get_system_locale(true), "barlang.bar");
     setenv("LC_CTYPE", "this.lang");
     TEST_EQ(get_system_locale(true), "this.lang");
+    setenv("LC_ALL", "barlang.bar");
+    TEST_EQ(get_system_locale(true), "barlang.bar");
 }
 
 void test_main(int /*argc*/, char** /*argv*/)

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2022 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/locale/util.hpp>
+#include "boostLocale/test/test_helpers.hpp"
+#include "boostLocale/test/unit_test.hpp"
+#include <cstdlib>
+
+void test_get_system_locale()
+{
+    // Clear all -> Default to C
+    {
+        using boost::locale::test::unsetenv;
+        unsetenv("LC_CTYPE");
+        unsetenv("LC_ALL");
+        unsetenv("LANG");
+    }
+
+    using boost::locale::util::get_system_locale;
+#if !defined(BOOST_WINDOWS) && !defined(__CYGWIN__)
+    TEST_EQ(get_system_locale(false), "C");
+#else
+    // On Windows the user default name is used, so we can only test the encoding
+    TEST(get_system_locale(true).find(".UTF-8") != std::string::npos);
+    {
+        const std::string loc = get_system_locale(false);
+        const std::string enc = loc.substr(loc.find_last_of('.'));
+        if(enc.find(".windows-") != 0u)
+            TEST_EQ(enc, ".UTF-8");
+    }
+#endif
+    // LC_CTYPE, LC_ALL and LANG variables used in this order
+    using boost::locale::test::setenv;
+    setenv("LANG", "mylang.foo");
+    TEST_EQ(get_system_locale(true), "mylang.foo");
+    setenv("LC_ALL", "barlang.bar");
+    TEST_EQ(get_system_locale(true), "barlang.bar");
+    setenv("LC_CTYPE", "this.lang");
+    TEST_EQ(get_system_locale(true), "this.lang");
+}
+
+void test_main(int /*argc*/, char** /*argv*/)
+{
+    test_get_system_locale();
+}

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -28,8 +28,9 @@ void test_get_system_locale()
     {
         const std::string loc = get_system_locale(false);
         const std::string enc = loc.substr(loc.find_last_of('.'));
+        // encoding should be a windows codepage, but in the error case can be UTF-8
         if(enc.find(".windows-") != 0u)
-            TEST_EQ(enc, ".UTF-8");
+            TEST_EQ(enc, ".UTF-8"); // LCOV_EXCL_LINE
     }
 #endif
     // LC_ALL, LC_CTYPE and LANG variables used in this order


### PR DESCRIPTION
 As per POSIX, see chapter 8.2, and linux man-pages, see man locale.7 the order should be

- LC_ALL
- LC_CTYPE
- LANG 

This PR does this using the changes from #22