### PR TITLE
Localization backend manager improvement

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -14,6 +14,8 @@
     - Other improvements and fixes
         - Fix UB on invalid index in format strings
         - Use `long long` as the count parameter for pluralized translations
+        - Make `localization_backend_manager` movable
+        - Add missing `noexcept` to move assignments/constructors
 - 1.82.0
     - Breaking changes
         - `get_system_locale` and dependents will now correctly favor `$LC_ALL` over `LC_CTYPE` as defined by POSIX

--- a/include/boost/locale/hold_ptr.hpp
+++ b/include/boost/locale/hold_ptr.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_HOLD_PTR_H
 
 #include <boost/locale/config.hpp>
+#include <boost/core/exchange.hpp>
 
 namespace boost { namespace locale {
     /// \brief a smart pointer similar to std::unique_ptr but the
@@ -28,7 +29,7 @@ namespace boost { namespace locale {
         hold_ptr(const hold_ptr&) = delete;
         hold_ptr& operator=(const hold_ptr&) = delete;
         // Movable
-        hold_ptr(hold_ptr&& other) noexcept : ptr_(other.ptr_) { other.ptr_ = nullptr; }
+        hold_ptr(hold_ptr&& other) noexcept : ptr_(exchange(other.ptr_, nullptr)) {}
         hold_ptr& operator=(hold_ptr&& other) noexcept
         {
             swap(other);

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -70,6 +70,10 @@ namespace boost { namespace locale {
         localization_backend_manager(const localization_backend_manager&);
         /// Assign localization_backend_manager
         localization_backend_manager& operator=(const localization_backend_manager&);
+        /// Move construct localization_backend_manager
+        localization_backend_manager(localization_backend_manager&&) noexcept;
+        /// Move assign localization_backend_manager
+        localization_backend_manager& operator=(localization_backend_manager&&) noexcept;
 
         /// Destructor
         ~localization_backend_manager();

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -211,11 +211,11 @@ namespace boost { namespace locale {
 
         /// Copy an object
         basic_message(const basic_message&) = default;
-        basic_message(basic_message&&) = default;
+        basic_message(basic_message&&) noexcept = default;
 
         /// Assign other message object to this one
         basic_message& operator=(const basic_message&) = default;
-        basic_message& operator=(basic_message&&) = default;
+        basic_message& operator=(basic_message&&) noexcept = default;
 
         /// Swap two message objects
         void

--- a/src/boost/locale/encoding/codepage.cpp
+++ b/src/boost/locale/encoding/codepage.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2022-2023 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -163,6 +163,10 @@ namespace boost { namespace locale {
         return *this;
     }
 
+    localization_backend_manager::localization_backend_manager(localization_backend_manager&&) noexcept = default;
+    localization_backend_manager&
+    localization_backend_manager::operator=(localization_backend_manager&&) noexcept = default;
+
     std::unique_ptr<localization_backend> localization_backend_manager::get() const
     {
         return std::unique_ptr<localization_backend>(pimpl_->create());

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -200,56 +200,49 @@ namespace boost { namespace locale {
     }
 
     namespace {
-        // prevent initialization order fiasco
+        localization_backend_manager make_default_backend_mgr()
+        {
+            localization_backend_manager mgr;
+#ifdef BOOST_LOCALE_WITH_ICU
+            mgr.adopt_backend("icu", impl_icu::create_localization_backend());
+#endif
+
+#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
+            mgr.adopt_backend("posix", impl_posix::create_localization_backend());
+#endif
+
+#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
+            mgr.adopt_backend("winapi", impl_win::create_localization_backend());
+#endif
+
+#ifndef BOOST_LOCALE_NO_STD_BACKEND
+            mgr.adopt_backend("std", impl_std::create_localization_backend());
+#endif
+
+            return mgr;
+        }
+
         boost::mutex& localization_backend_manager_mutex()
         {
             static boost::mutex the_mutex;
             return the_mutex;
         }
-        // prevent initialization order fiasco
         localization_backend_manager& localization_backend_manager_global()
         {
-            static localization_backend_manager the_manager;
+            static localization_backend_manager the_manager = make_default_backend_mgr();
             return the_manager;
         }
-
-        struct init {
-            init()
-            {
-                localization_backend_manager mgr;
-#ifdef BOOST_LOCALE_WITH_ICU
-                mgr.adopt_backend("icu", impl_icu::create_localization_backend());
-#endif
-
-#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-                mgr.adopt_backend("posix", impl_posix::create_localization_backend());
-#endif
-
-#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-                mgr.adopt_backend("winapi", impl_win::create_localization_backend());
-#endif
-
-#ifndef BOOST_LOCALE_NO_STD_BACKEND
-                mgr.adopt_backend("std", impl_std::create_localization_backend());
-#endif
-
-                localization_backend_manager::global(mgr);
-            }
-        } do_init;
     } // namespace
 
     localization_backend_manager localization_backend_manager::global()
     {
         boost::unique_lock<boost::mutex> lock(localization_backend_manager_mutex());
-        localization_backend_manager mgr = localization_backend_manager_global();
-        return mgr;
+        return localization_backend_manager_global();
     }
     localization_backend_manager localization_backend_manager::global(const localization_backend_manager& in)
     {
         boost::unique_lock<boost::mutex> lock(localization_backend_manager_mutex());
-        localization_backend_manager mgr = localization_backend_manager_global();
-        localization_backend_manager_global() = in;
-        return mgr;
+        return exchange(localization_backend_manager_global(), in);
     }
 
 }} // namespace boost::locale

--- a/test/boostLocale/test/tools.hpp
+++ b/test/boostLocale/test/tools.hpp
@@ -55,17 +55,19 @@ inline unsigned utf8_next(const std::string& s, unsigned& pos)
     return c;
 }
 
-/// Convert/decode an UTF-8 encoded string to the given char type
+/// Convert an UTF encoded string to an UTF-8 encoded string
 template<typename C>
-std::string to_utf8(const std::basic_string<C>& s)
+std::string to_utf8(const std::basic_string<C>& utf_string)
 {
-    return boost::locale::conv::from_utf(s, "UTF-8");
+    return boost::locale::conv::from_utf(utf_string, "UTF-8");
 }
-std::string to_utf8(const std::string& s)
+std::string to_utf8(const std::string& utf_string)
 {
-    return s;
+    return utf_string;
 }
 
+/// Convert/decode an UTF-8 encoded string to the given char type
+/// For `char` this will be Latin1, otherwise UTF-16/UTF-32
 template<typename Char>
 std::basic_string<Char> to(const std::string& utf8)
 {

--- a/test/test_codepage.cpp
+++ b/test/test_codepage.cpp
@@ -440,27 +440,13 @@ void test_main(int /*argc*/, char** /*argv*/)
     test_utf_name();
     test_win_codepages();
 
-    std::vector<std::string> backends;
-#ifdef BOOST_LOCALE_WITH_ICU
-    backends.push_back("icu");
-#endif
-#ifndef BOOST_LOCALE_NO_STD_BACKEND
-    backends.push_back("std");
-#endif
-#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-    backends.push_back("winapi");
-#endif
-#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-    backends.push_back("posix");
-#endif
-
 #if !defined(BOOST_LOCALE_WITH_ICU) && !defined(BOOST_LOCALE_WITH_ICONV) && BOOST_LOCALE_USE_WIN32_API
     test_iso_8859_8 = IsValidCodePage(28598) != 0;
 #endif
 
     test_simple_conversions();
 
-    for(const std::string& backendName : backends) {
+    for(const std::string& backendName : boost::locale::localization_backend_manager::global().get_all_backends()) {
         boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
         tmp_backend.select(backendName);
         boost::locale::localization_backend_manager::global(tmp_backend);

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -67,20 +67,6 @@ void test_main(int /*argc*/, char** /*argv*/)
 {
     using namespace boost::locale;
     using namespace boost::locale::period;
-    std::string def[] = {
-#ifdef BOOST_LOCALE_WITH_ICU
-      "icu",
-#endif
-#ifndef BOOST_LOCALE_NO_STD_BACKEND
-      "std",
-#endif
-#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-      "posix",
-#endif
-#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-      "winapi",
-#endif
-    };
     {
         auto* cal_facet = new mock_calendar_facet;
         std::locale old_loc = std::locale::global(std::locale(std::locale(), cal_facet));
@@ -126,7 +112,7 @@ void test_main(int /*argc*/, char** /*argv*/)
         TEST_EQ(mock_calendar::num_instances, 0); // No leaks
         std::locale::global(old_loc);
     }
-    for(const std::string& backend_name : def) {
+    for(const std::string& backend_name : boost::locale::localization_backend_manager::global().get_all_backends()) {
         std::cout << "Testing for backend: " << backend_name << std::endl;
         boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
         tmp_backend.select(backend_name);

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -409,21 +409,7 @@ void test_main(int argc, char** argv)
 
     const std::string message_path = (argc == 2) ? argv[1] : ".";
 
-    const std::string def[] = {
-#ifdef BOOST_LOCALE_WITH_ICU
-      "icu",
-#endif
-#ifndef BOOST_LOCALE_NO_STD_BACKEND
-      "std",
-#endif
-#ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-      "posix",
-#endif
-#ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-      "winapi",
-#endif
-    };
-    for(const std::string& backend_name : def) {
+    for(const std::string& backend_name : boost::locale::localization_backend_manager::global().get_all_backends()) {
         std::cout << "Testing for backend --------- " << backend_name << std::endl;
         boost::locale::localization_backend_manager tmp_backend = boost::locale::localization_backend_manager::global();
         tmp_backend.select(backend_name);


### PR DESCRIPTION
- Add missing move ctor/assign to `localization_backend_manager` to be used by e.g. `localization_backend_manager::global()`
- check and correct missing `noexcept` in move ops
- Add test for `localization_backend_manager::get_all_backends`