### PR TITLE
Enhance plural expression parsing for translations

### DIFF
--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -72,6 +72,18 @@
 #else
 #    define BOOST_LOCALE_USE_WIN32_API 0
 #endif
+
+// Allow to use virtual functions on non-exported classes
+// which leads to false positives under UBSAN -> Disable this check
+#ifdef __has_attribute
+#    if __has_attribute(no_sanitize)
+#        define BOOST_LOCALE_WRONG_VPTR_OK __attribute__((no_sanitize("vptr")))
+#    else
+#        define BOOST_LOCALE_WRONG_VPTR_OK
+#    endif
+#else
+#    define BOOST_LOCALE_WRONG_VPTR_OK
+#endif
 /// \endcond
 
 #endif // boost/locale/config.hpp

--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -72,18 +72,6 @@
 #else
 #    define BOOST_LOCALE_USE_WIN32_API 0
 #endif
-
-// Allow to use virtual functions on non-exported classes
-// which leads to false positives under UBSAN -> Disable this check
-#ifdef __has_attribute
-#    if __has_attribute(no_sanitize)
-#        define BOOST_LOCALE_WRONG_VPTR_OK __attribute__((no_sanitize("vptr")))
-#    else
-#        define BOOST_LOCALE_WRONG_VPTR_OK
-#    endif
-#else
-#    define BOOST_LOCALE_WRONG_VPTR_OK
-#endif
 /// \endcond
 
 #endif // boost/locale/config.hpp

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -217,17 +217,19 @@ namespace boost { namespace locale {
         basic_message& operator=(basic_message&&) = default;
 
         /// Swap two message objects
-        void swap(basic_message& other)
+        void
+        swap(basic_message& other) noexcept(noexcept(std::declval<string_type&>().swap(std::declval<string_type&>())))
         {
-            std::swap(n_, other.n_);
-            std::swap(c_id_, other.c_id_);
-            std::swap(c_context_, other.c_context_);
-            std::swap(c_plural_, other.c_plural_);
-
-            id_.swap(other.id_);
-            context_.swap(other.context_);
-            plural_.swap(other.plural_);
+            using std::swap;
+            swap(n_, other.n_);
+            swap(c_id_, other.c_id_);
+            swap(c_context_, other.c_context_);
+            swap(c_plural_, other.c_plural_);
+            swap(id_, other.id_);
+            swap(context_, other.context_);
+            swap(plural_, other.plural_);
         }
+        friend void swap(basic_message& x, basic_message& y) noexcept(noexcept(x.swap(y))) { x.swap(y); }
 
         /// Message class can be explicitly converted to string class
         operator string_type() const { return str(); }
@@ -255,9 +257,7 @@ namespace boost { namespace locale {
         {
             string_type buffer;
             const char_type* ptr = write(loc, id, buffer);
-            if(ptr == buffer.c_str())
-                return buffer;
-            else
+            if(ptr != buffer.c_str())
                 buffer = ptr;
             return buffer;
         }

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -43,6 +43,9 @@ namespace boost { namespace locale {
 
     /// \endcond
 
+    /// Type used for the count/n argument to the translation functions choosing between singular and plural forms
+    using count_type = long long;
+
     /// \brief This facet provides message formatting abilities
     template<typename CharType>
     class BOOST_SYMBOL_VISIBLE message_format : public base_message_format<CharType> {
@@ -75,7 +78,7 @@ namespace boost { namespace locale {
         ///
         /// If a translated string is found, it is returned, otherwise NULL is returned
         virtual const char_type*
-        get(int domain_id, const char_type* context, const char_type* single_id, int n) const = 0;
+        get(int domain_id, const char_type* context, const char_type* single_id, count_type n) const = 0;
 
         /// Convert a string that defines \a domain to the integer id used by \a get functions
         virtual int domain(const std::string& domain) const = 0;
@@ -156,7 +159,7 @@ namespace boost { namespace locale {
         /// until the message is destroyed. Generally useful with static constant strings.
         ///
         /// \a n is the number, \a single and \a plural are singular and plural forms of the message
-        explicit basic_message(const char_type* single, const char_type* plural, int n) :
+        explicit basic_message(const char_type* single, const char_type* plural, count_type n) :
             n_(n), c_id_(single), c_context_(0), c_plural_(plural)
         {}
 
@@ -171,8 +174,12 @@ namespace boost { namespace locale {
         /// until the message is destroyed. Generally useful with static constant strings.
         ///
         /// \a n is the number, \a single and \a plural are singular and plural forms of the message
-        explicit basic_message(const char_type* context, const char_type* single, const char_type* plural, int n) :
-            n_(n), c_id_(single), c_context_(context), c_plural_(plural)
+        explicit basic_message(const char_type* context,
+                               const char_type* single,
+                               const char_type* plural,
+                               count_type n) :
+            n_(n),
+            c_id_(single), c_context_(context), c_plural_(plural)
         {}
 
         /// Create a simple message from a string.
@@ -181,7 +188,7 @@ namespace boost { namespace locale {
         /// Create a simple plural form message from strings.
         ///
         /// \a n is the number, \a single and \a plural are single and plural forms of the message
-        explicit basic_message(const string_type& single, const string_type& plural, int number) :
+        explicit basic_message(const string_type& single, const string_type& plural, count_type number) :
             n_(number), c_id_(0), c_context_(0), c_plural_(0), id_(single), plural_(plural)
         {}
 
@@ -196,7 +203,7 @@ namespace boost { namespace locale {
         explicit basic_message(const string_type& context,
                                const string_type& single,
                                const string_type& plural,
-                               int number) :
+                               count_type number) :
             n_(number),
             c_id_(0), c_context_(0), c_plural_(0), id_(single), context_(context), plural_(plural)
         {}
@@ -226,11 +233,7 @@ namespace boost { namespace locale {
         operator string_type() const { return str(); }
 
         /// Translate message to a string in the default global locale, using default domain
-        string_type str() const
-        {
-            std::locale loc;
-            return str(loc, 0);
-        }
+        string_type str() const { return str(std::locale()); }
 
         /// Translate message to a string in the locale \a locale, using default domain
         string_type str(const std::locale& locale) const { return str(locale, 0); }
@@ -245,14 +248,7 @@ namespace boost { namespace locale {
         }
 
         /// Translate message to a string using the default locale and message domain  \a domain_id
-        string_type str(const std::string& domain_id) const
-        {
-            int id = 0;
-            std::locale loc;
-            if(std::has_facet<facet_type>(loc))
-                id = std::use_facet<facet_type>(loc).domain(domain_id);
-            return str(loc, id);
-        }
+        string_type str(const std::string& domain_id) const { return str(std::locale(), domain_id); }
 
         /// Translate message to a string using locale \a loc and message domain index  \a id
         string_type str(const std::locale& loc, int id) const
@@ -298,7 +294,6 @@ namespace boost { namespace locale {
 
         const char_type* write(const std::locale& loc, int domain_id, string_type& buffer) const
         {
-            const char_type* translated = 0;
             static const char_type empty_string[1] = {0};
 
             const char_type* id = this->id();
@@ -312,6 +307,7 @@ namespace boost { namespace locale {
             if(std::has_facet<facet_type>(loc))
                 facet = &std::use_facet<facet_type>(loc);
 
+            const char_type* translated = 0;
             if(facet) {
                 if(!plural) {
                     translated = facet->get(domain_id, context, id);
@@ -334,7 +330,7 @@ namespace boost { namespace locale {
 
         /// members
 
-        int n_;
+        count_type n_;
         const char_type* c_id_;
         const char_type* c_context_;
         const char_type* c_plural_;
@@ -383,15 +379,15 @@ namespace boost { namespace locale {
 
     /// \brief Translate a plural message form, \a single and \a plural are not copied
     template<typename CharType>
-    inline basic_message<CharType> translate(const CharType* single, const CharType* plural, int n)
+    inline basic_message<CharType> translate(const CharType* single, const CharType* plural, count_type n)
     {
         return basic_message<CharType>(single, plural, n);
     }
 
-    /// \brief Translate a plural message from in constext, \a context, \a single and \a plural are not copied
+    /// \brief Translate a plural message from in context, \a context, \a single and \a plural are not copied
     template<typename CharType>
     inline basic_message<CharType>
-    translate(const CharType* context, const CharType* single, const CharType* plural, int n)
+    translate(const CharType* context, const CharType* single, const CharType* plural, count_type n)
     {
         return basic_message<CharType>(context, single, plural, n);
     }
@@ -411,12 +407,12 @@ namespace boost { namespace locale {
         return basic_message<CharType>(context, msg);
     }
 
-    /// \brief Translate a plural message form in constext, \a context, \a single and \a plural are copied
+    /// \brief Translate a plural message form in context, \a context, \a single and \a plural are copied
     template<typename CharType>
     inline basic_message<CharType> translate(const std::basic_string<CharType>& context,
                                              const std::basic_string<CharType>& single,
                                              const std::basic_string<CharType>& plural,
-                                             int n)
+                                             count_type n)
     {
         return basic_message<CharType>(context, single, plural, n);
     }
@@ -424,7 +420,7 @@ namespace boost { namespace locale {
     /// \brief Translate a plural message form, \a single and \a plural are copied
     template<typename CharType>
     inline basic_message<CharType>
-    translate(const std::basic_string<CharType>& single, const std::basic_string<CharType>& plural, int n)
+    translate(const std::basic_string<CharType>& single, const std::basic_string<CharType>& plural, count_type n)
     {
         return basic_message<CharType>(single, plural, n);
     }
@@ -442,7 +438,7 @@ namespace boost { namespace locale {
     /// Translate plural form according to locale \a loc
     template<typename CharType>
     std::basic_string<CharType>
-    ngettext(const CharType* s, const CharType* p, int n, const std::locale& loc = std::locale())
+    ngettext(const CharType* s, const CharType* p, count_type n, const std::locale& loc = std::locale())
     {
         return basic_message<CharType>(s, p, n).str(loc);
     }
@@ -456,8 +452,11 @@ namespace boost { namespace locale {
 
     /// Translate plural form according to locale \a loc in domain \a domain
     template<typename CharType>
-    std::basic_string<CharType>
-    dngettext(const char* domain, const CharType* s, const CharType* p, int n, const std::locale& loc = std::locale())
+    std::basic_string<CharType> dngettext(const char* domain,
+                                          const CharType* s,
+                                          const CharType* p,
+                                          count_type n,
+                                          const std::locale& loc = std::locale())
     {
         return basic_message<CharType>(s, p, n).str(loc, domain);
     }
@@ -475,7 +474,7 @@ namespace boost { namespace locale {
     std::basic_string<CharType> npgettext(const CharType* context,
                                           const CharType* s,
                                           const CharType* p,
-                                          int n,
+                                          count_type n,
                                           const std::locale& loc = std::locale())
     {
         return basic_message<CharType>(context, s, p, n).str(loc);
@@ -495,7 +494,7 @@ namespace boost { namespace locale {
                                            const CharType* context,
                                            const CharType* s,
                                            const CharType* p,
-                                           int n,
+                                           count_type n,
                                            const std::locale& loc = std::locale())
     {
         return basic_message<CharType>(context, s, p, n).str(loc, domain);

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -418,7 +418,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
                 return nullptr;
             int form = 0;
             if(plural_forms_.at(domain_id))
-                form = (*plural_forms_[domain_id])(n);
+                form = plural_forms_[domain_id](n);
             else
                 form = n == 1 ? 0 : 1; // Fallback to English plural form
 
@@ -581,7 +581,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
 
         catalogs_set_type catalogs_;
         std::vector<std::unique_ptr<mo_file>> mo_catalogs_;
-        std::vector<lambda::plural_ptr> plural_forms_;
+        std::vector<lambda::plural_expr> plural_forms_;
         domains_map_type domains_;
 
         std::string locale_encoding_;

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -66,88 +66,94 @@ namespace boost { namespace locale { namespace gnu_gettext {
     }
 
     class c_file {
-        c_file(const c_file&);
-        void operator=(const c_file&);
-
     public:
-        FILE* file;
+        FILE* handle;
 
-        c_file() : file(0) {}
-        ~c_file() { close(); }
+        c_file(const c_file&) = delete;
+        void operator=(const c_file&) = delete;
 
-        void close()
+        ~c_file()
         {
-            if(file) {
-                fclose(file);
-                file = 0;
-            }
+            if(handle)
+                fclose(handle);
         }
 
 #if defined(BOOST_WINDOWS)
 
-        bool open(const std::string& file_name, const std::string& encoding)
+        c_file(const std::string& file_name, const std::string& encoding)
         {
-            close();
-
-            // Under windows we have to use "_wfopen" to get
-            // access to path's with Unicode in them
+            // Under windows we have to use "_wfopen" to get access to path's with Unicode in them
             //
             // As not all standard C++ libraries support nonstandard std::istream::open(wchar_t const *)
             // we would use old and good stdio and _wfopen CRTL functions
 
             std::wstring wfile_name = conv::to_utf<wchar_t>(file_name, encoding);
-            file = _wfopen(wfile_name.c_str(), L"rb");
-
-            return file != 0;
+            handle = _wfopen(wfile_name.c_str(), L"rb");
         }
 
 #else // POSIX systems do not have all this Wide API crap, as native codepages are UTF-8
 
         // We do not use encoding as we use native file name encoding
 
-        bool open(const std::string& file_name, const std::string& /* encoding */)
-        {
-            close();
-
-            file = fopen(file_name.c_str(), "rb");
-
-            return file != 0;
-        }
-
+        c_file(const std::string& file_name, const std::string& /* encoding */) : handle(fopen(file_name.c_str(), "rb"))
+        {}
 #endif
     };
+
+    std::vector<char> read_file(FILE* file)
+    {
+        fseek(file, 0, SEEK_END);
+        const long len = ftell(file);
+        if(len < 0)
+            throw std::runtime_error("Wrong file object");
+        else if(len > 0) {
+            fseek(file, 0, SEEK_SET);
+            std::vector<char> data(len);
+            if(fread(&data.front(), 1, data.size(), file) != data.size())
+                throw std::runtime_error("Failed to read file");
+            return data;
+        } else
+            return {};
+    }
 
     class mo_file {
     public:
         typedef std::pair<const char*, const char*> pair_type;
 
-        mo_file(std::vector<char>& file) : native_byteorder_(true), size_(0)
+        mo_file(std::vector<char> data) : data_(std::move(data))
         {
-            load_file(file);
-            init();
-        }
+            if(data_.size() < 4)
+                throw std::runtime_error("invalid 'mo' file format - the file is too short");
+            uint32_t magic = 0;
+            memcpy(&magic, data_.data(), 4);
+            if(magic == 0x950412de)
+                native_byteorder_ = true;
+            else if(magic == 0xde120495)
+                native_byteorder_ = false;
+            else
+                throw std::runtime_error("Invalid file format - invalid magic number");
 
-        mo_file(FILE* file) : native_byteorder_(true), size_(0)
-        {
-            load_file(file);
-            init();
+            // Read all format sizes
+            size_ = get(8);
+            keys_offset_ = get(12);
+            translations_offset_ = get(16);
+            hash_size_ = get(20);
+            hash_offset_ = get(24);
         }
 
         pair_type find(const char* context_in, const char* key_in) const
         {
-            pair_type null_pair((const char*)0, (const char*)0);
-            if(hash_size_ == 0)
+            pair_type null_pair(nullptr, nullptr);
+            if(!has_hash())
                 return null_pair;
-            uint32_t hkey = 0;
-            if(context_in == 0)
-                hkey = pj_winberger_hash_function(key_in);
-            else {
-                pj_winberger_hash::state_type st = pj_winberger_hash::initial_state;
+
+            pj_winberger_hash::state_type st = pj_winberger_hash::initial_state;
+            if(context_in) {
                 st = pj_winberger_hash::update_state(st, context_in);
                 st = pj_winberger_hash::update_state(st, '\4'); // EOT
-                st = pj_winberger_hash::update_state(st, key_in);
-                hkey = st;
             }
+            st = pj_winberger_hash::update_state(st, key_in);
+            uint32_t hkey = st;
             uint32_t incr = 1 + hkey % (hash_size_ - 2);
             hkey %= hash_size_;
             uint32_t orig = hkey;
@@ -181,17 +187,17 @@ namespace boost { namespace locale { namespace gnu_gettext {
             }
         }
 
-        const char* key(int id) const
+        const char* key(unsigned id) const
         {
-            uint32_t off = get(keys_offset_ + id * 8 + 4);
-            return data_ + off;
+            const uint32_t off = get(keys_offset_ + id * 8 + 4);
+            return data_.data() + off;
         }
 
-        pair_type value(int id) const
+        pair_type value(unsigned id) const
         {
-            uint32_t len = get(translations_offset_ + id * 8);
-            uint32_t off = get(translations_offset_ + id * 8 + 4);
-            if(off >= file_size_ || off + len >= file_size_)
+            const uint32_t len = get(translations_offset_ + id * 8);
+            const uint32_t off = get(translations_offset_ + id * 8 + 4);
+            if(len > data_.size() || off > data_.size() - len)
                 throw std::runtime_error("Bad mo-file format");
             return pair_type(&data_[off], &data_[off] + len);
         }
@@ -203,77 +209,16 @@ namespace boost { namespace locale { namespace gnu_gettext {
         bool empty() { return size_ == 0; }
 
     private:
-        void init()
-        {
-            // Read all format sizes
-            size_ = get(8);
-            keys_offset_ = get(12);
-            translations_offset_ = get(16);
-            hash_size_ = get(20);
-            hash_offset_ = get(24);
-        }
-
-        void load_file(std::vector<char>& data)
-        {
-            vdata_.swap(data);
-            file_size_ = vdata_.size();
-            data_ = &vdata_[0];
-            if(file_size_ < 4)
-                throw std::runtime_error("invalid 'mo' file format - the file is too short");
-            uint32_t magic = 0;
-            memcpy(&magic, data_, 4);
-            if(magic == 0x950412de)
-                native_byteorder_ = true;
-            else if(magic == 0xde120495)
-                native_byteorder_ = false;
-            else
-                throw std::runtime_error("Invalid file format - invalid magic number");
-        }
-
-        void load_file(FILE* file)
-        {
-            uint32_t magic = 0;
-            // if the size is wrong magic would be wrong
-            // ok to ignore fread result
-            size_t four_bytes = fread(&magic, 4, 1, file);
-            (void)four_bytes; // shut GCC
-
-            if(magic == 0x950412de)
-                native_byteorder_ = true;
-            else if(magic == 0xde120495)
-                native_byteorder_ = false;
-            else
-                throw std::runtime_error("Invalid file format");
-
-            fseek(file, 0, SEEK_END);
-            long len = ftell(file);
-            if(len < 0) {
-                throw std::runtime_error("Wrong file object");
-            }
-            fseek(file, 0, SEEK_SET);
-            vdata_.resize(len + 1, 0); // +1 to make sure the vector is not empty
-            if(fread(&vdata_.front(), 1, len, file) != unsigned(len))
-                throw std::runtime_error("Failed to read file");
-            data_ = &vdata_[0];
-            file_size_ = len;
-        }
-
         uint32_t get(unsigned offset) const
         {
-            uint32_t tmp;
-            if(offset > file_size_ - 4) {
+            uint32_t v;
+            if(offset > data_.size() - 4)
                 throw std::runtime_error("Bad mo-file format");
-            }
-            memcpy(&tmp, data_ + offset, 4);
-            convert(tmp);
-            return tmp;
-        }
+            memcpy(&v, &data_[offset], 4);
+            if(!native_byteorder_)
+                v = ((v & 0xFF) << 24) | ((v & 0xFF00) << 8) | ((v & 0xFF0000) >> 8) | ((v & 0xFF000000) >> 24);
 
-        void convert(uint32_t& v) const
-        {
-            if(native_byteorder_)
-                return;
-            v = ((v & 0xFF) << 24) | ((v & 0xFF00) << 8) | ((v & 0xFF0000) >> 8) | ((v & 0xFF000000) >> 24);
+            return v;
         }
 
         uint32_t keys_offset_;
@@ -281,9 +226,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
         uint32_t hash_size_;
         uint32_t hash_offset_;
 
-        const char* data_;
-        size_t file_size_;
-        std::vector<char> vdata_;
+        const std::vector<char> data_;
         bool native_byteorder_;
         size_t size_;
     };
@@ -537,24 +480,25 @@ namespace boost { namespace locale { namespace gnu_gettext {
             key_conversion_required_ =
               sizeof(CharType) == 1 && !util::are_encodings_equal(locale_encoding, key_encoding);
 
-            std::shared_ptr<mo_file> mo;
+            std::unique_ptr<mo_file> mo;
 
-            if(callback) {
-                std::vector<char> vfile = callback(file_name, locale_encoding);
-                if(vfile.empty())
+            {
+                std::vector<char> data;
+                if(callback)
+                    data = callback(file_name, locale_encoding);
+                else {
+                    c_file the_file(file_name, locale_encoding);
+                    if(!the_file.handle)
+                        return false;
+                    data = read_file(the_file.handle);
+                }
+                if(data.empty())
                     return false;
-                mo.reset(new mo_file(vfile));
-            } else {
-                c_file the_file;
-                the_file.open(file_name, locale_encoding);
-                if(!the_file.file)
-                    return false;
-                mo.reset(new mo_file(the_file.file));
+                mo.reset(new mo_file(std::move(data)));
             }
 
-            std::string plural = extract(mo->value(0).first, "plural=", "\r\n;");
-
-            std::string mo_encoding = extract(mo->value(0).first, "charset=", " \r\n;");
+            const std::string plural = extract(mo->value(0).first, "plural=", "\r\n;");
+            const std::string mo_encoding = extract(mo->value(0).first, "charset=", " \r\n;");
 
             if(mo_encoding.empty())
                 throw std::runtime_error("Invalid mo-format, encoding is not specified");
@@ -563,7 +507,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
                 plural_forms_[idx] = lambda::compile(plural.c_str());
 
             if(mo_useable_directly(mo_encoding, *mo))
-                mo_catalogs_[idx] = mo;
+                mo_catalogs_[idx] = std::move(mo);
             else {
                 converter<CharType> cvt_value(locale_encoding, mo_encoding);
                 converter<CharType> cvt_key(key_encoding, mo_encoding);
@@ -573,8 +517,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
                     key_type key(skey);
 
                     mo_file::pair_type tmp = mo->value(i);
-                    string_type value = cvt_value(tmp.first, tmp.second);
-                    catalogs_[idx][key].swap(value);
+                    catalogs_[idx][key] = cvt_value(tmp.first, tmp.second);
                 }
             }
             return true;
@@ -637,8 +580,8 @@ namespace boost { namespace locale { namespace gnu_gettext {
         }
 
         catalogs_set_type catalogs_;
-        std::vector<std::shared_ptr<mo_file>> mo_catalogs_;
-        std::vector<std::shared_ptr<lambda::plural>> plural_forms_;
+        std::vector<std::unique_ptr<mo_file>> mo_catalogs_;
+        std::vector<lambda::plural_ptr> plural_forms_;
         domains_map_type domains_;
 
         std::string locale_encoding_;

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -411,19 +411,20 @@ namespace boost { namespace locale { namespace gnu_gettext {
             return get_string(domain_id, context, in_id).first;
         }
 
-        const CharType* get(int domain_id, const CharType* context, const CharType* single_id, int n) const override
+        const CharType*
+        get(int domain_id, const CharType* context, const CharType* single_id, count_type n) const override
         {
             pair_type ptr = get_string(domain_id, context, single_id);
             if(!ptr.first)
                 return nullptr;
-            int form = 0;
+            lambda::expr::value_type form;
             if(plural_forms_.at(domain_id))
                 form = plural_forms_[domain_id](n);
             else
                 form = n == 1 ? 0 : 1; // Fallback to English plural form
 
             const CharType* p = ptr.first;
-            for(int i = 0; p < ptr.second && i < form; i++) {
+            for(decltype(form) i = 0; p < ptr.second && i < form; i++) {
                 p = std::find(p, ptr.second, CharType(0));
                 if(p == ptr.second)
                     return nullptr;

--- a/src/boost/locale/shared/mo_lambda.cpp
+++ b/src/boost/locale/shared/mo_lambda.cpp
@@ -17,7 +17,6 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
     namespace { // anon
         struct identity : public plural {
             int operator()(int n) const override { return n; };
-            plural_ptr clone() const override { return plural_ptr(new identity()); }
         };
 
         struct unary : public plural {
@@ -37,37 +36,33 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
         struct number : public plural {
             number(int v) : val(v) {}
             int operator()(int /*n*/) const override { return val; }
-            plural_ptr clone() const override { return plural_ptr(new number(val)); }
 
         private:
             int val;
         };
 
-#define UNOP(name, oper)                                                                 \
-    struct name : public unary {                                                         \
-        name(plural_ptr op) : unary(std::move(op)) {}                                    \
-        int operator()(int n) const override { return oper(*op1)(n); }                   \
-        plural_ptr clone() const override { return plural_ptr(new name(op1->clone())); } \
+#define UNOP(name, oper)                                               \
+    struct name : public unary {                                       \
+        name(plural_ptr op) : unary(std::move(op)) {}                  \
+        int operator()(int n) const override { return oper(*op1)(n); } \
     };
 
-#define BINOP(name, oper)                                                                              \
-    struct name : public binary {                                                                      \
-        name(plural_ptr p1, plural_ptr p2) : binary(std::move(p1), std::move(p2)) {}                   \
-                                                                                                       \
-        int operator()(int n) const override { return (*op1)(n)oper(*op2)(n); }                        \
-        plural_ptr clone() const override { return plural_ptr(new name(op1->clone(), op2->clone())); } \
+#define BINOP(name, oper)                                                            \
+    struct name : public binary {                                                    \
+        name(plural_ptr p1, plural_ptr p2) : binary(std::move(p1), std::move(p2)) {} \
+                                                                                     \
+        int operator()(int n) const override { return (*op1)(n)oper(*op2)(n); }      \
     };
 
-#define BINOPD(name, oper)                                                                             \
-    struct name : public binary {                                                                      \
-        name(plural_ptr p1, plural_ptr p2) : binary(std::move(p1), std::move(p2)) {}                   \
-        int operator()(int n) const override                                                           \
-        {                                                                                              \
-            int v1 = (*op1)(n);                                                                        \
-            int v2 = (*op2)(n);                                                                        \
-            return v2 == 0 ? 0 : v1 oper v2;                                                           \
-        }                                                                                              \
-        plural_ptr clone() const override { return plural_ptr(new name(op1->clone(), op2->clone())); } \
+#define BINOPD(name, oper)                                                           \
+    struct name : public binary {                                                    \
+        name(plural_ptr p1, plural_ptr p2) : binary(std::move(p1), std::move(p2)) {} \
+        int operator()(int n) const override                                         \
+        {                                                                            \
+            int v1 = (*op1)(n);                                                      \
+            int v2 = (*op2)(n);                                                      \
+            return v2 == 0 ? 0 : v1 oper v2;                                         \
+        }                                                                            \
     };
 
         enum { END = 0, SHL = 256, SHR, GTE, LTE, EQ, NEQ, AND, OR, NUM, VARIABLE };
@@ -123,10 +118,6 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
                 op1(std::move(p1)), op2(std::move(p2)), op3(std::move(p3))
             {}
             int operator()(int n) const override { return (*op1)(n) ? (*op2)(n) : (*op3)(n); }
-            plural_ptr clone() const override
-            {
-                return plural_ptr(new conditional(op1->clone(), op2->clone(), op3->clone()));
-            }
 
         private:
             plural_ptr op1, op2, op3;

--- a/src/boost/locale/shared/mo_lambda.hpp
+++ b/src/boost/locale/shared/mo_lambda.hpp
@@ -13,7 +13,8 @@
 namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
     struct BOOST_SYMBOL_VISIBLE expr {
-        virtual int operator()(int n) const = 0;
+        using value_type = long long;
+        virtual value_type operator()(value_type n) const = 0;
         virtual ~expr() = default;
     };
     using expr_ptr = std::unique_ptr<expr>;
@@ -24,7 +25,7 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
     public:
         plural_expr() = default;
         explicit plural_expr(expr_ptr p) : p_(std::move(p)) {}
-        int operator()(int n) const { return (*p_)(n); }
+        expr::value_type operator()(expr::value_type n) const { return (*p_)(n); }
         explicit operator bool() const { return static_cast<bool>(p_); }
     };
 

--- a/src/boost/locale/shared/mo_lambda.hpp
+++ b/src/boost/locale/shared/mo_lambda.hpp
@@ -12,13 +12,14 @@
 
 namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
+    struct plural;
+    using plural_ptr = std::unique_ptr<plural>;
+
     struct plural {
         virtual int operator()(int n) const = 0;
-        virtual plural* clone() const = 0;
+        virtual plural_ptr clone() const = 0;
         virtual ~plural() = default;
     };
-
-    typedef std::shared_ptr<plural> plural_ptr;
 
     BOOST_LOCALE_DECL plural_ptr compile(const char* c_expression);
 

--- a/src/boost/locale/shared/mo_lambda.hpp
+++ b/src/boost/locale/shared/mo_lambda.hpp
@@ -17,7 +17,6 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
     struct plural {
         virtual int operator()(int n) const = 0;
-        virtual plural_ptr clone() const = 0;
         virtual ~plural() = default;
     };
 

--- a/src/boost/locale/shared/mo_lambda.hpp
+++ b/src/boost/locale/shared/mo_lambda.hpp
@@ -12,7 +12,7 @@
 
 namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
-    struct expr {
+    struct BOOST_SYMBOL_VISIBLE expr {
         virtual int operator()(int n) const = 0;
         virtual ~expr() = default;
     };
@@ -24,7 +24,7 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
     public:
         plural_expr() = default;
         explicit plural_expr(expr_ptr p) : p_(std::move(p)) {}
-        BOOST_LOCALE_WRONG_VPTR_OK int operator()(int n) const { return (*p_)(n); }
+        int operator()(int n) const { return (*p_)(n); }
         explicit operator bool() const { return static_cast<bool>(p_); }
     };
 

--- a/src/boost/locale/shared/mo_lambda.hpp
+++ b/src/boost/locale/shared/mo_lambda.hpp
@@ -12,15 +12,23 @@
 
 namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
-    struct plural;
-    using plural_ptr = std::unique_ptr<plural>;
-
-    struct plural {
+    struct expr {
         virtual int operator()(int n) const = 0;
-        virtual ~plural() = default;
+        virtual ~expr() = default;
+    };
+    using expr_ptr = std::unique_ptr<expr>;
+
+    class plural_expr {
+        expr_ptr p_;
+
+    public:
+        plural_expr() = default;
+        explicit plural_expr(expr_ptr p) : p_(std::move(p)) {}
+        BOOST_LOCALE_WRONG_VPTR_OK int operator()(int n) const { return (*p_)(n); }
+        explicit operator bool() const { return static_cast<bool>(p_); }
     };
 
-    BOOST_LOCALE_DECL plural_ptr compile(const char* c_expression);
+    BOOST_LOCALE_DECL plural_expr compile(const char* c_expression);
 
 }}}} // namespace boost::locale::gnu_gettext::lambda
 

--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -21,8 +21,8 @@ T getRandValue(const T min, const T max)
 template<typename T>
 void test_plural_expr_rand(const T& ref, const char* expr)
 {
-    constexpr auto minVal = std::numeric_limits<int>::min() / 1024;
-    constexpr auto maxVal = std::numeric_limits<int>::max() / 1024;
+    constexpr auto minVal = std::numeric_limits<long long>::min() / 1024;
+    constexpr auto maxVal = std::numeric_limits<long long>::max() / 1024;
     const auto ptr = boost::locale::gnu_gettext::lambda::compile(expr);
     TEST(ptr);
     constexpr int number_of_tries = 256;
@@ -47,6 +47,21 @@ void test_plural_expr()
         return ptr;               \
     }()
 #define TEST_EQ_EXPR(expr, rhs) test_eq_impl(COMPILE_PLURAL_EXPR(expr)(0), rhs, expr, __LINE__)
+    // Number only
+    TEST_EQ_EXPR("0", 0);
+    TEST_EQ_EXPR("42", 42);
+    BOOST_LOCALE_START_CONST_CONDITION
+    if(sizeof(long) >= 4) {
+        BOOST_LOCALE_END_CONST_CONDITION
+        TEST_EQ_EXPR("2147483647", 2147483647); // largest signed 4 byte value
+    }
+    BOOST_LOCALE_START_CONST_CONDITION
+    if(sizeof(long) > 4) {
+        BOOST_LOCALE_END_CONST_CONDITION
+        TEST_EQ_EXPR("4294967295", 4294967295); // largest 4 byte value
+        TEST_EQ_EXPR("100000000000", 100000000000);
+    }
+
     // Unary
     TEST_EQ_EXPR("!0", 1);
     TEST_EQ_EXPR("!1", 0);
@@ -180,7 +195,7 @@ void test_plural_expr()
     // Random test using the variable comparing against C++ evaluated result
 #define TEST_PLURAL_EXPR(expr) \
     test_plural_expr_rand(     \
-      [](int n) {              \
+      [](long long n) {        \
           (void)n;             \
           return expr;         \
       },                       \
@@ -208,8 +223,8 @@ void test_plural_expr()
                                                                                       2));
 #undef TEST_PLURAL_EXPR
 
-    constexpr auto minVal = std::numeric_limits<int>::min();
-    constexpr auto maxVal = std::numeric_limits<int>::max();
+    constexpr auto minVal = std::numeric_limits<long long>::min();
+    constexpr auto maxVal = std::numeric_limits<long long>::max();
 
     // E.g. Japanese
     {

--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -10,18 +10,6 @@
 #include <limits>
 #include <random>
 
-// We want to use `boost::locale::gnu_gettext::lambda::plural`
-// without exporting it which leads to false positives under UBSAN -> Disable this check
-#ifdef __has_attribute
-#    if __has_attribute(no_sanitize)
-#        define BOOST_LOCALE_WRONG_VPTR_OK __attribute__((no_sanitize("vptr")))
-#    else
-#        define BOOST_LOCALE_WRONG_VPTR_OK
-#    endif
-#else
-#    define BOOST_LOCALE_WRONG_VPTR_OK
-#endif
-
 template<typename T>
 T getRandValue(const T min, const T max)
 {
@@ -31,15 +19,16 @@ T getRandValue(const T min, const T max)
 }
 
 template<typename T>
-BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr_rand(const T& ref, const char* expr)
+void test_plural_expr_rand(const T& ref, const char* expr)
 {
     constexpr auto minVal = std::numeric_limits<int>::min() / 1024;
     constexpr auto maxVal = std::numeric_limits<int>::max() / 1024;
     const auto ptr = boost::locale::gnu_gettext::lambda::compile(expr);
+    TEST(ptr);
     constexpr int number_of_tries = 256;
     for(int i = 0; i < number_of_tries; i++) {
         const auto n = getRandValue(minVal, maxVal);
-        const auto result = (*ptr)(n);
+        const auto result = ptr(n);
         const auto refResult = ref(n);
         if(result != refResult) {
             std::cerr << "Expression: " << expr << "; n=" << n << '\n'; // LCOV_EXCL_LINE
@@ -48,8 +37,147 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr_rand(const T& ref, const char* 
     }
 }
 
-BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
+void test_plural_expr()
 {
+    using boost::locale::gnu_gettext::lambda::compile;
+#define COMPILE_PLURAL_EXPR(expr) \
+    []() {                        \
+        auto ptr = compile(expr); \
+        TEST(ptr);                \
+        return ptr;               \
+    }()
+#define TEST_EQ_EXPR(expr, rhs) test_eq_impl(COMPILE_PLURAL_EXPR(expr)(0), rhs, expr, __LINE__)
+    // Unary
+    TEST_EQ_EXPR("!0", 1);
+    TEST_EQ_EXPR("!1", 0);
+    TEST_EQ_EXPR("!42", 0);
+    // Arithmetic
+    TEST_EQ_EXPR("30 / 5", 6);
+    TEST_EQ_EXPR("3 * 7", 21);
+    TEST_EQ_EXPR("14 % 3", 2);
+    TEST_EQ_EXPR("2 + 5", 7);
+    TEST_EQ_EXPR("7 - 5", 2);
+    // Comparison
+    TEST_EQ_EXPR("30 > 5", 1);
+    TEST_EQ_EXPR("5 > 5", 0);
+    TEST_EQ_EXPR("4 > 5", 0);
+    TEST_EQ_EXPR("30 < 5", 0);
+    TEST_EQ_EXPR("5 < 5", 0);
+    TEST_EQ_EXPR("4 < 5", 1);
+    TEST_EQ_EXPR("30 >= 5", 1);
+    TEST_EQ_EXPR("5 >= 5", 1);
+    TEST_EQ_EXPR("4 >= 5", 0);
+    TEST_EQ_EXPR("30 <= 5", 0);
+    TEST_EQ_EXPR("5 <= 5", 1);
+    TEST_EQ_EXPR("4 <= 5", 1);
+    TEST_EQ_EXPR("5 == 5", 1);
+    TEST_EQ_EXPR("4 == 5", 0);
+    TEST_EQ_EXPR("5 != 5", 0);
+    TEST_EQ_EXPR("4 != 5", 1);
+    // Logicals
+    TEST_EQ_EXPR("0 || 0", 0);
+    TEST_EQ_EXPR("0 || 1", 1);
+    TEST_EQ_EXPR("1 || 0", 1);
+    TEST_EQ_EXPR("1 || 1", 1);
+    TEST_EQ_EXPR("0 && 0", 0);
+    TEST_EQ_EXPR("0 && 1", 0);
+    TEST_EQ_EXPR("1 && 0", 0);
+    TEST_EQ_EXPR("1 && 1", 1);
+    // Corner case for div/mod
+    TEST_EQ_EXPR("0 / 0", 0);
+    TEST_EQ_EXPR("1 / 0", 0);
+    TEST_EQ_EXPR("20 / 0", 0);
+    TEST_EQ_EXPR("0 % 0", 0);
+    TEST_EQ_EXPR("1 % 0", 0);
+    TEST_EQ_EXPR("20 % 0", 0);
+    // Operator precedence
+    {
+        // Unary over all
+        TEST_EQ_EXPR("5 * -3", -15);
+        TEST_EQ_EXPR("2 + -3", -1);
+        TEST_EQ_EXPR("-(1-6) % --2", 1);
+        TEST_EQ_EXPR("!-1", 0);
+        TEST_EQ_EXPR("-!0", -1);
+        TEST_EQ_EXPR("-!1", 0);
+        TEST_EQ_EXPR("5 * !3", 0);
+        TEST_EQ_EXPR("5 * !0", 5);
+        TEST_EQ_EXPR("2 + !3", 2);
+        TEST_EQ_EXPR("2 + !0", 3);
+        TEST_EQ_EXPR("!(1-6) % 10", 0);
+        TEST_EQ_EXPR("!!(1-6) % 10", 1);
+        TEST_EQ_EXPR("!0 == 1", 1);
+        TEST_EQ_EXPR("!0 || 1", 1);
+        // Mul over add/sub
+        TEST_EQ_EXPR("5 * 3 + 1", 16);
+        TEST_EQ_EXPR("1 + 3 * 5", 16);
+        TEST_EQ_EXPR("5 * 3 - 1", 14);
+        TEST_EQ_EXPR("10 - 2 * 3", 4);
+        // Div over add/sub
+        TEST_EQ_EXPR("30 / 2 + 1", 16);
+        TEST_EQ_EXPR("1 + 30 / 2", 16);
+        TEST_EQ_EXPR("30 / 2 - 1", 14);
+        TEST_EQ_EXPR("10 - 30 / 2", -5);
+        // Mod over add/sub
+        TEST_EQ_EXPR("5 % 3 + 1", 3);
+        TEST_EQ_EXPR("1 + 5 % 3", 3);
+        TEST_EQ_EXPR("5 % 4 - 1", 0);
+        TEST_EQ_EXPR("5 - 5 % 3", 3);
+        // Same precedence of add/sub
+        TEST_EQ_EXPR("10 - 4 - 2", 4);
+        // Same precedence of mul/div/mod
+        TEST_EQ_EXPR("2 * 20 / 40", 1);
+        TEST_EQ_EXPR("20 / 20 * 2", 2);
+        TEST_EQ_EXPR("7 * 2 % 10", 4);
+        TEST_EQ_EXPR("7 % 4 * 2", 6);
+        // Comparison after operation
+        TEST_EQ_EXPR("5 * 2 == 5 + 5", 1);
+        TEST_EQ_EXPR("50 / 5 != 40 % 40", 1);
+        TEST_EQ_EXPR("5 * 2 < 5 + 6", 1);
+        TEST_EQ_EXPR("5 * 2 <= 5 + 6", 1);
+        TEST_EQ_EXPR("50 / 5 > 40 % 40", 1);
+        TEST_EQ_EXPR("50 / 5 >= 40 % 40", 1);
+        // Relational before equal with counter example
+        TEST_EQ_EXPR("1 < 2 == 1", 1);
+        TEST_EQ_EXPR("1 < (2 == 1)", 0);
+        TEST_EQ_EXPR("0 == 0 < 0", 1);
+        TEST_EQ_EXPR("(0 == 0) < 0", 0);
+
+        TEST_EQ_EXPR("1 <= 2 == 1", 1);
+        TEST_EQ_EXPR("1 <= (2 == 1)", 0);
+        TEST_EQ_EXPR("0 == 0 <= -1", 1);
+        TEST_EQ_EXPR("(0 == 0) <= -1", 0);
+
+        TEST_EQ_EXPR("0 > 0 == 0", 1);
+        TEST_EQ_EXPR("0 > (0 == 0)", 0);
+        TEST_EQ_EXPR("1 == 2 > 1", 1);
+        TEST_EQ_EXPR("(1 == 2) > 1", 0);
+
+        TEST_EQ_EXPR("-1 >= 0 == 0", 1);
+        TEST_EQ_EXPR("-1 >= (0 == 0)", 0);
+        TEST_EQ_EXPR("1 == 2 >= 1", 1);
+        TEST_EQ_EXPR("(1 == 2) >= 1", 0);
+        // Comparison on both sides
+        TEST_EQ_EXPR("0 > -2 == -1 < 0", 1);
+        TEST_EQ_EXPR("((0 > -2) == -1) < 0", 0); // RHS late
+        TEST_EQ_EXPR("0 > (-2 == (-1 < 0))", 0); // LHS late
+        TEST_EQ_EXPR("(0 > (-2 == -1)) < 0", 0); // both late
+        // Logical after comparison with counter example
+        TEST_EQ_EXPR("1 && 3==3", 1);
+        TEST_EQ_EXPR("(1 && 3)==3", 0);
+        TEST_EQ_EXPR("3==3 && 1", 1);
+        TEST_EQ_EXPR("3==(3 && 1)", 0);
+        TEST_EQ_EXPR("0 || 3==3", 1);
+        TEST_EQ_EXPR("(0 || 3)==3", 0);
+        TEST_EQ_EXPR("3==3 || 0", 1);
+        TEST_EQ_EXPR("3==(3 || 0)", 0);
+        // OR after AND
+        TEST_EQ_EXPR("0 && 0 || 1", 1);
+        TEST_EQ_EXPR("0 && (0 || 1)", 0);
+        TEST_EQ_EXPR("1 || 0 && 0", 1);
+    }
+#undef TEST_EQ_EXPR
+
+    // Random test using the variable comparing against C++ evaluated result
 #define TEST_PLURAL_EXPR(expr) \
     test_plural_expr_rand(     \
       [](int n) {              \
@@ -80,24 +208,19 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
                                                                                       2));
 #undef TEST_PLURAL_EXPR
 
-    using boost::locale::gnu_gettext::lambda::compile;
     constexpr auto minVal = std::numeric_limits<int>::min();
     constexpr auto maxVal = std::numeric_limits<int>::max();
 
     // E.g. Japanese
     {
-        const auto ptr = compile("0");
-        TEST(ptr);
-        const auto& p = *ptr;
+        const auto p = COMPILE_PLURAL_EXPR("0");
         TEST_EQ(p(0), 0);
         TEST_EQ(p(minVal), 0);
         TEST_EQ(p(maxVal), 0);
     }
     // E.g. English
     {
-        const auto ptr = compile("(n != 1)");
-        TEST(ptr);
-        const auto& p = *ptr;
+        const auto p = COMPILE_PLURAL_EXPR("(n != 1)");
         TEST_EQ(p(0), 1);
         TEST_EQ(p(1), 0);
         TEST_EQ(p(minVal), 1);
@@ -105,9 +228,7 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
     }
     // E.g. French
     {
-        const auto ptr = compile("(n > 1)");
-        TEST(ptr);
-        const auto& p = *ptr;
+        const auto p = COMPILE_PLURAL_EXPR("(n > 1)");
         TEST_EQ(p(0), 0);
         TEST_EQ(p(1), 0);
         TEST_EQ(p(2), 1);
@@ -116,9 +237,7 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
     }
     // E.g. Latvian
     {
-        const auto ptr = compile("(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)");
-        TEST(ptr);
-        const auto& p = *ptr;
+        const auto p = COMPILE_PLURAL_EXPR("(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2)");
         TEST_EQ(p(0), 2);
         TEST_EQ(p(1), 0);
         TEST_EQ(p(2), 1);
@@ -132,9 +251,7 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
     }
     // E.g. Irish
     {
-        const auto ptr = compile("n == 1 ? 0 : n == 2 ? 1 : 2");
-        TEST(ptr);
-        const auto& p = *ptr;
+        const auto p = COMPILE_PLURAL_EXPR("n == 1 ? 0 : n == 2 ? 1 : 2");
         TEST_EQ(p(0), 2);
         TEST_EQ(p(1), 0);
         TEST_EQ(p(2), 1);
@@ -145,9 +262,7 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
     }
     // E.g. Czech
     {
-        const auto ptr = compile("(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2");
-        TEST(ptr);
-        const auto& p = *ptr;
+        const auto p = COMPILE_PLURAL_EXPR("(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2");
         TEST_EQ(p(0), 2);
         TEST_EQ(p(1), 0);
         TEST_EQ(p(2), 1);
@@ -157,6 +272,7 @@ BOOST_LOCALE_WRONG_VPTR_OK void test_plural_expr()
         TEST_EQ(p(minVal), 2);
         TEST_EQ(p(maxVal), 2);
     }
+#undef COMPILE_PLURAL_EXPR
     // Error cases
     TEST(!compile("") && compile("n")); // Empty
     // Invalid comparison

--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -309,6 +309,12 @@ void test_plural_expr()
     TEST(!compile("n==1)") && compile("(n==1)"));
     TEST(!compile("n + 1)") && compile("(n + 1)"));
     TEST(!compile("n==1 ? 1 : 2)") && compile("(n==1 ? 1 : 2)"));
+    // Empty parenthesis
+    TEST(!compile("n==()1"));
+    TEST(!compile("n==()"));
+    // Missing operator for unary op
+    TEST(!compile("1==!"));
+    TEST(!compile("1 + -"));
     // No bitwise ops
     TEST(!compile("n << 1"));
     TEST(!compile("n >> 1"));

--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -309,6 +309,13 @@ void test_plural_expr()
     TEST(!compile("n==1)") && compile("(n==1)"));
     TEST(!compile("n + 1)") && compile("(n + 1)"));
     TEST(!compile("n==1 ? 1 : 2)") && compile("(n==1 ? 1 : 2)"));
+    // No bitwise ops
+    TEST(!compile("n << 1"));
+    TEST(!compile("n >> 1"));
+    TEST(!compile("n & 1"));
+    TEST(!compile("n | 1"));
+    TEST(!compile("n ^ 1"));
+    TEST(!compile("~n"));
 }
 
 void test_main(int /*argc*/, char** /*argv*/)

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -13,6 +13,7 @@
 #include "boostLocale/test/unit_test.hpp"
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 namespace bl = boost::locale;
@@ -101,7 +102,7 @@ template<typename Char>
 void test_cntranslate(const std::string& sContext,
                       const std::string& sSingular,
                       const std::string& sPlural,
-                      int n,
+                      long long n,
                       const std::string& sExpected,
                       const std::locale& l,
                       const std::string& domain)
@@ -151,7 +152,7 @@ void test_cntranslate(const std::string& sContext,
 template<typename Char>
 void test_ntranslate(const std::string& sSingular,
                      const std::string& sPlural,
-                     int n,
+                     long long n,
                      const std::string& sExpected,
                      const std::locale& l,
                      const std::string& domain)
@@ -289,7 +290,7 @@ void test_translate(const std::string& sOriginal,
 void test_cntranslate(const std::string& c,
                       const std::string& s,
                       const std::string& p,
-                      int n,
+                      long long n,
                       const std::string& expected,
                       const std::locale& l,
                       const std::string& domain)
@@ -308,7 +309,7 @@ void test_cntranslate(const std::string& c,
 
 void test_ntranslate(const std::string& s,
                      const std::string& p,
-                     int n,
+                     long long n,
                      const std::string& expected,
                      const std::locale& l,
                      const std::string& domain)
@@ -432,11 +433,19 @@ void test_main(int argc, char** argv)
                 test_ntranslate("x day", "x days", 2, "יומיים", l, "default");
                 test_ntranslate("x day", "x days", 3, "x ימים", l, "default");
                 test_ntranslate("x day", "x days", 20, "x יום", l, "default");
-
                 test_ntranslate("x day", "x days", 0, "x days", l, "undefined");
                 test_ntranslate("x day", "x days", 1, "x day", l, "undefined");
                 test_ntranslate("x day", "x days", 2, "x days", l, "undefined");
                 test_ntranslate("x day", "x days", 20, "x days", l, "undefined");
+                // Ensure no truncation occurs
+                test_ntranslate("x day", "x days", std::numeric_limits<long long>::min(), "x days", l, "undefined");
+                test_ntranslate("x day", "x days", std::numeric_limits<long long>::max(), "x days", l, "undefined");
+                for(unsigned bit = 1; bit < std::numeric_limits<long long>::digits; ++bit) {
+                    // Set each individual bit possible and add 1.
+                    // If the value is truncated the 1 will remain leading to singular form
+                    const auto num = static_cast<long long>(static_cast<unsigned long long>(1) << bit);
+                    test_ntranslate("x day", "x days", num + 1, "x days", l, "undefined");
+                }
             }
             std::cout << "    plural forms with context" << std::endl;
             {


### PR DESCRIPTION
- Use `long long` as the count argument for translations
- Remove bitwise/shift ops
- Enhanced tests
- Refactoring for readability

Improved from and hence closes #155