### PR TITLE
Add test for parsing the plural expression in catalogs

### DIFF
--- a/src/boost/locale/icu/date_time.cpp
+++ b/src/boost/locale/icu/date_time.cpp
@@ -95,16 +95,16 @@ namespace boost { namespace locale { namespace impl_icu {
                 guard l(lock_);
                 v = calendar_->getFirstDayOfWeek(err);
             } else {
-                UCalendarDateFields uper = to_icu(p);
+                UCalendarDateFields field = to_icu(p);
                 guard l(lock_);
                 switch(type) {
-                    case absolute_minimum: v = calendar_->getMinimum(uper); break;
-                    case actual_minimum: v = calendar_->getActualMinimum(uper, err); break;
-                    case greatest_minimum: v = calendar_->getGreatestMinimum(uper); break;
-                    case current: v = calendar_->get(uper, err); break;
-                    case least_maximum: v = calendar_->getLeastMaximum(uper); break;
-                    case actual_maximum: v = calendar_->getActualMaximum(uper, err); break;
-                    case absolute_maximum: v = calendar_->getMaximum(uper); break;
+                    case absolute_minimum: v = calendar_->getMinimum(field); break;
+                    case actual_minimum: v = calendar_->getActualMinimum(field, err); break;
+                    case greatest_minimum: v = calendar_->getGreatestMinimum(field); break;
+                    case current: v = calendar_->get(field, err); break;
+                    case least_maximum: v = calendar_->getLeastMaximum(field); break;
+                    case actual_maximum: v = calendar_->getActualMaximum(field, err); break;
+                    case absolute_maximum: v = calendar_->getMaximum(field); break;
                 }
             }
             check_and_throw_dt(err);

--- a/src/boost/locale/shared/mo_lambda.hpp
+++ b/src/boost/locale/shared/mo_lambda.hpp
@@ -20,7 +20,7 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
     typedef std::shared_ptr<plural> plural_ptr;
 
-    plural_ptr compile(const char* c_expression);
+    BOOST_LOCALE_DECL plural_ptr compile(const char* c_expression);
 
 }}}} // namespace boost::locale::gnu_gettext::lambda
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -31,6 +31,7 @@ project : requirements
 run show_config.cpp
     : : : <test-info>always_show_run_output ;
 # Shared
+run test_catalog.cpp ;
 run test_utf.cpp ;
 run test_util.cpp test_helpers.cpp ;
 run test_date_time.cpp ;

