### PR TITLE
Better locale name support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,20 +284,20 @@ jobs:
         if: matrix.coverage
         run: ci/github/codecov.sh "setup"
 
-      - name: Run tests with iconv
-        if: '!matrix.coverity'
-        run: ci/build.sh
-        env: {B2_FLAGS: -a boost.locale.icu=off boost.locale.iconv=on}
-      - name: Run tests with ICU
-        if: '!matrix.coverity'
-        run: ci/build.sh
-        env: {B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=off}
-      - name: Run tests with ICU/iconv
+      - name: Run tests
         if: '!matrix.coverity'
         run: |
           B2_TARGETS="libs/$SELF/test//show_config --verbose-test" ci/build.sh
           ci/build.sh
-        env: {B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=on}
+
+      - name: Run tests with iconv only
+        if: '!matrix.coverity'
+        run: ci/build.sh
+        env: {B2_FLAGS: -a boost.locale.icu=off boost.locale.iconv=on}
+      - name: Run tests with ICU only
+        if: '!matrix.coverity'
+        run: ci/build.sh
+        env: {B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=off}
 
       - name: Upload coverage
         if: matrix.coverage

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -8,12 +8,14 @@
 /*!
 \page changelog Changelog
 
-- Unreleased
+- 1.82.0
     - Breaking changes
         - `get_system_locale` and dependents will now correctly favor `$LC_ALL` over `LC_CTYPE` as defined by POSIX
     - Other improvements and fixes
         - Add `boost::locale::util::locale_data` to parse a locale
         - `boost::locale::info::encoding()` result is in uppercase as documented, e.g. "UTF-8" instead of "utf-8"
+        - Support M49 country codes such as `en_001` or `en_150`
+        - Treat `en_US_POSIX` as an alias for the `C` locale
 - 1.81.0
     - Breaking changes
         - Require C++11 or higher

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -10,6 +10,7 @@
 #include "boost/locale/util/encoding.hpp"
 #include "boost/locale/util/string.hpp"
 #include <boost/assert.hpp>
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 
@@ -89,14 +90,18 @@ namespace boost { namespace locale { namespace util {
         std::string tmp = input.substr(0, end);
         if(tmp.empty())
             return false;
+
         // uppercase ASCII
         for(char& c : tmp) {
             if(util::is_lower_ascii(c))
                 c += 'A' - 'a';
-            else if(util::is_numeric_ascii(c))
-                continue;
-            else if(!util::is_upper_ascii(c))
-                return false;
+            else if(!util::is_upper_ascii(c)) {
+                // Could be M49 country code: 3 digits
+                if(tmp.size() == 3u && std::find_if_not(tmp.begin(), tmp.end(), util::is_numeric_ascii) == tmp.end())
+                    break;
+                else
+                    return false;
+            }
         }
 
         country_ = tmp;

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -91,17 +91,21 @@ namespace boost { namespace locale { namespace util {
         if(tmp.empty())
             return false;
 
-        // uppercase ASCII
+        // Make uppercase
         for(char& c : tmp) {
             if(util::is_lower_ascii(c))
                 c += 'A' - 'a';
-            else if(!util::is_upper_ascii(c)) {
-                // Could be M49 country code: 3 digits
-                if(tmp.size() == 3u && std::find_if_not(tmp.begin(), tmp.end(), util::is_numeric_ascii) == tmp.end())
-                    break;
-                else
-                    return false;
-            }
+        }
+        // If it's ALL uppercase ASCII, assume ISO 3166 country id
+        if(std::find_if_not(tmp.begin(), tmp.end(), util::is_upper_ascii) != tmp.end()) {
+            // else handle special cases:
+            //   - en_US_POSIX is an alias for C
+            //   - M49 country code: 3 digits
+            if(language_ == "en" && tmp == "US_POSIX") {
+                language_ = "C";
+                tmp.clear();
+            } else if(tmp.size() != 3u || std::find_if_not(tmp.begin(), tmp.end(), util::is_numeric_ascii) != tmp.end())
+                return false;
         }
 
         country_ = tmp;

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -93,6 +93,8 @@ namespace boost { namespace locale { namespace util {
         for(char& c : tmp) {
             if(util::is_lower_ascii(c))
                 c += 'A' - 'a';
+            else if('0' <= tmp[i] && tmp[i] <= '9')
+                continue;
             else if(!util::is_upper_ascii(c))
                 return false;
         }

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -93,7 +93,7 @@ namespace boost { namespace locale { namespace util {
         for(char& c : tmp) {
             if(util::is_lower_ascii(c))
                 c += 'A' - 'a';
-            else if('0' <= tmp[i] && tmp[i] <= '9')
+            else if(util::is_numeric_ascii(c))
                 continue;
             else if(!util::is_upper_ascii(c))
                 return false;

--- a/test/boostLocale/test/posix_tools.hpp
+++ b/test/boostLocale/test/posix_tools.hpp
@@ -23,16 +23,6 @@ void freelocale(locale_t) {}
 #    define LC_ALL_MASK 0xFFFFFFFF
 #endif
 
-inline bool has_posix_locale(const std::string& name)
-{
-    locale_t l = newlocale(LC_ALL_MASK, name.c_str(), 0);
-    if(l) {
-        freelocale(l);
-        return true;
-    }
-    return false;
-}
-
 class locale_holder {
     locale_t l_;
     void reset(const locale_t l = 0)
@@ -54,5 +44,11 @@ public:
     }
     operator locale_t() const { return l_; }
 };
+
+inline bool has_posix_locale(const std::string& name)
+{
+    locale_holder l(newlocale(LC_ALL_MASK, name.c_str(), 0));
+    return !!l;
+}
 
 #endif

--- a/test/boostLocale/test/posix_tools.hpp
+++ b/test/boostLocale/test/posix_tools.hpp
@@ -23,7 +23,7 @@ void freelocale(locale_t) {}
 #    define LC_ALL_MASK 0xFFFFFFFF
 #endif
 
-inline bool have_locale(const std::string& name)
+inline bool has_posix_locale(const std::string& name)
 {
     locale_t l = newlocale(LC_ALL_MASK, name.c_str(), 0);
     if(l) {

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -13,6 +13,10 @@
 #include <locale>
 #include <stdexcept>
 #include <vector>
+#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
+#    include "../src/boost/locale/win32/lcid.hpp"
+#endif
+#include <boost/core/ignore_unused.hpp>
 
 #ifdef BOOST_LOCALE_WITH_ICU
 #    include <unicode/uversion.h>
@@ -36,20 +40,25 @@ const char* env(const char* s)
     return "";
 }
 
-bool has_locale(const char* name)
+bool has_win_locale(const std::string& locale_name)
 {
-    const bool result = std::setlocale(LC_ALL, name) != nullptr;
-    std::setlocale(LC_ALL, "C");
-    return result;
+#ifdef BOOST_LOCALE_NO_WINAPI_BACKEND
+    boost::ignore_unused(locale_name);
+    return false;
+#else
+    return boost::locale::impl_win::locale_to_lcid(locale_name) != 0;
+#endif
 }
 
 void check_locales(const std::vector<const char*>& names)
 {
-    std::cout << "  " << std::setw(32) << "locale" << std::setw(4) << "C" << std::setw(4) << "C++" << std::endl;
+    std::cout << std::setw(32) << "locale" << std::setw(7) << "POSIX" << std::setw(5) << "STD" << std::setw(5) << "WIN"
+              << std::endl;
     for(const char* name : names) {
-        std::cout << "  " << std::setw(32) << name;
-        std::cout << std::setw(4) << (has_locale(name) ? "Yes" : "No");
-        std::cout << std::setw(4) << (has_std_locale(name) ? "Yes" : "No");
+        std::cout << std::setw(32) << name;
+        std::cout << std::setw(7) << (has_posix_locale(name) ? "Yes" : "No");
+        std::cout << std::setw(5) << (has_std_locale(name) ? "Yes" : "No");
+        std::cout << std::setw(5) << (has_win_locale(name) ? "Yes" : "No");
         std::cout << std::endl;
     }
 }
@@ -111,6 +120,8 @@ void test_main(int /*argc*/, char** /*argv*/)
       "ja_JP.UTF-8",
       "ja_JP.SJIS",
       "Japanese_Japan.932",
