### PR TITLE
Refactoring: Simplify templates based on (supported) char types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(boost_locale
   src/boost/locale/util/default_locale.cpp
   src/boost/locale/util/encoding.cpp
   src/boost/locale/util/encoding.hpp
+  src/boost/locale/util/foreach_char.hpp
   src/boost/locale/util/info.cpp
   src/boost/locale/util/locale_data.cpp
   src/boost/locale/util/numeric.hpp

--- a/include/boost/locale/boundary/facets.hpp
+++ b/include/boost/locale/boundary/facets.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_BOUNDARY_FACETS_HPP_INCLUDED
 
 #include <boost/locale/boundary/types.hpp>
+#include <boost/locale/detail/facet_id.hpp>
 #include <boost/locale/detail/is_supported_char.hpp>
 #include <locale>
 #include <vector>
@@ -54,13 +55,13 @@ namespace boost { namespace locale {
         ///
         /// It is implemented for supported character types, at least \c char, \c wchar_t
         template<typename Char>
-        class BOOST_LOCALE_DECL boundary_indexing : public std::locale::facet {
+        class BOOST_SYMBOL_VISIBLE boundary_indexing : public std::locale::facet,
+                                                       public boost::locale::detail::facet_id<boundary_indexing<Char>> {
             BOOST_LOCALE_ASSERT_IS_SUPPORTED(Char);
 
         public:
             /// Default constructor typical for facets
             boundary_indexing(size_t refs = 0) : std::locale::facet(refs) {}
-            ~boundary_indexing();
 
             /// Create index for boundary type \a t for text in range [begin,end)
             ///
@@ -68,9 +69,6 @@ namespace boost { namespace locale {
             /// index is never empty, even if the range [begin,end) is empty it consists
             /// of at least one boundary point with the offset 0.
             virtual index_type map(boundary_type t, const Char* begin, const Char* end) const = 0;
-
-            /// Identification of this facet
-            static std::locale::id id;
         };
 
         /// @}

--- a/include/boost/locale/boundary/facets.hpp
+++ b/include/boost/locale/boundary/facets.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_BOUNDARY_FACETS_HPP_INCLUDED
 
 #include <boost/locale/boundary/types.hpp>
+#include <boost/locale/detail/is_supported_char.hpp>
 #include <locale>
 #include <vector>
 
@@ -49,19 +50,17 @@ namespace boost { namespace locale {
         /// with marks
         typedef std::vector<break_info> index_type;
 
-        template<typename CharType>
-        class boundary_indexing;
-
-#ifdef BOOST_LOCALE_DOXYGEN
-        /// \brief This facet generates an index for boundary analysis
-        /// for a given text.
+        /// \brief This facet generates an index for boundary analysis of a given text.
         ///
-        /// It is specialized for 4 types of characters \c char_t, \c wchar_t, \c char16_t and \c char32_t
+        /// It is implemented for supported character types, at least \c char, \c wchar_t
         template<typename Char>
         class BOOST_LOCALE_DECL boundary_indexing : public std::locale::facet {
+            BOOST_LOCALE_ASSERT_IS_SUPPORTED(Char);
+
         public:
             /// Default constructor typical for facets
             boundary_indexing(size_t refs = 0) : std::locale::facet(refs) {}
+            ~boundary_indexing();
 
             /// Create index for boundary type \a t for text in range [begin,end)
             ///
@@ -73,51 +72,6 @@ namespace boost { namespace locale {
             /// Identification of this facet
             static std::locale::id id;
         };
-
-#else
-
-        template<>
-        class BOOST_LOCALE_DECL boundary_indexing<char> : public std::locale::facet {
-        public:
-            boundary_indexing(size_t refs = 0) : std::locale::facet(refs) {}
-            ~boundary_indexing();
-            virtual index_type map(boundary_type t, const char* begin, const char* end) const = 0;
-            static std::locale::id id;
-        };
-
-        template<>
-        class BOOST_LOCALE_DECL boundary_indexing<wchar_t> : public std::locale::facet {
-        public:
-            boundary_indexing(size_t refs = 0) : std::locale::facet(refs) {}
-            ~boundary_indexing();
-            virtual index_type map(boundary_type t, const wchar_t* begin, const wchar_t* end) const = 0;
-
-            static std::locale::id id;
-        };
-
-#    ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        template<>
-        class BOOST_LOCALE_DECL boundary_indexing<char16_t> : public std::locale::facet {
-        public:
-            boundary_indexing(size_t refs = 0) : std::locale::facet(refs) {}
-            ~boundary_indexing();
-            virtual index_type map(boundary_type t, const char16_t* begin, const char16_t* end) const = 0;
-            static std::locale::id id;
-        };
-#    endif
-
-#    ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        template<>
-        class BOOST_LOCALE_DECL boundary_indexing<char32_t> : public std::locale::facet {
-        public:
-            boundary_indexing(size_t refs = 0) : std::locale::facet(refs) {}
-            ~boundary_indexing();
-            virtual index_type map(boundary_type t, const char32_t* begin, const char32_t* end) const = 0;
-            static std::locale::id id;
-        };
-#    endif
-
-#endif
 
         /// @}
     } // namespace boundary

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -17,8 +17,6 @@
 
 namespace boost { namespace locale {
 
-    class info;
-
     /// \defgroup collation Collation
     ///
     /// This module introduces collation related classes

--- a/include/boost/locale/conversion.hpp
+++ b/include/boost/locale/conversion.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_LOCALE_CONVERTER_HPP_INCLUDED
 #define BOOST_LOCALE_CONVERTER_HPP_INCLUDED
 
+#include <boost/locale/detail/facet_id.hpp>
 #include <boost/locale/detail/is_supported_char.hpp>
 #include <boost/locale/util/string.hpp>
 #include <locale>
@@ -41,16 +42,14 @@ namespace boost { namespace locale {
     /// It is used to perform text conversion operations defined by \ref converter_base::conversion_type.
     /// It is implemented for supported character types, at least \c char, \c wchar_t
     template<typename Char>
-    class BOOST_LOCALE_DECL converter : public converter_base, public std::locale::facet {
+    class BOOST_SYMBOL_VISIBLE converter : public converter_base,
+                                           public std::locale::facet,
+                                           public detail::facet_id<converter<Char>> {
         BOOST_LOCALE_ASSERT_IS_SUPPORTED(Char);
 
     public:
-        /// Locale identification
-        static std::locale::id id;
-
         /// Standard constructor
         converter(size_t refs = 0) : std::locale::facet(refs) {}
-        ~converter();
         /// Convert text in range [\a begin, \a end) according to conversion method \a how. Parameter
         /// \a flags is used for specification of normalization method like nfd, nfc etc.
         virtual std::basic_string<Char>

--- a/include/boost/locale/conversion.hpp
+++ b/include/boost/locale/conversion.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_LOCALE_CONVERTER_HPP_INCLUDED
 #define BOOST_LOCALE_CONVERTER_HPP_INCLUDED
 
+#include <boost/locale/detail/is_supported_char.hpp>
 #include <boost/locale/util/string.hpp>
 #include <locale>
 
@@ -35,76 +36,26 @@ namespace boost { namespace locale {
         };
     };
 
-    template<typename CharType>
-    class converter;
-
-#ifdef BOOST_LOCALE_DOXYGEN
-    ///
     /// \brief The facet that implements text manipulation
     ///
-    /// It is used to performs text conversion operations defined by \ref converter_base::conversion_type.
-    /// It is specialized for four types of characters \c char, \c wchar_t, \c char16_t, \c char32_t
+    /// It is used to perform text conversion operations defined by \ref converter_base::conversion_type.
+    /// It is implemented for supported character types, at least \c char, \c wchar_t
     template<typename Char>
     class BOOST_LOCALE_DECL converter : public converter_base, public std::locale::facet {
+        BOOST_LOCALE_ASSERT_IS_SUPPORTED(Char);
+
     public:
         /// Locale identification
         static std::locale::id id;
 
         /// Standard constructor
         converter(size_t refs = 0) : std::locale::facet(refs) {}
-
+        ~converter();
         /// Convert text in range [\a begin, \a end) according to conversion method \a how. Parameter
         /// \a flags is used for specification of normalization method like nfd, nfc etc.
         virtual std::basic_string<Char>
         convert(conversion_type how, const Char* begin, const Char* end, int flags = 0) const = 0;
     };
-#else
-
-    template<>
-    class BOOST_LOCALE_DECL converter<char> : public converter_base, public std::locale::facet {
-    public:
-        static std::locale::id id;
-
-        converter(size_t refs = 0) : std::locale::facet(refs) {}
-        ~converter();
-        virtual std::string convert(conversion_type how, const char* begin, const char* end, int flags = 0) const = 0;
-    };
-
-    template<>
-    class BOOST_LOCALE_DECL converter<wchar_t> : public converter_base, public std::locale::facet {
-    public:
-        static std::locale::id id;
-        converter(size_t refs = 0) : std::locale::facet(refs) {}
-        ~converter();
-        virtual std::wstring
-        convert(conversion_type how, const wchar_t* begin, const wchar_t* end, int flags = 0) const = 0;
-    };
-
-#    ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    template<>
-    class BOOST_LOCALE_DECL converter<char16_t> : public converter_base, public std::locale::facet {
-    public:
-        static std::locale::id id;
-        converter(size_t refs = 0) : std::locale::facet(refs) {}
-        ~converter();
-        virtual std::u16string
-        convert(conversion_type how, const char16_t* begin, const char16_t* end, int flags = 0) const = 0;
-    };
-#    endif
-
-#    ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-    template<>
-    class BOOST_LOCALE_DECL converter<char32_t> : public converter_base, public std::locale::facet {
-    public:
-        static std::locale::id id;
-        converter(size_t refs = 0) : std::locale::facet(refs) {}
-        ~converter();
-        virtual std::u32string
-        convert(conversion_type how, const char32_t* begin, const char32_t* end, int flags = 0) const = 0;
-    };
-#    endif
-
-#endif
 
     /// The type that defined <a href="http://unicode.org/reports/tr15/#Norm_Forms">normalization form</a>
     enum norm_type {

--- a/include/boost/locale/date_time_facet.hpp
+++ b/include/boost/locale/date_time_facet.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_DATE_TIME_FACET_HPP_INCLUDED
 
 #include <boost/locale/config.hpp>
+#include <boost/locale/detail/facet_id.hpp>
 #include <boost/cstdint.hpp>
 #include <locale>
 
@@ -91,7 +92,7 @@ namespace boost { namespace locale {
     /// This class defines generic calendar class, it is used by date_time and calendar
     /// objects internally. It is less useful for end users, but it is build for localization
     /// backend implementation
-    class BOOST_LOCALE_DECL abstract_calendar {
+    class BOOST_SYMBOL_VISIBLE abstract_calendar {
     public:
         /// Type that defines how to fetch the value
         enum value_type {
@@ -163,20 +164,16 @@ namespace boost { namespace locale {
         /// Check of two calendars have same rules
         virtual bool same(const abstract_calendar* other) const = 0;
 
-        virtual ~abstract_calendar();
+        virtual ~abstract_calendar() = default;
     };
 
     /// \brief the facet that generates calendar for specific locale
-    class BOOST_LOCALE_DECL calendar_facet : public std::locale::facet {
+    class BOOST_SYMBOL_VISIBLE calendar_facet : public std::locale::facet, public detail::facet_id<calendar_facet> {
     public:
         /// Basic constructor
         calendar_facet(size_t refs = 0) : std::locale::facet(refs) {}
-        ~calendar_facet();
         /// Create a new calendar that points to current point of time.
         virtual abstract_calendar* create_calendar() const = 0;
-
-        /// Locale id (needed to work with std::locale)
-        static std::locale::id id;
     };
 
 }} // namespace boost::locale

--- a/include/boost/locale/detail/facet_id.hpp
+++ b/include/boost/locale/detail/facet_id.hpp
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2022-2023 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_DETAIL_FACET_ID_HPP_INCLUDED
+#define BOOST_LOCALE_DETAIL_FACET_ID_HPP_INCLUDED
+
+#include <boost/locale/config.hpp>
+#include <locale>
+
+/// \cond INTERNAL
+namespace boost { namespace locale { namespace detail {
+
+    /// CRTP base class to hold the id required for facets
+    ///
+    /// Required because the id needs to be defined in a CPP file and hence ex/imported for shared libraries.
+    /// However the virtual classes need to be declared as BOOST_VISIBLE to combine the VTables because otherwise
+    /// casts/virtual-calls might be flagged as invalid by UBSAN
+    template<class Derived>
+    struct BOOST_LOCALE_DECL facet_id {
+        static std::locale::id id;
+    };
+
+}}} // namespace boost::locale::detail
+
+/// \endcond
+
+#endif

--- a/include/boost/locale/detail/is_supported_char.hpp
+++ b/include/boost/locale/detail/is_supported_char.hpp
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2022-2023 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_DETAIL_IS_SUPPORTED_CHAR_HPP_INCLUDED
+#define BOOST_LOCALE_DETAIL_IS_SUPPORTED_CHAR_HPP_INCLUDED
+
+#include <boost/locale/config.hpp>
+#include <type_traits>
+
+/// \cond INTERNAL
+namespace boost { namespace locale { namespace detail {
+    /// Trait, returns true iff the argument is a supported character type
+    template<typename Char>
+    struct is_supported_char : std::false_type {};
+
+    template<>
+    struct is_supported_char<char> : std::true_type {};
+    template<>
+    struct is_supported_char<wchar_t> : std::true_type {};
+
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    template<>
+    struct is_supported_char<char16_t> : std::true_type {};
+#endif
+
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    template<>
+    struct is_supported_char<char32_t> : std::true_type {};
+#endif
+
+    template<typename Char>
+    using enable_if_is_supported_char = typename std::enable_if<is_supported_char<Char>::value>::type;
+
+}}} // namespace boost::locale::detail
+
+#define BOOST_LOCALE_ASSERT_IS_SUPPORTED(Char) \
+    static_assert(boost::locale::detail::is_supported_char<Char>::value, "Unsupported Char type")
+
+/// \endcond
+
+#endif

--- a/include/boost/locale/generic_codecvt.hpp
+++ b/include/boost/locale/generic_codecvt.hpp
@@ -13,12 +13,8 @@
 
 namespace boost { namespace locale {
 
-#ifndef BOOST_LOCALE_DOXYGEN
-    //
     // Make sure that mbstate can keep 16 bit of UTF-16 sequence
-    //
     static_assert(sizeof(std::mbstate_t) >= 2, "std::mbstate_t is to small");
-#endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1700
 // up to MSVC 11 (2012) do_length is non-standard it counts wide characters instead of narrow and does not change

--- a/include/boost/locale/gnu_gettext.hpp
+++ b/include/boost/locale/gnu_gettext.hpp
@@ -7,9 +7,11 @@
 #ifndef BOOST_LOCLAE_GNU_GETTEXT_HPP
 #define BOOST_LOCLAE_GNU_GETTEXT_HPP
 
+#include <boost/locale/detail/is_supported_char.hpp>
 #include <boost/locale/message.hpp>
 #include <functional>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 #ifdef BOOST_MSVC
@@ -106,28 +108,8 @@ namespace boost { namespace locale {
 
         /// Create a message_format facet using GNU Gettext catalogs. It uses \a info structure to get
         /// information about where to read them from and uses it for character set conversion (if needed)
-        template<typename CharType>
-        message_format<CharType>* create_messages_facet(const messages_info& info);
-
-        /// \cond INTERNAL
-
-        template<>
-        BOOST_LOCALE_DECL message_format<char>* create_messages_facet(const messages_info& info);
-
-        template<>
-        BOOST_LOCALE_DECL message_format<wchar_t>* create_messages_facet(const messages_info& info);
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        template<>
-        BOOST_LOCALE_DECL message_format<char16_t>* create_messages_facet(const messages_info& info);
-#endif
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        template<>
-        BOOST_LOCALE_DECL message_format<char32_t>* create_messages_facet(const messages_info& info);
-#endif
-
-        /// \endcond
+        template<typename CharType, class = boost::locale::detail::enable_if_is_supported_char<CharType>>
+        BOOST_LOCALE_DECL message_format<CharType>* create_messages_facet(const messages_info& info);
 
     } // namespace gnu_gettext
 

--- a/include/boost/locale/info.hpp
+++ b/include/boost/locale/info.hpp
@@ -8,6 +8,7 @@
 #define BOOST_LOCALE_INFO_HPP_INCLUDED
 
 #include <boost/locale/config.hpp>
+#include <boost/locale/detail/facet_id.hpp>
 #include <locale>
 #include <string>
 
@@ -21,12 +22,8 @@ namespace boost { namespace locale {
     /// \brief a facet that holds general information about locale
     ///
     /// This facet should be always created in order to make all Boost.Locale functions work
-    class BOOST_LOCALE_DECL info : public std::locale::facet {
+    class BOOST_SYMBOL_VISIBLE info : public std::locale::facet, public detail::facet_id<info> {
     public:
-        ~info();
-
-        static std::locale::id id; ///< This member uniquely defines this facet, required by STL
-
         /// String information about the locale
         enum string_propery {
             language_property, ///< ISO 639 language id

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_LOCALE_MESSAGE_HPP_INCLUDED
 #define BOOST_LOCALE_MESSAGE_HPP_INCLUDED
 
+#include <boost/locale/detail/is_supported_char.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/util/string.hpp>
 #include <locale>
@@ -37,27 +38,25 @@ namespace boost { namespace locale {
     /// @{
     ///
 
-    /// \cond INTERNAL
-
-    template<typename CharType>
-    struct base_message_format;
-
-    /// \endcond
-
     /// Type used for the count/n argument to the translation functions choosing between singular and plural forms
     using count_type = long long;
 
     /// \brief This facet provides message formatting abilities
     template<typename CharType>
-    class BOOST_SYMBOL_VISIBLE message_format : public base_message_format<CharType> {
+    class BOOST_LOCALE_DECL message_format : public std::locale::facet {
+        BOOST_LOCALE_ASSERT_IS_SUPPORTED(CharType);
+
     public:
         /// Character type
         typedef CharType char_type;
         /// String type
         typedef std::basic_string<CharType> string_type;
 
-        /// Default constructor
-        message_format(size_t refs = 0) : base_message_format<CharType>(refs) {}
+        /// Locale identification
+        static std::locale::id id;
+
+        /// Standard constructor
+        message_format(size_t refs = 0) : std::locale::facet(refs) {}
 
         /// This function returns a pointer to the string for a message defined by a \a context
         /// and identification string \a id. Both create a single key for message lookup in
@@ -93,7 +92,7 @@ namespace boost { namespace locale {
         virtual const char_type* convert(const char_type* msg, string_type& buffer) const = 0;
 
     protected:
-        virtual ~message_format() = default;
+        virtual ~message_format();
     };
 
     /// \cond INTERNAL
@@ -503,45 +502,6 @@ namespace boost { namespace locale {
         return basic_message<CharType>(context, s, p, n).str(loc, domain);
     }
 
-    /// \cond INTERNAL
-
-    template<>
-    struct BOOST_LOCALE_DECL base_message_format<char> : public std::locale::facet {
-        base_message_format(size_t refs = 0) : std::locale::facet(refs) {}
-        ~base_message_format();
-        static std::locale::id id;
-    };
-
-    template<>
-    struct BOOST_LOCALE_DECL base_message_format<wchar_t> : public std::locale::facet {
-        base_message_format(size_t refs = 0) : std::locale::facet(refs) {}
-        ~base_message_format();
-        static std::locale::id id;
-    };
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-
-    template<>
-    struct BOOST_LOCALE_DECL base_message_format<char16_t> : public std::locale::facet {
-        base_message_format(size_t refs = 0) : std::locale::facet(refs) {}
-        ~base_message_format();
-        static std::locale::id id;
-    };
-
-#endif
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-
-    template<>
-    struct BOOST_LOCALE_DECL base_message_format<char32_t> : public std::locale::facet {
-        base_message_format(size_t refs = 0) : std::locale::facet(refs) {}
-        ~base_message_format();
-        static std::locale::id id;
-    };
-
-#endif
-
-    /// \endcond
     /// @}
 
     namespace as {

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_LOCALE_MESSAGE_HPP_INCLUDED
 #define BOOST_LOCALE_MESSAGE_HPP_INCLUDED
 
+#include <boost/locale/detail/facet_id.hpp>
 #include <boost/locale/detail/is_supported_char.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/util/string.hpp>
@@ -43,7 +44,8 @@ namespace boost { namespace locale {
 
     /// \brief This facet provides message formatting abilities
     template<typename CharType>
-    class BOOST_LOCALE_DECL message_format : public std::locale::facet {
+    class BOOST_SYMBOL_VISIBLE message_format : public std::locale::facet,
+                                                public detail::facet_id<message_format<CharType>> {
         BOOST_LOCALE_ASSERT_IS_SUPPORTED(CharType);
 
     public:
@@ -51,9 +53,6 @@ namespace boost { namespace locale {
         typedef CharType char_type;
         /// String type
         typedef std::basic_string<CharType> string_type;
-
-        /// Locale identification
-        static std::locale::id id;
 
         /// Standard constructor
         message_format(size_t refs = 0) : std::locale::facet(refs) {}
@@ -90,9 +89,6 @@ namespace boost { namespace locale {
         /// Note: for char_type that is char16_t, char32_t and wchar_t it is no-op, returns
         /// msg
         virtual const char_type* convert(const char_type* msg, string_type& buffer) const = 0;
-
-    protected:
-        virtual ~message_format();
     };
 
     /// \cond INTERNAL

--- a/src/boost/locale/icu/boundary.cpp
+++ b/src/boost/locale/icu/boundary.cpp
@@ -7,11 +7,11 @@
 
 #include <boost/locale/boundary.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale//util/encoding.hpp"
 #include "boost/locale/icu/all_generator.hpp"
 #include "boost/locale/icu/cdata.hpp"
 #include "boost/locale/icu/icu_util.hpp"
 #include "boost/locale/icu/uconv.hpp"
+#include "boost/locale/util/encoding.hpp"
 #if BOOST_LOCALE_ICU_VERSION >= 306
 #    include <unicode/utext.h>
 #endif

--- a/src/boost/locale/icu/formatter.cpp
+++ b/src/boost/locale/icu/formatter.cpp
@@ -12,6 +12,7 @@
 #include "boost/locale/icu/icu_util.hpp"
 #include "boost/locale/icu/time_zone.hpp"
 #include "boost/locale/icu/uconv.hpp"
+#include "boost/locale/util/foreach_char.hpp"
 #include <limits>
 #include <memory>
 #include <unicode/datefmt.h>
@@ -442,16 +443,9 @@ namespace boost { namespace locale { namespace impl_icu {
         return nullptr; // LCOV_EXCL_LINE
     }
 
-    template class formatter<char>;
-    template class formatter<wchar_t>;
+#define BOOST_LOCALE_INSTANTIATE(CHAR) template class formatter<CHAR>;
+    BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INSTANTIATE)
 
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    template class formatter<char16_t>;
-#endif
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-    template class formatter<char32_t>;
-#endif
 }}} // namespace boost::locale::impl_icu
 
 // boostinspect:nominmax

--- a/src/boost/locale/shared/ids.cpp
+++ b/src/boost/locale/shared/ids.cpp
@@ -10,6 +10,7 @@
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/info.hpp>
 #include <boost/locale/message.hpp>
+#include "boost/locale/util/foreach_char.hpp"
 #include <boost/core/ignore_unused.hpp>
 
 namespace boost { namespace locale {
@@ -23,68 +24,42 @@ namespace boost { namespace locale {
 
     abstract_calendar::~abstract_calendar() = default;
 
-    std::locale::id converter<char>::id;
-    converter<char>::~converter() = default;
-    std::locale::id base_message_format<char>::id;
-    base_message_format<char>::~base_message_format() = default;
+    template<typename Char>
+    std::locale::id converter<Char>::id;
+    template<typename Char>
+    converter<Char>::~converter() = default;
 
-    std::locale::id converter<wchar_t>::id;
-    converter<wchar_t>::~converter() = default;
-    std::locale::id base_message_format<wchar_t>::id;
-    base_message_format<wchar_t>::~base_message_format() = default;
+    template<typename Char>
+    std::locale::id message_format<Char>::id;
+    template<typename Char>
+    message_format<Char>::~message_format() = default;
 
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-
-    std::locale::id converter<char16_t>::id;
-    converter<char16_t>::~converter() = default;
-    std::locale::id base_message_format<char16_t>::id;
-    base_message_format<char16_t>::~base_message_format() = default;
-
-#endif
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-
-    std::locale::id converter<char32_t>::id;
-    converter<char32_t>::~converter() = default;
-    std::locale::id base_message_format<char32_t>::id;
-    base_message_format<char32_t>::~base_message_format() = default;
-
-#endif
+#define BOOST_LOCALE_INSTANTIATE(CHARTYPE) \
+    template BOOST_LOCALE_DECL class converter<CHARTYPE>;    \
+    template BOOST_LOCALE_DECL class message_format<CHARTYPE>;
+    BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INSTANTIATE)
+#undef BOOST_LOCALE_INSTANTIATE
 
     namespace boundary {
+        template<typename Char>
+        std::locale::id boundary_indexing<Char>::id;
+        template<typename Char>
+        boundary_indexing<Char>::~boundary_indexing() = default;
 
-        std::locale::id boundary_indexing<char>::id;
-        boundary_indexing<char>::~boundary_indexing() = default;
-
-        std::locale::id boundary_indexing<wchar_t>::id;
-        boundary_indexing<wchar_t>::~boundary_indexing() = default;
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-        std::locale::id boundary_indexing<char16_t>::id;
-        boundary_indexing<char16_t>::~boundary_indexing() = default;
-#endif
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-        std::locale::id boundary_indexing<char32_t>::id;
-        boundary_indexing<char32_t>::~boundary_indexing() = default;
-#endif
+#define BOOST_LOCALE_INSTANTIATE(CHARTYPE) template class boundary_indexing<CHARTYPE>;
+        BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INSTANTIATE)
+#undef BOOST_LOCALE_INSTANTIATE
     } // namespace boundary
 
     namespace {
         // Initialize each facet once to avoid issues where doing so
-        // in a multithreaded environment could cause problems (races)
+        // in a multi threaded environment could cause problems (races)
         struct init_all {
             init_all()
             {
                 const std::locale& l = std::locale::classic();
-                init_by<char>(l);
-                init_by<wchar_t>(l);
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                init_by<char16_t>(l);
-#endif
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                init_by<char32_t>(l);
-#endif
+#define BOOST_LOCALE_INIT_BY(CHAR) init_by<CHAR>(l);
+                BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INIT_BY)
 
                 init_facet<info>(l);
                 init_facet<calendar_facet>(l);

--- a/src/boost/locale/shared/ids.cpp
+++ b/src/boost/locale/shared/ids.cpp
@@ -14,42 +14,22 @@
 #include <boost/core/ignore_unused.hpp>
 
 namespace boost { namespace locale {
+    namespace detail {
+        template<class Derived>
+        std::locale::id facet_id<Derived>::id;
+    } // namespace detail
+#define BOOST_LOCALE_DEFINE_ID(CLASS) template struct detail::facet_id<CLASS>
 
-    std::locale::id info::id;
-    // Make sure we have the VTable here (Export/Import issues)
-    info::~info() = default;
+    BOOST_LOCALE_DEFINE_ID(info);
+    BOOST_LOCALE_DEFINE_ID(calendar_facet);
 
-    std::locale::id calendar_facet::id;
-    calendar_facet::~calendar_facet() = default;
+#define BOOST_LOCALE_INSTANTIATE(CHARTYPE)            \
+    BOOST_LOCALE_DEFINE_ID(converter<CHARTYPE>);      \
+    BOOST_LOCALE_DEFINE_ID(message_format<CHARTYPE>); \
+    BOOST_LOCALE_DEFINE_ID(boundary::boundary_indexing<CHARTYPE>);
 
-    abstract_calendar::~abstract_calendar() = default;
-
-    template<typename Char>
-    std::locale::id converter<Char>::id;
-    template<typename Char>
-    converter<Char>::~converter() = default;
-
-    template<typename Char>
-    std::locale::id message_format<Char>::id;
-    template<typename Char>
-    message_format<Char>::~message_format() = default;
-
-#define BOOST_LOCALE_INSTANTIATE(CHARTYPE) \
-    template BOOST_LOCALE_DECL class converter<CHARTYPE>;    \
-    template BOOST_LOCALE_DECL class message_format<CHARTYPE>;
     BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INSTANTIATE)
 #undef BOOST_LOCALE_INSTANTIATE
-
-    namespace boundary {
-        template<typename Char>
-        std::locale::id boundary_indexing<Char>::id;
-        template<typename Char>
-        boundary_indexing<Char>::~boundary_indexing() = default;
-
-#define BOOST_LOCALE_INSTANTIATE(CHARTYPE) template class boundary_indexing<CHARTYPE>;
-        BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INSTANTIATE)
-#undef BOOST_LOCALE_INSTANTIATE
-    } // namespace boundary
 
     namespace {
         // Initialize each facet once to avoid issues where doing so

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -23,6 +23,7 @@
 #include "boost/locale/shared/mo_hash.hpp"
 #include "boost/locale/shared/mo_lambda.hpp"
 #include "boost/locale/util/encoding.hpp"
+#include "boost/locale/util/foreach_char.hpp"
 #include <boost/assert.hpp>
 #include <boost/version.hpp>
 #include <algorithm>
@@ -593,34 +594,15 @@ namespace boost { namespace locale { namespace gnu_gettext {
         bool key_conversion_required_;
     };
 
-    template<>
-    message_format<char>* create_messages_facet(const messages_info& info)
+    template<typename CharType, class /* enable_if */>
+    message_format<CharType>* create_messages_facet(const messages_info& info)
     {
-        return new mo_message<char>(info);
+        return new mo_message<CharType>(info);
     }
 
-    template<>
-    message_format<wchar_t>* create_messages_facet(const messages_info& info)
-    {
-        return new mo_message<wchar_t>(info);
-    }
+#define BOOST_LOCALE_INSTANTIATE(CHARTYPE) \
+    template BOOST_LOCALE_DECL message_format<CHARTYPE>* create_messages_facet(const messages_info& info);
 
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-
-    template<>
-    message_format<char16_t>* create_messages_facet(const messages_info& info)
-    {
-        return new mo_message<char16_t>(info);
-    }
-#endif
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-
-    template<>
-    message_format<char32_t>* create_messages_facet(const messages_info& info)
-    {
-        return new mo_message<char32_t>(info);
-    }
-#endif
+    BOOST_LOCALE_FOREACH_CHAR(BOOST_LOCALE_INSTANTIATE)
 
 }}} // namespace boost::locale::gnu_gettext

--- a/src/boost/locale/util/foreach_char.hpp
+++ b/src/boost/locale/util/foreach_char.hpp
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2023-2023 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_UTIL_FOREACH_CHAR_HPP
+#define BOOST_LOCALE_UTIL_FOREACH_CHAR_HPP
+
+#include <boost/locale/config.hpp>
+
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+#    define BOOST_LOCALE_FOREACH_CHAR_I_CHAR16_T(F) F(char16_t)
+#else
+#    define BOOST_LOCALE_FOREACH_CHAR_I_CHAR16_T(F)
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+#    define BOOST_LOCALE_FOREACH_CHAR_I_CHAR32_T(F) F(char32_t)
+#else
+#    define BOOST_LOCALE_FOREACH_CHAR_I_CHAR32_T(F)
+#endif
+
+#define BOOST_LOCALE_FOREACH_CHAR(F)        \
+    F(char)                                 \
+    F(wchar_t)                              \
+    BOOST_LOCALE_FOREACH_CHAR_I_CHAR16_T(F) \
+    BOOST_LOCALE_FOREACH_CHAR_I_CHAR32_T(F)
+
+#endif


### PR DESCRIPTION
Instead of explicit instantiation for each supported char type and an extra copy for documentation generation reduce to only a single template and instantiate the whole class explicitly. To ensure a reasonable error is generated introduce an `is_supported_char`-trait and `static_assert` on it. To further reduce the repetition when instantiating the templates create a macro to loop over the supported char types.