--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -1,0 +1,186 @@
+//
+// Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include "../src/boost/locale/shared/mo_lambda.hpp"
+#include "boostLocale/test/unit_test.hpp"
+#include <iostream>
+#include <limits>
+#include <random>
+
+// We want to use `boost::locale::gnu_gettext::lambda::plural`
+// without exporting it which leads to false positives under UBSAN -> Disable this check
+#ifdef __has_attribute
+#    if __has_attribute(no_sanitize)
+#        define BOOST_LOCALE_WRONG_VPTR_OK __attribute__((no_sanitize("vptr")))
+#    else
+#        define BOOST_LOCALE_WRONG_VPTR_OK
+#    endif
+#else
+#    define BOOST_LOCALE_WRONG_VPTR_OK
+#endif
+
+template<typename T>
+T getRandValue(const T min, const T max)
+{
+    static std::mt19937 gen{std::random_device{}()};
+    std::uniform_int_distribution<T> distrib(min, max);
+    return distrib(gen);
+}
+
+template<typename T>
+BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr_rand(const T& ref, const char* expr)
+{
+    constexpr auto minVal = std::numeric_limits<int>::min() / 1024;
+    constexpr auto maxVal = std::numeric_limits<int>::max() / 1024;
+    const auto ptr = boost::locale::gnu_gettext::lambda::compile(expr);
+    constexpr int number_of_tries = 256;
+    for(int i = 0; i < number_of_tries; i++) {
+        const auto n = getRandValue(minVal, maxVal);
+        const auto result = (*ptr)(n);
+        const auto refResult = ref(n);
+        if(result != refResult) {
+            std::cerr << "Expression: " << expr << "; n=" << n << '\n'; // LCOV_EXCL_LINE
+            TEST_EQ(result, refResult);                                 // LCOV_EXCL_LINE
+        }
+    }
+}
+
+BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
+{
+#define TEST_PLURAL_EXPR(expr) \
+    test_plural_expr_rand(     \
+      [](int n) {              \
+          (void)n;             \
+          return expr;         \
+      },                       \
+      #expr);
+    TEST_PLURAL_EXPR(42);
+    TEST_PLURAL_EXPR(1337);
+    TEST_PLURAL_EXPR(n + 3);
+    TEST_PLURAL_EXPR(n - 3);
+    TEST_PLURAL_EXPR(n * 5);
+    TEST_PLURAL_EXPR(n / 5);
+    TEST_PLURAL_EXPR(n % 8);
+    // Parentheses
+    TEST_PLURAL_EXPR((5 * n) + 3);
+    TEST_PLURAL_EXPR(5 * (n + 3));
+    // Comparisons and ternary
+    TEST_PLURAL_EXPR(n % 2 == 0 ? n + 5 : n * 3);
+    TEST_PLURAL_EXPR(n % 2 != 0 ? n + 5 : n * 3);
+    TEST_PLURAL_EXPR(n % 4 < 2 ? n + 5 : n * 3);
+    TEST_PLURAL_EXPR(n % 4 <= 2 ? n + 5 : n * 3);
+    TEST_PLURAL_EXPR(n % 4 > 2 ? n + 5 : n * 3);
+    TEST_PLURAL_EXPR(n % 4 >= 2 ? n + 5 : n * 3);
+    // Complex expression (e.g. for Russian)
+    TEST_PLURAL_EXPR((n % 10 == 1 && n % 100 != 11                                  ? 0 :
+                      n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 :
+                                                                                      2));
+#undef TEST_PLURAL_EXPR
+
+    using boost::locale::gnu_gettext::lambda::compile;
+    constexpr auto minVal = std::numeric_limits<int>::min();
+    constexpr auto maxVal = std::numeric_limits<int>::max();
+
+    // E.g. Japanese
+    {
+        const auto ptr = compile("0");
+        TEST(ptr);
+        const auto& p = *ptr;
+        TEST_EQ(p(0), 0);
+        TEST_EQ(p(minVal), 0);
+        TEST_EQ(p(maxVal), 0);
+    }
+    // E.g. English
+    {
+        const auto ptr = compile("(n != 1)");
+        TEST(ptr);
+        const auto& p = *ptr;
+        TEST_EQ(p(0), 1);
+        TEST_EQ(p(1), 0);
+        TEST_EQ(p(minVal), 1);
+        TEST_EQ(p(maxVal), 1);
+    }
+    // E.g. French
+    {
+        const auto ptr = compile("(n > 1)");
+        TEST(ptr);
+        const auto& p = *ptr;
+        TEST_EQ(p(0), 0);
+        TEST_EQ(p(1), 0);
+        TEST_EQ(p(2), 1);
+        TEST_EQ(p(minVal), 0);
+        TEST_EQ(p(maxVal), 1);
+    }
+    // E.g. Latvian
+    {
+        const auto ptr = compile("(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)");
+        TEST(ptr);
+        const auto& p = *ptr;
+        TEST_EQ(p(0), 2);
+        TEST_EQ(p(1), 0);
+        TEST_EQ(p(2), 1);
+        TEST_EQ(p(3), 1);
+        TEST_EQ(p(11), 1);
+        TEST_EQ(p(12), 1);
+        TEST_EQ(p(21), 0);
+        TEST_EQ(p(31), 0);
+        TEST_EQ(p(101), 0);
+        TEST_EQ(p(111), 1);
+    }
+    // E.g. Irish
+    {
+        const auto ptr = compile("n == 1 ? 0 : n == 2 ? 1 : 2");
+        TEST(ptr);
+        const auto& p = *ptr;
+        TEST_EQ(p(0), 2);
+        TEST_EQ(p(1), 0);
+        TEST_EQ(p(2), 1);
+        TEST_EQ(p(3), 2);
+        TEST_EQ(p(4), 2);
+        TEST_EQ(p(minVal), 2);
+        TEST_EQ(p(maxVal), 2);
+    }
+    // E.g. Czech
+    {
+        const auto ptr = compile("(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2");
+        TEST(ptr);
+        const auto& p = *ptr;
+        TEST_EQ(p(0), 2);
+        TEST_EQ(p(1), 0);
+        TEST_EQ(p(2), 1);
+        TEST_EQ(p(3), 1);
+        TEST_EQ(p(4), 1);
+        TEST_EQ(p(5), 2);
+        TEST_EQ(p(minVal), 2);
+        TEST_EQ(p(maxVal), 2);
+    }
+    // Error cases
+    TEST(!compile("") && compile("n")); // Empty
+    // Invalid comparison
+    TEST(!compile("n===1") && compile("n==1"));
+    TEST(!compile("n!1") && compile("n!=1"));
+    TEST(!compile("n!<1") && compile("n<1"));
+    TEST(!compile("n<==1") && compile("n<=1"));
+    TEST(!compile("n<>1") && compile("n>1"));
+    // Incomplete ternary
+    TEST(!compile("n==1 ?"));
+    TEST(!compile("n==1 ? 1"));
+    TEST(!compile("n==1 ? 1 :"));
+    TEST(compile("n==1 ? 1 : 0"));
+    // Missing closing parenthesis
+    TEST(!compile("(n==1") && compile("(n==1)"));
+    TEST(!compile("(n + 1") && compile("(n + 1)"));
+    TEST(!compile("(n==1 ? 1 : 2") && compile("(n==1 ? 1 : 2)"));
+    // Extra closing parenthesis
+    TEST(!compile("n==1)") && compile("(n==1)"));
+    TEST(!compile("n + 1)") && compile("(n + 1)"));
+    TEST(!compile("n==1 ? 1 : 2)") && compile("(n==1 ? 1 : 2)"));
+}
+
+void test_main(int /*argc*/, char** /*argv*/)
+{
+    test_plural_expr();
+}

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -10,6 +10,7 @@
 #include <boost/locale/localization_backend.hpp>
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
+#include <cmath>
 #include <ctime>
 #include <iomanip>
 #include <limits>
@@ -297,7 +298,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ_FMT(tp_5_april_1990_153313 - month(12 * 3 + 1), "1987-03-05 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 >> month(12 * 3 + 1), "1990-03-05 15:33:13");
             // Check that possible int overflows get handled
-            const int max_full_years_in_months = (std::numeric_limits<int>::max() / 12) * 12;
+            constexpr int max_full_years_in_months = (std::numeric_limits<int>::max() / 12) * 12;
             TEST_EQ_FMT(tp_5_april_1990_153313 >> month(max_full_years_in_months), "1990-04-05 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 << month(max_full_years_in_months), "1990-04-05 15:33:13");
             TEST_EQ_FMT(tp_5_april_1990_153313 + day(30 + 2), "1990-05-07 15:33:13");
@@ -500,11 +501,12 @@ void test_main(int /*argc*/, char** /*argv*/)
                 // Defaults to current time, i.e. different than a date in 1970
                 date_time time_point_1970 = year(1970) + february() + day(5);
                 TEST(time_point_default != time_point_1970);
-                // We can not check an exact time as we can't know
-                // at which exact time the time point was recorded
+                // We can not check an exact time as we can't know at which exact time the time point was recorded. So
+                // only check that it refers to the same hour
                 const double time_point_time = time_point_default.time();
                 TEST_GE(time_point_time, current_time);
-                TEST_EQ(static_cast<time_t>(time_point_time / 3600), current_time / 3600); // Roughly match
+                constexpr double secsPerHour = 60 * 60;
+                TEST_LE(time_point_time - current_time, secsPerHour);
                 // However at least the date should match
                 const tm current_time_gmt = *gmtime_wrap(&current_time);
                 TEST_EQ(time_point_default.get(year()), current_time_gmt.tm_year + 1900);

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -97,27 +97,28 @@ std::u32string same_u32(std::u32string s)
 }
 #endif
 
+namespace impl {
+
 template<typename Char>
-void strings_equal(std::string n_c,
-                   std::string n_s,
-                   std::string n_p,
-                   int n,
-                   std::string iexpected,
-                   const std::locale& l,
-                   std::string domain)
+void test_cntranslate(const std::string& sContext,
+                      const std::string& sSingular,
+                      const std::string& sPlural,
+                      int n,
+                      const std::string& sExpected,
+                      const std::locale& l,
+                      const std::string& domain)
 {
     typedef std::basic_string<Char> string_type;
-    string_type expected = to_correct_string<Char>(iexpected, l);
+    const string_type expected = to_correct_string<Char>(sExpected, l);
 
-    string_type c = to<Char>(n_c.c_str());
-    string_type s = to<Char>(n_s.c_str());
-    string_type p = to<Char>(n_p.c_str());
+    const string_type c = to<Char>(sContext.c_str());
+    const string_type s = to<Char>(sSingular.c_str());
+    const string_type p = to<Char>(sPlural.c_str());
 
     if(domain == "default") {
         TEST_EQ(bl::translate(c, s, p, n).str(l), expected);
-        const Char *c_c_str = c.c_str(), *s_c_str = s.c_str(), *p_c_str = p.c_str(); // workaround gcc-3.4 bug
-        TEST_EQ(bl::translate(c_c_str, s_c_str, p_c_str, n).str(l), expected);
-        std::locale tmp_locale = std::locale();
+        TEST_EQ(bl::translate(c.c_str(), s.c_str(), p.c_str(), n).str(l), expected);
+        std::locale tmp_locale;
         std::locale::global(l);
         string_type tmp = bl::translate(c, s, p, n);
         TEST_EQ(tmp, expected);
@@ -131,7 +132,7 @@ void strings_equal(std::string n_c,
         TEST_EQ(ss.str(), expected);
     }
     TEST_EQ(bl::translate(c, s, p, n).str(l, domain), expected);
-    std::locale tmp_locale = std::locale();
+    std::locale tmp_locale;
     std::locale::global(l);
     TEST_EQ(bl::translate(c, s, p, n).str(domain), expected);
     std::locale::global(tmp_locale);
@@ -150,22 +151,21 @@ void strings_equal(std::string n_c,
 }
 
 template<typename Char>
-void strings_equal(std::string n_s,
-                   std::string n_p,
-                   int n,
-                   std::string iexpected,
-                   const std::locale& l,
-                   std::string domain)
+void test_ntranslate(const std::string& sSingular,
+                     const std::string& sPlural,
+                     int n,
+                     const std::string& sExpected,
+                     const std::locale& l,
+                     const std::string& domain)
 {
     typedef std::basic_string<Char> string_type;
-    string_type expected = to_correct_string<Char>(iexpected, l);
-    string_type s = to<Char>(n_s.c_str());
-    string_type p = to<Char>(n_p.c_str());
+    const string_type expected = to_correct_string<Char>(sExpected, l);
+    const string_type s = to<Char>(sSingular.c_str());
+    const string_type p = to<Char>(sPlural.c_str());
     if(domain == "default") {
         TEST_EQ(bl::translate(s, p, n).str(l), expected);
-        const Char *s_c_str = s.c_str(), *p_c_str = p.c_str(); // workaround gcc-3.4 bug
-        TEST_EQ(bl::translate(s_c_str, p_c_str, n).str(l), expected);
-        std::locale tmp_locale = std::locale();
+        TEST_EQ(bl::translate(s.c_str(), p.c_str(), n).str(l), expected);
+        std::locale tmp_locale;
         std::locale::global(l);
         string_type tmp = bl::translate(s, p, n);
         TEST_EQ(tmp, expected);
@@ -179,7 +179,7 @@ void strings_equal(std::string n_s,
         TEST_EQ(ss.str(), expected);
     }
     TEST_EQ(bl::translate(s, p, n).str(l, domain), expected);
-    std::locale tmp_locale = std::locale();
+    std::locale tmp_locale;
     std::locale::global(l);
     TEST_EQ(bl::translate(s, p, n).str(domain), expected);
     std::locale::global(tmp_locale);
@@ -198,22 +198,20 @@ void strings_equal(std::string n_s,
 }
 
 template<typename Char>
-void strings_equal(std::string n_c,
-                   std::string n_original,
-                   std::string iexpected,
-                   const std::locale& l,
-                   std::string domain)
+void test_ctranslate(const std::string& sContext,
+                     const std::string& sOriginal,
+                     const std::string& sExpected,
+                     const std::locale& l,
+                     const std::string& domain)
 {
     typedef std::basic_string<Char> string_type;
-    string_type expected = to_correct_string<Char>(iexpected, l);
-    string_type original = to<Char>(n_original.c_str());
-    string_type c = to<Char>(n_c.c_str());
+    const string_type expected = to_correct_string<Char>(sExpected, l);
+    const string_type original = to<Char>(sOriginal.c_str());
+    const string_type c = to<Char>(sContext.c_str());
     if(domain == "default") {
         TEST_EQ(bl::translate(c, original).str(l), expected);
-        const Char* original_c_str = original.c_str(); // workaround gcc-3.4 bug
-        const Char* context_c_str = c.c_str();
-        TEST_EQ(bl::translate(context_c_str, original_c_str).str(l), expected);
-        std::locale tmp_locale = std::locale();
+        TEST_EQ(bl::translate(c.c_str(), original.c_str()).str(l), expected);
+        std::locale tmp_locale;
         std::locale::global(l);
         string_type tmp = bl::translate(c, original);
         TEST_EQ(tmp, expected);
@@ -227,7 +225,7 @@ void strings_equal(std::string n_c,
         TEST_EQ(ss.str(), expected);
     }
     TEST_EQ(bl::translate(c, original).str(l, domain), expected);
-    std::locale tmp_locale = std::locale();
+    std::locale tmp_locale;
     std::locale::global(l);
     TEST_EQ(bl::translate(c, original).str(domain), expected);
     std::locale::global(tmp_locale);
@@ -246,16 +244,18 @@ void strings_equal(std::string n_c,
 }
 
 template<typename Char>
-void strings_equal(std::string n_original, std::string iexpected, const std::locale& l, std::string domain)
+void test_translate(const std::string& sOriginal,
+                    const std::string& sExpected,
+                    const std::locale& l,
+                    const std::string& domain)
 {
     typedef std::basic_string<Char> string_type;
-    string_type expected = to_correct_string<Char>(iexpected, l);
-    string_type original = to<Char>(n_original.c_str());
+    const string_type expected = to_correct_string<Char>(sExpected, l);
+    const string_type original = to<Char>(sOriginal.c_str());
     if(domain == "default") {
         TEST_EQ(bl::translate(original).str(l), expected);
-        const Char* original_c_str = original.c_str(); // workaround gcc-3.4 bug
-        TEST_EQ(bl::translate(original_c_str).str(l), expected);
-        std::locale tmp_locale = std::locale();
+        TEST_EQ(bl::translate(original.c_str()).str(l), expected);
+        std::locale tmp_locale;
         std::locale::global(l);
         string_type tmp = bl::translate(original);
         TEST_EQ(tmp, expected);
@@ -269,7 +269,7 @@ void strings_equal(std::string n_original, std::string iexpected, const std::loc
         TEST_EQ(ss.str(), expected);
     }
     TEST_EQ(bl::translate(original).str(l, domain), expected);
-    std::locale tmp_locale = std::locale();
+    std::locale tmp_locale;
     std::locale::global(l);
     TEST_EQ(bl::translate(original).str(domain), expected);
     std::locale::global(tmp_locale);
@@ -286,75 +286,79 @@ void strings_equal(std::string n_original, std::string iexpected, const std::loc
         TEST_EQ(ss.str(), expected);
     }
 }
+} // namespace impl
 
-void test_cntranslate(std::string c,
-                      std::string s,
-                      std::string p,
+void test_cntranslate(const std::string& c,
+                      const std::string& s,
+                      const std::string& p,
                       int n,
-                      std::string expected,
+                      const std::string& expected,
                       const std::locale& l,
-                      std::string domain)
+                      const std::string& domain)
 {
-    strings_equal<char>(c, s, p, n, expected, l, domain);
-    strings_equal<wchar_t>(c, s, p, n, expected, l, domain);
+    impl::test_cntranslate<char>(c, s, p, n, expected, l, domain);
+    impl::test_cntranslate<wchar_t>(c, s, p, n, expected, l, domain);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char16_t>(c, s, p, n, expected, l, domain);
+        impl::test_cntranslate<char16_t>(c, s, p, n, expected, l, domain);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char32_t>(c, s, p, n, expected, l, domain);
+        impl::test_cntranslate<char32_t>(c, s, p, n, expected, l, domain);
 #endif
 }
 
-void test_ntranslate(std::string s,
-                     std::string p,
+void test_ntranslate(const std::string& s,
+                     const std::string& p,
                      int n,
-                     std::string expected,
+                     const std::string& expected,
                      const std::locale& l,
-                     std::string domain)
+                     const std::string& domain)
 {
-    strings_equal<char>(s, p, n, expected, l, domain);
-    strings_equal<wchar_t>(s, p, n, expected, l, domain);
+    impl::test_ntranslate<char>(s, p, n, expected, l, domain);
+    impl::test_ntranslate<wchar_t>(s, p, n, expected, l, domain);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char16_t>(s, p, n, expected, l, domain);
+        impl::test_ntranslate<char16_t>(s, p, n, expected, l, domain);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char32_t>(s, p, n, expected, l, domain);
+        impl::test_ntranslate<char32_t>(s, p, n, expected, l, domain);
 #endif
 }
 
-void test_ctranslate(std::string c,
-                     std::string original,
-                     std::string expected,
+void test_ctranslate(const std::string& c,
+                     const std::string& original,
+                     const std::string& expected,
                      const std::locale& l,
-                     std::string domain)
+                     const std::string& domain)
 {
-    strings_equal<char>(c, original, expected, l, domain);
-    strings_equal<wchar_t>(c, original, expected, l, domain);
+    impl::test_ctranslate<char>(c, original, expected, l, domain);
+    impl::test_ctranslate<wchar_t>(c, original, expected, l, domain);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char16_t>(c, original, expected, l, domain);
+        impl::test_ctranslate<char16_t>(c, original, expected, l, domain);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char32_t>(c, original, expected, l, domain);
+        impl::test_ctranslate<char32_t>(c, original, expected, l, domain);
 #endif
 }
 
-void test_translate(std::string original, std::string expected, const std::locale& l, std::string domain)
+void test_translate(const std::string& original,
+                    const std::string& expected,
+                    const std::locale& l,
+                    const std::string& domain)
 {
-    strings_equal<char>(original, expected, l, domain);
-    strings_equal<wchar_t>(original, expected, l, domain);
+    impl::test_translate<char>(original, expected, l, domain);
+    impl::test_translate<wchar_t>(original, expected, l, domain);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char16_t>(original, expected, l, domain);
+        impl::test_translate<char16_t>(original, expected, l, domain);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
     if(backend == "icu" || backend == "std")
-        strings_equal<char32_t>(original, expected, l, domain);
+        impl::test_translate<char32_t>(original, expected, l, domain);
 #endif
 }
 
@@ -367,7 +371,7 @@ void test_main(int argc, char** argv)
     if(argc == 2)
         message_path = argv[1];
 
-    std::string def[] = {
+    const std::string def[] = {
 #ifdef BOOST_LOCALE_WITH_ICU
       "icu",
 #endif
@@ -502,10 +506,7 @@ void test_main(int argc, char** argv)
         {
             boost::locale::generator g;
             g.add_messages_domain("default");
-            if(argc == 2)
-                g.add_messages_path(argv[1]);
-            else
-                g.add_messages_path("./");
+            g.add_messages_path((argc == 2) ? argv[1] : "./");
 
             std::locale l = g("he_IL.UTF-8");
 
@@ -530,10 +531,7 @@ void test_main(int argc, char** argv)
         {
             boost::locale::generator g;
             g.add_messages_domain("default/ISO-8859-8");
-            if(argc == 2)
-                g.add_messages_path(argv[1]);
-            else
-                g.add_messages_path("./");
+            g.add_messages_path((argc == 2) ? argv[1] : "./");
 
             std::locale l = g("he_IL.UTF-8");
 
@@ -550,14 +548,17 @@ void test_main(int argc, char** argv)
         bl::gettext(L"");
         bl::dgettext("", "");
         bl::dgettext("", L"");
+
         bl::pgettext("", "");
         bl::pgettext(L"", L"");
         bl::dpgettext("", "", "");
         bl::dpgettext("", L"", L"");
+
         bl::ngettext("", "", 1);
         bl::ngettext(L"", L"", 1);
         bl::dngettext("", "", "", 1);
         bl::dngettext("", L"", L"", 1);
+
         bl::npgettext("", "", "", 1);
         bl::npgettext(L"", L"", L"", 1);
         bl::dnpgettext("", "", "", "", 1);


### PR DESCRIPTION
The parser and evaluator of plural expressions in PO/MO files isn't really tested thorouhly.
Add tests for expressions from some languages as well as some basic tests for all possible operations comparing those against the result of calculating the value in C++.