+      "en_001.UTF-8",
+      "en_150.UTF-8",
     };
     std::cout << "- Testing locales availability on the operation system:" << std::endl;
     check_locales(locales_to_check);

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -498,27 +498,15 @@ void test_main(int /*argc*/, char** /*argv*/)
         test_utf = true;
 #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
         if(backendName == "posix") {
-            {
-                locale_holder l(newlocale(LC_ALL_MASK, he_il_8bit.c_str(), 0));
-                if(!l)
-                    test_iso = false;
-            }
-            {
-                locale_holder l(newlocale(LC_ALL_MASK, en_us_8bit.c_str(), 0));
-                if(!l)
-                    test_iso = false;
-            }
-            {
-                locale_holder l(newlocale(LC_ALL_MASK, "en_US.UTF-8", 0));
-                if(!l)
-                    test_utf = false;
-            }
+            if(!has_posix_locale(he_il_8bit))
+                test_iso = false;
+            if(!has_posix_locale(en_us_8bit))
+                test_iso = false;
+            if(!has_posix_locale("en_US.UTF-8"))
+                test_utf = false;
 #    ifdef BOOST_LOCALE_WITH_ICONV
-            {
-                locale_holder l(newlocale(LC_ALL_MASK, ja_jp_shiftjis.c_str(), 0));
-                if(!l)
-                    test_sjis = false;
-            }
+            if(!has_posix_locale(ja_jp_shiftjis))
+                test_sjis = false;
 #    else
             test_sjis = false;
 #    endif

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -5,10 +5,21 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale.hpp>
+#include "../src/boost/locale/win32/lcid.hpp"
+#include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
+#include <boost/core/ignore_unused.hpp>
 #include <iomanip>
+#include <locale>
+#include <sstream>
 #include <string>
 #include <vector>
+#ifdef BOOST_LOCALE_WITH_ICU
+#    include <unicode/uversion.h>
+#    define BOOST_LOCALE_ICU_VERSION (U_ICU_VERSION_MAJOR_NUM * 100 + U_ICU_VERSION_MINOR_NUM)
+#else
+#    define BOOST_LOCALE_ICU_VERSION 0
+#endif
 
 bool has_message(const std::locale& l)
 {
@@ -24,6 +35,85 @@ std::locale::id test_facet::id;
 
 template<typename CharType>
 using codecvt_by_char_type = std::codecvt<CharType, char, std::mbstate_t>;
+
+namespace bl = boost::locale;
+
+bool hasLocaleForBackend(const std::string& locale_name, const std::string& backendName)
+{
+    if(backendName == "winapi") {
+#ifdef BOOST_LOCALE_NO_WINAPI_BACKEND
+        boost::ignore_unused(locale_name);
+        return false;
+#else
+        return bl::impl_win::locale_to_lcid(locale_name) != 0;
+#endif
+    } else if(backendName == "std")
+        return has_std_locale(locale_name.c_str());
+    else if(backendName == "posix")
+        return have_locale(locale_name);
+    else                                         // ICU
+        return BOOST_LOCALE_ICU_VERSION >= 5901; // First version to use (correct) CLDR data
+}
+
+void test_special_locales(const std::vector<std::string>& backends)
+{
+    for(const std::string& backendName : backends) {
+        std::cout << "Backend: " << backendName << std::endl;
+        bl::localization_backend_manager tmp_backend = bl::localization_backend_manager::global();
+        tmp_backend.select(backendName);
+        bl::localization_backend_manager::global(tmp_backend);
+
+        bl::generator g;
+        namespace as = bl::as;
+        constexpr time_t datetime = 60 * 60 * 24 * (31 + 4) // Feb 5th
+                                    + (15 * 60 + 42) * 60;  // 15:42
+
+        const std::string enWorldName = "en_001.UTF-8";
+        if(!hasLocaleForBackend(enWorldName, backendName))
+            std::cout << "\tSkipping due to missing locale " << enWorldName << std::endl;
+        else {
+            auto l = g(enWorldName);
+            const auto& info = std::use_facet<bl::info>(l);
+            TEST_EQ(info.language(), "en");
+            TEST_EQ(info.country(), "001");
+            TEST(info.utf8());
+            TEST_EQ(info.encoding(), "UTF-8");
+
+            std::ostringstream os;
+            os.imbue(l);
+            os << as::time << as::gmt << as::time_short;
+            os << datetime;
+            TEST_EQ(os.str().substr(0, 4), "3:42"); // 3:42 pm
+        }
+        const std::string enEuropeName = "en_150.UTF-8";
+        if(!hasLocaleForBackend(enEuropeName, backendName))
+            std::cout << "\tSkipping due to missing locale " << enEuropeName << std::endl;
+        else {
+            auto l = g(enEuropeName);
+            const auto& info = std::use_facet<bl::info>(l);
+            TEST_EQ(info.language(), "en");
+            TEST_EQ(info.country(), "150");
+            TEST(info.utf8());
+            TEST_EQ(info.encoding(), "UTF-8");
+
+            std::ostringstream os;
+
+            std::string expectedTimeFormat = "15:42";
+            // The std locale may not fully support the 150 region and use a different format
+            if(backendName == "std") {
+                os.imbue(std::locale(os.getloc(), new std::time_put_byname<char>(enEuropeName)));
+                os << std::put_time(gmtime_wrap(&datetime), "%X");
+                expectedTimeFormat = os.str();
+                os.str("");
+            }
+
+            os.imbue(l);
+            os << as::time << as::gmt << as::time_short;
+            os << datetime;
+            TEST_EQ(os.str().substr(0, expectedTimeFormat.size()), expectedTimeFormat);
+        }
+    }
+}
 
 void test_main(int /*argc*/, char** /*argv*/)
 {
@@ -41,10 +131,9 @@ void test_main(int /*argc*/, char** /*argv*/)
     backends.push_back("posix");
 #endif
 
-    namespace bl = boost::locale;
     const bl::localization_backend_manager orig_backend = bl::localization_backend_manager::global();
     for(const std::string& backendName : backends) {
-        std::cout << "Backend: " << backendName << '\n';
+        std::cout << "Backend: " << backendName << std::endl;
         bl::localization_backend_manager tmp_backend = bl::localization_backend_manager::global();
         tmp_backend.select(backendName);
         bl::localization_backend_manager::global(tmp_backend);
@@ -89,6 +178,9 @@ void test_main(int /*argc*/, char** /*argv*/)
         // information
         TEST(std::has_facet<bl::info>(l));
     }
+    std::cout << "Test special locales" << std::endl;
+    test_special_locales(backends);
+    std::cout << "Restoring original backend" << std::endl;
     bl::localization_backend_manager::global(orig_backend);
 
     bl::generator g;

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -50,7 +50,7 @@ bool hasLocaleForBackend(const std::string& locale_name, const std::string& back
     } else if(backendName == "std")
         return has_std_locale(locale_name.c_str());
     else if(backendName == "posix")
-        return have_locale(locale_name);
+        return has_posix_locale(locale_name);
     else                                         // ICU
         return BOOST_LOCALE_ICU_VERSION >= 5901; // First version to use (correct) CLDR data
 }

--- a/test/test_posix_collate.cpp
+++ b/test/test_posix_collate.cpp
@@ -61,13 +61,13 @@ void test_char()
 
 #if !defined(__APPLE__) && !defined(__FreeBSD__)
     for(const std::string locale_name : {"en_US.UTF-8", "en_US.ISO8859-1"}) {
-        if(have_locale(locale_name)) {
+        if(!has_posix_locale(locale_name))
+            std::cout << "- " << locale_name << " not supported, skipping" << std::endl;
+        else {
             std::cout << "- Testing " << locale_name << std::endl;
             l = gen(locale_name);
             test_one<CharType>(l, "a", "ç", -1);
             test_one<CharType>(l, "ç", "d", -1);
-        } else {
-            std::cout << "- " << locale_name << " not supported, skipping" << std::endl;
         }
     }
 #else

--- a/test/test_posix_convert.cpp
+++ b/test/test_posix_convert.cpp
@@ -32,16 +32,18 @@ void test_char()
     test_one<CharType>(l, "Hello World i", "hello world i", "HELLO WORLD I");
 
     std::string name = "en_US.UTF-8";
-    if(have_locale(name)) {
+    if(!has_posix_locale(name))
+        std::cout << "- " << name << " is not supported, skipping" << std::endl;
+    else {
         std::cout << "- Testing " << name << std::endl;
         l = gen(name);
         test_one<CharType>(l, "Façade", "façade", "FAÇADE");
-    } else {
-        std::cout << "- en_US.UTF-8 is not supported, skipping" << std::endl;
     }
 
     name = "en_US.ISO8859-1";
-    if(have_locale(name)) {
+    if(!has_posix_locale(name))
+        std::cout << "- " << name << " is not supported, skipping" << std::endl;
+    else {
         std::cout << "Testing " << name << std::endl;
         l = gen(name);
         test_one<CharType>(l, "Hello World", "hello world", "HELLO WORLD");
@@ -49,12 +51,12 @@ void test_char()
         if(sizeof(CharType) != 1)
 #endif
             test_one<CharType>(l, "Façade", "façade", "FAÇADE");
-    } else {
-        std::cout << "- en_US.ISO8859-1 is not supported, skipping" << std::endl;
     }
 
     name = "tr_TR.UTF-8";
-    if(have_locale(name)) {
+    if(!has_posix_locale(name))
+        std::cout << "- " << name << " is not supported, skipping" << std::endl;
+    else {
         std::cout << "Testing " << name << std::endl;
         locale_holder cl(newlocale(LC_ALL_MASK, name.c_str(), 0));
         TEST(cl);
@@ -64,8 +66,6 @@ void test_char()
         else
             std::cout << "  Turkish locale is not supported well" << std::endl; // LCOV_EXCL_LINE
 #endif
-    } else {
-        std::cout << "- tr_TR.UTF-8 is not supported, skipping" << std::endl;
     }
 }
 

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -146,7 +146,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     boost::locale::generator gen;
     for(const std::string locale_name : {"en_US.UTF-8", "en_US.ISO8859-1", "he_IL.UTF-8", "he_IL.ISO8859-8"}) {
         std::cout << locale_name << " locale" << std::endl;
-        if(!have_locale(locale_name)) {
+        if(!has_posix_locale(locale_name)) {
             std::cout << locale_name << " not supported" << std::endl;
         } else {
             std::locale generated_locale = gen(locale_name);
@@ -163,7 +163,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     {
         std::cout << "Testing UTF-8 punct issues" << std::endl;
         const std::string locale_name = "ru_RU.UTF-8";
-        if(!have_locale(locale_name)) {
+        if(!has_posix_locale(locale_name)) {
             std::cout << "- No Russian locale" << std::endl;
         } else {
             std::ostringstream ss;

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -125,6 +125,14 @@ void test_locale_data()
     TEST(data.is_utf8());
     TEST_EQ(data.variant(), "radical");
 
+    // Country can be a 3-digit value
+    TEST(data.parse("en_001.UTF-8"));
+    TEST_EQ(data.language(), "en");
+    TEST_EQ(data.country(), "001");
+    TEST_EQ(data.encoding(), "UTF-8");
+    TEST(data.is_utf8());
+    TEST_EQ(data.variant(), "");
+
     // to_string yields the input (if format is correct already)
     for(const std::string name : {"C",
                                   "en_US.UTF-8",
@@ -134,7 +142,9 @@ void test_locale_data()
                                   "en_US",
                                   "ko_KR.EUC@dict",
                                   "th_TH.TIS620",
-                                  "zh_TW.UTF-8@radical"})
+                                  "zh_TW.UTF-8@radical",
+                                  "en_001",
+                                  "en_150.UTF-8"})
     {
         TEST(data.parse(name));
         TEST_EQ(data.to_string(), name);
@@ -199,6 +209,12 @@ void test_locale_data()
     }
     // Invalid country
     TEST(!data.parse("en_UÖ.UTF-8"));
+    TEST_EQ(data.to_string(), "en");
+    TEST(!data.parse("en_1234.UTF-8")); // To many digits
+    TEST_EQ(data.to_string(), "en");
+    TEST(!data.parse("en_US1.UTF-8")); // digits in text
+    TEST_EQ(data.to_string(), "en");
+    TEST(!data.parse("en_1US.UTF-8")); // digits in text
     TEST_EQ(data.to_string(), "en");
 
     // Empty parts:

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -180,6 +180,12 @@ void test_locale_data()
     TEST(data.parse("POSIX.UTF-8"));
     TEST_EQ(data.to_string(), "C.UTF-8");
 
+    // Special case: en_US_POSIX is an alias for "C"
+    TEST(data.parse("en_US_POSIX"));
+    TEST_EQ(data.to_string(), "C");
+    TEST(data.parse("En_Us_POsix.UTF-8"));
+    TEST_EQ(data.to_string(), "C.UTF-8");
+
     // Missing values are defaulted
     TEST(data.parse("en"));
     TEST_EQ(data.to_string(), "en");


### PR DESCRIPTION
- Add support for en_001 and en_150 locales, Closes #59
- Generally allow M49 country codes (3 digits)
- Treat en_US_POSIX as an alias for the C locale

Fixes #58