### PR TITLE
Add custom `boost::locale::numpunct`

### DIFF
--- a/include/boost/locale.hpp
+++ b/include/boost/locale.hpp
@@ -20,6 +20,7 @@
 #include <boost/locale/info.hpp>
 #include <boost/locale/localization_backend.hpp>
 #include <boost/locale/message.hpp>
+#include <boost/locale/numpunct.hpp>
 #include <boost/locale/util.hpp>
 
 #endif

--- a/include/boost/locale/numpunct.hpp
+++ b/include/boost/locale/numpunct.hpp
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2021-2021 Salvo Miosi
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_LOCALE_NUMPUNCT_HPP_INCLUDED
+#define BOOST_LOCALE_NUMPUNCT_HPP_INCLUDED
+#include <boost/locale/config.hpp>
+#include <locale>
+#include <string>
+
+namespace boost { namespace locale {
+
+    template<typename CharType>
+    class numpunct_base : public std::numpunct<CharType> {
+        typedef std::basic_string<CharType> string_type;
+
+    public:
+        numpunct_base(size_t refs = 0) : std::numpunct<CharType>(refs) {}
+
+        string_type decimal_point_str() const { return do_decimal_point_str(); }
+
+        string_type thousands_sep_str() const { return do_thousands_sep_str(); }
+
+    protected:
+        CharType do_decimal_point() const BOOST_OVERRIDE
+        {
+            string_type dec = do_decimal_point_str();
+            if(dec.size() > 1) {
+                return '.';
+            } else {
+                return dec[0];
+            }
+        }
+
+        virtual string_type do_decimal_point_str() const
+        {
+            static const char t[] = ".";
+            return string_type(t, t + sizeof(t) - 1);
+        }
+
+        CharType do_thousands_sep() const BOOST_OVERRIDE
+        {
+            string_type thous = do_thousands_sep_str();
+            if(thous.size() > 1) {
+                return ',';
+            } else {
+                return thous[0];
+            }
+        }
+
+        virtual string_type do_thousands_sep_str() const
+        {
+            static const char t[] = ",";
+            return string_type(t, t + sizeof(t) - 1);
+        }
+
+        virtual string_type do_truename() const BOOST_OVERRIDE
+        {
+            static const char t[] = "true";
+            return string_type(t, t + sizeof(t) - 1);
+        }
+
+        virtual string_type do_falsename() const BOOST_OVERRIDE
+        {
+            static const char t[] = "false";
+            return string_type(t, t + sizeof(t) - 1);
+        }
+    };
+
+    template<typename CharType>
+    struct numpunct;
+
+    template<>
+    struct numpunct<char> : numpunct_base<char> {
+        numpunct(size_t refs = 0) : numpunct_base<char>(refs) {}
+    };
+
+    template<>
+    struct numpunct<wchar_t> : numpunct_base<wchar_t> {
+        numpunct(size_t refs = 0) : numpunct_base<wchar_t>(refs) {}
+    };
+
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    template<>
+    struct numpunct<char16_t> : numpunct_base<char16_t> {
+        numpunct(size_t refs = 0) : numpunct_base<char16_t>(refs) {}
+    };
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    template<>
+    struct numpunct<char32_t> : numpunct_base<char32_t> {
+        numpunct(size_t refs = 0) : numpunct_base<char32_t>(refs) {}
+    };
+#endif
+}} // namespace boost::locale
+
+#endif

--- a/include/boost/locale/numpunct.hpp
+++ b/include/boost/locale/numpunct.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021-2021 Salvo Miosi
+// Copyright (c) 2023-2023 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE_1_0.txt or copy at
@@ -8,63 +9,71 @@
 
 #ifndef BOOST_LOCALE_NUMPUNCT_HPP_INCLUDED
 #define BOOST_LOCALE_NUMPUNCT_HPP_INCLUDED
