### PR TITLE
Improve conversion example.

### DIFF
--- a/examples/conversions.cpp
+++ b/examples/conversions.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2023 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -8,31 +9,37 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <iostream>
 
-#include <ctime>
-
 int main()
 {
-    using namespace boost::locale;
+    if(boost::locale::localization_backend_manager::global().get_all_backends().at(0) != "icu")
+        std::cout << "Need ICU support for this example!\nConversion below will likely be wrong!\n";
+
     // Create system default locale
-    generator gen;
+    boost::locale::generator gen;
     std::locale loc = gen("");
     std::locale::global(loc);
     std::cout.imbue(loc);
 
+    // This is needed to prevent the C stdio library from
+    // converting strings to narrow on some platforms
+    std::ios_base::sync_with_stdio(false);
+
     std::cout << "Correct case conversion can't be done by simple, character by character conversion\n";
-    std::cout << "because case conversion is context sensitive and not 1-to-1 conversion\n";
+    std::cout << "because case conversion is context sensitive and not a 1-to-1 conversion.\n";
     std::cout << "For example:\n";
-    std::cout << "   German grüßen correctly converted to " << to_upper("grüßen") << ", instead of incorrect "
-              << boost::to_upper_copy(std::string("grüßen")) << std::endl;
-    std::cout << "     where ß is replaced with SS\n";
-    std::cout << "   Greek ὈΔΥΣΣΕΎΣ is correctly converted to " << to_lower("ὈΔΥΣΣΕΎΣ") << ", instead of incorrect "
-              << boost::to_lower_copy(std::string("ὈΔΥΣΣΕΎΣ")) << std::endl;
-    std::cout << "     where Σ is converted to σ or to ς, according to position in the word\n";
-    std::cout << "Such type of conversion just can't be done using std::toupper that work on character base, also "
-                 "std::toupper is\n";
-    std::cout << "not even applicable when working with variable character length like in UTF-8 or UTF-16 limiting the "
-                 "correct\n";
-    std::cout << "behavior to unicode subset BMP or ASCII only\n";
+    const std::string gruessen("grüßen");
+    std::cout << "   German " << gruessen << " would be incorrectly converted to " << boost::to_upper_copy(gruessen);
+    std::cout << ", while Boost.Locale converts it to " << boost::locale::to_upper(gruessen) << std::endl
+              << "     where ß is replaced with SS.\n";
+    const std::string greek("ὈΔΥΣΣΕΎΣ");
+    std::cout << "   Greek " << greek << " would be incorrectly converted to " << boost::to_lower_copy(greek);
+    std::cout << ", while Boost.Locale correctly converts it to " << boost::locale::to_lower(greek) << std::endl
+              << "     where Σ is converted to σ or to ς, according to position in the word.\n";
+    std::cout
+      << "Such type of conversion just can't be done using std::toupper/boost::to_upper* that work on character "
+         "by character base.\n"
+         "Also std::toupper is not fully applicable when working with variable character length like UTF-8 or UTF-16\n"
+         "limiting the correct behavior to BMP or ASCII only\n";
 }
 
 // boostinspect:noascii

--- a/examples/wconversions.cpp
+++ b/examples/wconversions.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2023 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -32,13 +33,13 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <iostream>
 
-#include <ctime>
-
 int main()
 {
-    using namespace boost::locale;
+    if(boost::locale::localization_backend_manager::global().get_all_backends().at(0) != "icu")
+        std::wcout << L"Need ICU support for this example!\nConversion below will likely be wrong!\n";
+
     // Create system default locale
-    generator gen;
+    boost::locale::generator gen;
     std::locale loc = gen("");
     std::locale::global(loc);
     std::wcout.imbue(loc);
@@ -48,19 +49,21 @@ int main()
     std::ios_base::sync_with_stdio(false);
 
     std::wcout << L"Correct case conversion can't be done by simple, character by character conversion\n";
-    std::wcout << L"because case conversion is context sensitive and not 1-to-1 conversion\n";
+    std::wcout << L"because case conversion is context sensitive and not a 1-to-1 conversion.\n";
     std::wcout << L"For example:\n";
-    std::wcout << L"   German grüßen correctly converted to " << to_upper(L"grüßen") << L", instead of incorrect "
-               << boost::to_upper_copy(std::wstring(L"grüßen")) << std::endl;
-    std::wcout << L"     where ß is replaced with SS\n";
-    std::wcout << L"   Greek ὈΔΥΣΣΕΎΣ is correctly converted to " << to_lower(L"ὈΔΥΣΣΕΎΣ") << L", instead of incorrect "
-               << boost::to_lower_copy(std::wstring(L"ὈΔΥΣΣΕΎΣ")) << std::endl;
-    std::wcout << L"     where Σ is converted to σ or to ς, according to position in the word\n";
-    std::wcout << L"Such type of conversion just can't be done using std::toupper that work on character base, also "
-                  L"std::toupper is \n";
-    std::wcout << L"not fully applicable when working with variable character length like in UTF-8 or UTF-16 limiting "
-                  L"the correct \n";
-    std::wcout << L"behavoir to BMP or ASCII only\n";
+    const std::wstring gruessen(L"grüßen");
+    std::wcout << L"   German " << gruessen << " would be incorrectly converted to " << boost::to_upper_copy(gruessen);
+    std::wcout << ", while Boost.Locale converts it to " << boost::locale::to_upper(gruessen) << std::endl
+               << L"     where ß is replaced with SS.\n";
+    const std::wstring greek(L"ὈΔΥΣΣΕΎΣ");
+    std::wcout << L"   Greek " << greek << " would be incorrectly converted to " << boost::to_lower_copy(greek);
+    std::wcout << ", while Boost.Locale correctly converts it to " << boost::locale::to_lower(greek) << std::endl
+               << L"     where Σ is converted to σ or to ς, according to position in the word.\n";
+    std::wcout
+      << L"Such type of conversion just can't be done using std::toupper/boost::to_upper* that work on character "
+         L"by character base.\n"
+         L"Also std::toupper is not fully applicable when working with variable character length like UTF-8 or UTF-16\n"
+         L"limiting the correct behavior to BMP or ASCII only\n";
 }
 
 // boostinspect:noascii


### PR DESCRIPTION
Make it clear which output is from Boost.Locale and what is the expected behavior by changing the order.
Also check for ICU support as only ICU is able to do that conversion.

Closes #51