### PR TITLE
[Refactor] Improve translation catalog handling

### DIFF
--- a/src/boost/locale/util/encoding.cpp
+++ b/src/boost/locale/util/encoding.cpp
@@ -7,7 +7,6 @@
 
 #include "boost/locale/util/encoding.hpp"
 #include "boost/locale/util/string.hpp"
-#include <boost/assert.hpp>
 #if BOOST_LOCALE_USE_WIN32_API
 #    include "boost/locale/util/win_codepages.hpp"
 #    ifndef NOMINMAX


### PR DESCRIPTION
Combine 3 vectors of message domain data into one

Instead of having to synchronize the size of 3 related vectors use a vector of structs with all the data so it is clear that all data is available if any is.