+
 #include <boost/locale/config.hpp>
 #include <locale>
 #include <string>
 
 namespace boost { namespace locale {
 
+    /// \brief Extension of `std::numpunct` providing possibly encoded values of decimal point and thousands separator.
+    ///
+    /// To achieve interface compatibility with `std::numpunct` for the case where the separators are encoded using
+    /// multiple chars the functions `do_decimal_point` and `do_thousands_sep` will fall back to the values used by the
+    /// "C" locale.
+    ///
+    /// \note
+    ///
+    /// - Not all backends support encoded separators, so \ref decimal_point_str & \ref thousands_sep_str may return
+    ///   strings of length 1.
+    /// - Some backends may provide single char replacements of the encoded separators instead of falling back to the
+    ///   "C" locale.
     template<typename CharType>
     class numpunct_base : public std::numpunct<CharType> {
-        typedef std::basic_string<CharType> string_type;
-
     public:
+        using string_type = std::numpunct<CharType>::string_type;
+
         numpunct_base(size_t refs = 0) : std::numpunct<CharType>(refs) {}
 
+        /// Provides the character to use as decimal point possibly encoded into multiple code units
         string_type decimal_point_str() const { return do_decimal_point_str(); }
-
+        /// Provides the character to use as thousands separator possibly encoded into multiple code units
         string_type thousands_sep_str() const { return do_thousands_sep_str(); }
 
     protected:
-        CharType do_decimal_point() const BOOST_OVERRIDE
+        CharType do_decimal_point() const override
         {
-            string_type dec = do_decimal_point_str();
-            if(dec.size() > 1) {
-                return '.';
-            } else {
-                return dec[0];
-            }
+            const string_type dec = do_decimal_point_str();
+            return (dec.size() > 1) ? '.' : dec[0];
         }
 
+        /// Provides the character to use as decimal point possibly encoded into multiple code units
         virtual string_type do_decimal_point_str() const
         {
             static const char t[] = ".";
             return string_type(t, t + sizeof(t) - 1);
         }
 
-        CharType do_thousands_sep() const BOOST_OVERRIDE
+        CharType do_thousands_sep() const override
         {
-            string_type thous = do_thousands_sep_str();
-            if(thous.size() > 1) {
-                return ',';
-            } else {
-                return thous[0];
-            }
+            const string_type sep = do_thousands_sep_str();
+            return (sep.size() > 1) ? '.' : sep[0];
         }
 
+        /// Provides the character to use as thousands separator possibly encoded into multiple code units
         virtual string_type do_thousands_sep_str() const
         {
             static const char t[] = ",";
             return string_type(t, t + sizeof(t) - 1);
         }
 
-        virtual string_type do_truename() const BOOST_OVERRIDE
+        string_type do_truename() const override
         {
             static const char t[] = "true";
             return string_type(t, t + sizeof(t) - 1);
         }
 
-        virtual string_type do_falsename() const BOOST_OVERRIDE
+        string_type do_falsename() const override
         {
             static const char t[] = "false";
             return string_type(t, t + sizeof(t) - 1);

--- a/include/boost/locale/numpunct.hpp
+++ b/include/boost/locale/numpunct.hpp
@@ -11,6 +11,7 @@
 #define BOOST_LOCALE_NUMPUNCT_HPP_INCLUDED
 
 #include <boost/locale/config.hpp>
+#include <boost/locale/detail/is_supported_char.hpp>
 #include <locale>
 #include <string>
 
@@ -29,11 +30,13 @@ namespace boost { namespace locale {
     /// - Some backends may provide single char replacements of the encoded separators instead of falling back to the
     ///   "C" locale.
     template<typename CharType>
-    class numpunct_base : public std::numpunct<CharType> {
+    class numpunct : public std::numpunct<CharType> {
+        BOOST_LOCALE_ASSERT_IS_SUPPORTED(CharType);
+
     public:
         using string_type = std::numpunct<CharType>::string_type;
 
-        numpunct_base(size_t refs = 0) : std::numpunct<CharType>(refs) {}
+        numpunct(size_t refs = 0) : std::numpunct<CharType>(refs) {}
 
         /// Provides the character to use as decimal point possibly encoded into multiple code units
         string_type decimal_point_str() const { return do_decimal_point_str(); }
@@ -79,32 +82,6 @@ namespace boost { namespace locale {
             return string_type(t, t + sizeof(t) - 1);
         }
     };
-
-    template<typename CharType>
-    struct numpunct;
-
-    template<>
-    struct numpunct<char> : numpunct_base<char> {
-        numpunct(size_t refs = 0) : numpunct_base<char>(refs) {}
-    };
-
-    template<>
-    struct numpunct<wchar_t> : numpunct_base<wchar_t> {
-        numpunct(size_t refs = 0) : numpunct_base<wchar_t>(refs) {}
-    };
-
-#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    template<>
-    struct numpunct<char16_t> : numpunct_base<char16_t> {
-        numpunct(size_t refs = 0) : numpunct_base<char16_t>(refs) {}
-    };
-#endif
-#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-    template<>
-    struct numpunct<char32_t> : numpunct_base<char32_t> {
-        numpunct(size_t refs = 0) : numpunct_base<char32_t>(refs) {}
-    };
-#endif
 }} // namespace boost::locale
 
 #endif

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -1,5 +1,7 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2021-2021 Salvo Miosi
+// Copyright (c) 2022-2023 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -10,13 +12,15 @@
 #include "boost/locale/icu/cdata.hpp"
 #include "boost/locale/icu/formatter.hpp"
 #include "boost/locale/icu/formatters_cache.hpp"
-#include "uconv.hpp"
+#include "boost/locale/icu/uconv.hpp"
 #include <algorithm>
 #include <ios>
 #include <limits>
 #include <locale>
 #include <string>
 #include <type_traits>
+#include <unicode/decimfmt.h>
+#include <unicode/numfmt.h>
 
 namespace boost { namespace locale { namespace impl_icu {
 
@@ -313,7 +317,7 @@ namespace boost { namespace locale { namespace impl_icu {
         {
             UErrorCode err = U_ZERO_ERROR;
             icu::NumberFormat* fmt = icu::NumberFormat::createInstance(d.locale, UNUM_DECIMAL, err);
-            if(icu::DecimalFormat* dec = dynamic_cast<icu::DecimalFormat*>(fmt)) {
+            if(icu::DecimalFormat* dec = icu_cast<icu::DecimalFormat>(fmt)) {
                 boost::locale::impl_icu::icu_std_converter<CharType> cnv(d.encoding);
                 const icu::DecimalFormatSymbols* syms = dec->getDecimalFormatSymbols();
                 decimal_point_ = cnv.std(syms->getSymbol(icu::DecimalFormatSymbols::kDecimalSeparatorSymbol));
@@ -330,9 +334,9 @@ namespace boost { namespace locale { namespace impl_icu {
         }
 
     protected:
-        string_type do_decimal_point_str() const BOOST_OVERRIDE { return decimal_point_; }
-        string_type do_thousands_sep_str() const BOOST_OVERRIDE { return thousands_sep_; }
-        std::string do_grouping() const BOOST_OVERRIDE { return grouping_; }
+        string_type do_decimal_point_str() const override { return decimal_point_; }
+        string_type do_thousands_sep_str() const override { return thousands_sep_; }
+        std::string do_grouping() const override { return grouping_; }
 
     private:
         string_type decimal_point_;

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -5,10 +5,12 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/formatting.hpp>
+#include <boost/locale/numpunct.hpp>
 #include "boost/locale/icu/all_generator.hpp"
 #include "boost/locale/icu/cdata.hpp"
 #include "boost/locale/icu/formatter.hpp"
 #include "boost/locale/icu/formatters_cache.hpp"
+#include "uconv.hpp"
 #include <algorithm>
 #include <ios>
 #include <limits>
@@ -303,11 +305,48 @@ namespace boost { namespace locale { namespace impl_icu {
     };
 
     template<typename CharType>
+    struct icu_numpunct : public numpunct<CharType> {
+        typedef std::basic_string<CharType> string_type;
+
+    public:
+        icu_numpunct(const cdata& d)
+        {
+            UErrorCode err = U_ZERO_ERROR;
+            icu::NumberFormat* fmt = icu::NumberFormat::createInstance(d.locale, UNUM_DECIMAL, err);
+            if(icu::DecimalFormat* dec = dynamic_cast<icu::DecimalFormat*>(fmt)) {
+                boost::locale::impl_icu::icu_std_converter<CharType> cnv(d.encoding);
+                const icu::DecimalFormatSymbols* syms = dec->getDecimalFormatSymbols();
+                decimal_point_ = cnv.std(syms->getSymbol(icu::DecimalFormatSymbols::kDecimalSeparatorSymbol));
+                thousands_sep_ = cnv.std(syms->getSymbol(icu::DecimalFormatSymbols::kGroupingSeparatorSymbol));
+                if(dec->isGroupingUsed()) {
+                    int32_t grouping_size = dec->getGroupingSize();
+                    grouping_ = std::string(reinterpret_cast<char*>(&grouping_size), 1);
+                    int32_t grouping_size_2 = dec->getSecondaryGroupingSize();
+                    if(grouping_size_2 > 0 && grouping_size_2 != grouping_size) {
+                        grouping_ += static_cast<char>(grouping_size_2);
+                    }
+                }
+            }
+        }
+
+    protected:
+        string_type do_decimal_point_str() const BOOST_OVERRIDE { return decimal_point_; }
+        string_type do_thousands_sep_str() const BOOST_OVERRIDE { return thousands_sep_; }
+        std::string do_grouping() const BOOST_OVERRIDE { return grouping_; }
+
+    private:
+        string_type decimal_point_;
+        string_type thousands_sep_;
+        std::string grouping_;
+    };
+
+    template<typename CharType>
     std::locale install_formatting_facets(const std::locale& in, const cdata& cd)
     {
         std::locale tmp = std::locale(in, new num_format<CharType>(cd));
         if(!std::has_facet<formatters_cache>(in))
             tmp = std::locale(tmp, new formatters_cache(cd.locale));
+        tmp = std::locale(tmp, new icu_numpunct<CharType>(cd));
         return tmp;
     }
 

--- a/src/boost/locale/posix/numeric.cpp
+++ b/src/boost/locale/posix/numeric.cpp
@@ -10,6 +10,7 @@
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
+#include <boost/locale/numpunct.hpp>
 #include <boost/predef/os.h>
 #include <algorithm>
 #include <cctype>
@@ -341,38 +342,24 @@ namespace boost { namespace locale { namespace impl_posix {
     };
 
     template<typename CharType>
-    class num_punct_posix : public std::numpunct<CharType> {
+    class num_punct_posix : public numpunct<CharType> {
     public:
         typedef std::basic_string<CharType> string_type;
-        num_punct_posix(locale_t lc, size_t refs = 0) : std::numpunct<CharType>(refs)
+        num_punct_posix(locale_t lc, size_t refs = 0) : numpunct<CharType>(refs)
         {
             basic_numpunct np(lc);
             to_str(np.thousands_sep, thousands_sep_, lc);
             to_str(np.decimal_point, decimal_point_, lc);
             grouping_ = np.grouping;
-            if(thousands_sep_.size() > 1)
-                grouping_ = std::string();
-            if(decimal_point_.size() > 1)
-                decimal_point_ = CharType('.');
         }
         void to_str(std::string& s1, std::string& s2, locale_t /*lc*/) { s2.swap(s1); }
         void to_str(std::string& s1, std::wstring& s2, locale_t lc)
         {
             s2 = conv::to_utf<wchar_t>(s1, nl_langinfo_l(CODESET, lc));
         }
-        CharType do_decimal_point() const override { return *decimal_point_.c_str(); }
-        CharType do_thousands_sep() const override { return *thousands_sep_.c_str(); }
+        string_type do_decimal_point_str() const override { return decimal_point_; }
+        string_type do_thousands_sep_str() const override { return thousands_sep_; }
         std::string do_grouping() const override { return grouping_; }
-        string_type do_truename() const override
-        {
-            static const char t[] = "true";
-            return string_type(t, t + sizeof(t) - 1);
-        }
-        string_type do_falsename() const override
-        {
-            static const char t[] = "false";
-            return string_type(t, t + sizeof(t) - 1);
-        }
 
     private:
         string_type decimal_point_;

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -130,27 +130,25 @@ namespace boost { namespace locale { namespace impl_win {
     template<typename CharType>
     std::locale create_formatting_impl(const std::locale& in, const winlocale& lc)
     {
+        std::locale tmp(in, new num_format<CharType>(lc));
         if(lc.is_c()) {
-            std::locale tmp(in, new numpunct<CharType>());
+            tmp = std::locale(tmp, new numpunct<CharType>());
             tmp = std::locale(tmp, new std::time_put_byname<CharType>("C"));
-            tmp = std::locale(tmp, new num_format<CharType>(lc));
-            return tmp;
         } else {
-            std::locale tmp(in, new num_punct_win<CharType>(lc));
+            tmp = std::locale(tmp, new num_punct_win<CharType>(lc));
             tmp = std::locale(tmp, new time_put_win<CharType>(lc));
-            tmp = std::locale(tmp, new num_format<CharType>(lc));
-            return tmp;
         }
+        return tmp;
     }
 
     template<typename CharType>
-    std::locale create_parsing_impl(std::locale tmp, const winlocale& lc)
+    std::locale create_parsing_impl(const std::locale& in, const winlocale& lc)
     {
+        std::locale tmp(in, new util::base_num_parse<CharType>());
         if(lc.is_c())
             tmp = std::locale(tmp, new numpunct<CharType>());
         else
             tmp = std::locale(tmp, new num_punct_win<CharType>(lc));
-        tmp = std::locale(tmp, new util::base_num_parse<CharType>());
         return tmp;
     }
 

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -8,6 +8,7 @@
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
+#include <boost/locale/numpunct.hpp>
 #include "boost/locale/win32/all_generator.hpp"
 #include "boost/locale/win32/api.hpp"
 #include <algorithm>
@@ -96,10 +97,10 @@ namespace boost { namespace locale { namespace impl_win {
     };
 
     template<typename CharType>
-    class num_punct_win : public std::numpunct<CharType> {
+    class num_punct_win : public numpunct<CharType> {
     public:
         typedef std::basic_string<CharType> string_type;
-        num_punct_win(const winlocale& lc, size_t refs = 0) : std::numpunct<CharType>(refs)
+        num_punct_win(const winlocale& lc, size_t refs = 0) : numpunct<CharType>(refs)
         {
             numeric_info np = wcsnumformat_l(lc);
 
@@ -111,28 +112,14 @@ namespace boost { namespace locale { namespace impl_win {
             to_str(np.thousands_sep, thousands_sep_);
             to_str(np.decimal_point, decimal_point_);
             grouping_ = np.grouping;
-            if(thousands_sep_.size() > 1)
-                grouping_ = std::string();
-            if(decimal_point_.size() > 1)
-                decimal_point_ = CharType('.');
         }
 
         void to_str(std::wstring& s1, std::wstring& s2) { s2.swap(s1); }
 
         void to_str(std::wstring& s1, std::string& s2) { s2 = conv::utf_to_utf<char>(s1); }
-        CharType do_decimal_point() const override { return *decimal_point_.c_str(); }
-        CharType do_thousands_sep() const override { return *thousands_sep_.c_str(); }
+        string_type do_decimal_point_str() const BOOST_OVERRIDE { return decimal_point_; }
+        string_type do_thousands_sep_str() const BOOST_OVERRIDE { return thousands_sep_; }
         std::string do_grouping() const override { return grouping_; }
-        string_type do_truename() const override
-        {
-            static const char t[] = "true";
-            return string_type(t, t + sizeof(t) - 1);
-        }
-        string_type do_falsename() const override
-        {
-            static const char t[] = "false";
-            return string_type(t, t + sizeof(t) - 1);
-        }
 
     private:
         string_type decimal_point_;
@@ -144,7 +131,7 @@ namespace boost { namespace locale { namespace impl_win {
     std::locale create_formatting_impl(const std::locale& in, const winlocale& lc)
     {
         if(lc.is_c()) {
-            std::locale tmp(in, new std::numpunct_byname<CharType>("C"));
+            std::locale tmp(in, new numpunct<CharType>());
             tmp = std::locale(tmp, new std::time_put_byname<CharType>("C"));
             tmp = std::locale(tmp, new num_format<CharType>(lc));
             return tmp;
@@ -157,14 +144,12 @@ namespace boost { namespace locale { namespace impl_win {
     }
 
     template<typename CharType>
-    std::locale create_parsing_impl(const std::locale& in, const winlocale& lc)
+    std::locale create_parsing_impl(std::locale tmp, const winlocale& lc)
     {
-        std::numpunct<CharType>* np = 0;
         if(lc.is_c())
-            np = new std::numpunct_byname<CharType>("C");
+            tmp = std::locale(tmp, new numpunct<CharType>());
         else
-            np = new num_punct_win<CharType>(lc);
-        std::locale tmp(in, np);
+            tmp = std::locale(tmp, new num_punct_win<CharType>(lc));
         tmp = std::locale(tmp, new util::base_num_parse<CharType>());
         return tmp;
     }

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -117,8 +117,8 @@ namespace boost { namespace locale { namespace impl_win {
         void to_str(std::wstring& s1, std::wstring& s2) { s2.swap(s1); }
 
         void to_str(std::wstring& s1, std::string& s2) { s2 = conv::utf_to_utf<char>(s1); }
-        string_type do_decimal_point_str() const BOOST_OVERRIDE { return decimal_point_; }
-        string_type do_thousands_sep_str() const BOOST_OVERRIDE { return thousands_sep_; }
+        string_type do_decimal_point_str() const override { return decimal_point_; }
+        string_type do_thousands_sep_str() const override { return thousands_sep_; }
         std::string do_grouping() const override { return grouping_; }
 
     private:


### PR DESCRIPTION
Rebase of #65 onto develop with current changes incorporated. Hence closes #65

Contains the original commit(s) from @salvoilmiosi of #65 squashed and rebased onto develop to fix the conflicts.   
On top some refactoring and documentation additions to suit current state of the library.

Will also contain tests.

Design:
- provide `boost::locale::numpunct` for all backends
- add `decimal_point_str` & `thousands_sep_str` to provide possibly encoded variants of the decimal and thousand separators
-  `decimal_point` & `thousands_sep` return best-effort single-chars, by default falling back to the "C" locale
- Tests should ensure that a Boost.Locale agnostic library (i.e. reading `facet.thousands_sep()` & `facet.decimal_point()` and doing "regular" streaming using `std::locale`) get the expected results.