### PR TITLE
Reconcile `utf8_support` handling in std backend

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,6 +61,8 @@ environment:
       B2_CXXFLAGS: -permissive-
       B2_CXXSTD: 2a
       B2_TOOLSET: msvc-14.1
+      # The VS2017 image has some issues which we workaround, so collect coverage for that.
+      COVERAGE: true
 
     - FLAVOR: Visual Studio 2019
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,7 @@ jobs:
           gen_locale he_IL.UTF-8
           gen_locale ja_JP.UTF-8
           gen_locale ru_RU.UTF-8
+          gen_locale sv_SE.UTF-8
           gen_locale tr_TR.UTF-8
           # ISO locales used by some tests
           gen_locale en_US.iso88591

--- a/src/boost/locale/std/all_generator.hpp
+++ b/src/boost/locale/std/all_generator.hpp
@@ -12,7 +12,7 @@
 #include <string>
 
 namespace boost { namespace locale { namespace impl_std {
-    enum class utf8_support { none, native, native_with_wide, from_wide };
+    enum class utf8_support { none, native_with_wide, from_wide };
 
     std::locale create_convert(const std::locale& in,
                                const std::string& locale_name,

--- a/src/boost/locale/std/all_generator.hpp
+++ b/src/boost/locale/std/all_generator.hpp
@@ -12,32 +12,30 @@
 #include <string>
 
 namespace boost { namespace locale { namespace impl_std {
-    enum class utf8_support { none, native_with_wide, from_wide };
+    /// UTF-8 support of the standard library for the requested locale
+    enum class utf8_support {
+        /// No UTF-8 requested or required (e.g. other narrow encoding)
+        none,
+        /// UTF-8 encoding supported by the std-locale
+        native,
+        /// UTF-8 encoding has to be emulated using wchar_t
+        from_wide
+    };
 
-    std::locale create_convert(const std::locale& in,
-                               const std::string& locale_name,
-                               char_facet_t type,
-                               utf8_support utf = utf8_support::none);
+    std::locale
+    create_convert(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf);
 
-    std::locale create_collate(const std::locale& in,
-                               const std::string& locale_name,
-                               char_facet_t type,
-                               utf8_support utf = utf8_support::none);
+    std::locale
+    create_collate(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf);
 
-    std::locale create_formatting(const std::locale& in,
-                                  const std::string& locale_name,
-                                  char_facet_t type,
-                                  utf8_support utf = utf8_support::none);
+    std::locale
+    create_formatting(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf);
 
-    std::locale create_parsing(const std::locale& in,
-                               const std::string& locale_name,
-                               char_facet_t type,
-                               utf8_support utf = utf8_support::none);
+    std::locale
+    create_parsing(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf);
 
-    std::locale create_codecvt(const std::locale& in,
-                               const std::string& locale_name,
-                               char_facet_t type,
-                               utf8_support utf = utf8_support::none);
+    std::locale
+    create_codecvt(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf);
 
 }}} // namespace boost::locale::impl_std
 

--- a/src/boost/locale/std/codecvt.cpp
+++ b/src/boost/locale/std/codecvt.cpp
@@ -18,9 +18,16 @@ namespace boost { namespace locale { namespace impl_std {
     std::locale
     create_codecvt(const std::locale& in, const std::string& locale_name, char_facet_t type, utf8_support utf)
     {
+#if defined(BOOST_WINDOWS)
+        // This isn't fully correct:
+        // It will treat the 2-Byte wchar_t as UTF-16 encoded while it may be UCS-2
+        // std::basic_filebuf explicitely disallows using suche multi-byte codecvts
+        // but it works in practice so far, so use it instead of failing for codepoints above U+FFFF
+        if(utf != utf8_support::none)
+            return util::create_utf8_codecvt(in, type);
+#endif
         if(utf == utf8_support::from_wide)
             return util::create_utf8_codecvt(in, type);
-
         switch(type) {
             case char_facet_t::nochar: break;
             case char_facet_t::char_f: return codecvt_bychar<char>(in, locale_name);

--- a/src/boost/locale/std/converter.cpp
+++ b/src/boost/locale/std/converter.cpp
@@ -90,14 +90,14 @@ namespace boost { namespace locale { namespace impl_std {
     {
         switch(type) {
             case char_facet_t::nochar: break;
-            case char_facet_t::char_f: {
-                if(utf == utf8_support::native_with_wide || utf == utf8_support::from_wide) {
+            case char_facet_t::char_f:
+                if(utf != utf8_support::none) {
                     std::locale base(std::locale::classic(), new std::ctype_byname<wchar_t>(locale_name));
                     return std::locale(in, new utf8_converter(base));
+                } else {
+                    std::locale base(std::locale::classic(), new std::ctype_byname<char>(locale_name));
+                    return std::locale(in, new std_converter<char>(base));
                 }
-                std::locale base(std::locale::classic(), new std::ctype_byname<char>(locale_name));
-                return std::locale(in, new std_converter<char>(base));
-            }
             case char_facet_t::wchar_f: {
                 std::locale base(std::locale::classic(), new std::ctype_byname<wchar_t>(locale_name));
                 return std::locale(in, new std_converter<wchar_t>(base));

--- a/src/boost/locale/std/numeric.cpp
+++ b/src/boost/locale/std/numeric.cpp
@@ -262,15 +262,6 @@ namespace boost { namespace locale { namespace impl_std {
                         tmp = std::locale(tmp, new utf8_moneypunct_from_wide<false>(base));
                         return std::locale(tmp, new util::base_num_format<char>());
                     }
-                    case utf8_support::native: {
-                        std::locale base = std::locale(locale_name);
-
-                        std::locale tmp = std::locale(in, new time_put_from_base<char>(base));
-                        tmp = std::locale(tmp, new utf8_numpunct(locale_name));
-                        tmp = std::locale(tmp, new utf8_moneypunct<true>(locale_name));
-                        tmp = std::locale(tmp, new utf8_moneypunct<false>(locale_name));
-                        return std::locale(tmp, new util::base_num_format<char>());
-                    }
                     case utf8_support::native_with_wide: {
                         std::locale base = std::locale(locale_name);
 
@@ -326,12 +317,6 @@ namespace boost { namespace locale { namespace impl_std {
                         std::locale tmp = std::locale(in, new utf8_numpunct_from_wide(base));
                         tmp = std::locale(tmp, new utf8_moneypunct_from_wide<true>(base));
                         tmp = std::locale(tmp, new utf8_moneypunct_from_wide<false>(base));
-                        return std::locale(tmp, new util::base_num_parse<char>());
-                    }
-                    case utf8_support::native: {
-                        std::locale tmp = std::locale(in, new utf8_numpunct(locale_name));
-                        tmp = std::locale(tmp, new utf8_moneypunct<true>(locale_name));
-                        tmp = std::locale(tmp, new utf8_moneypunct<false>(locale_name));
                         return std::locale(tmp, new util::base_num_parse<char>());
                     }
                     case utf8_support::native_with_wide: {

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -137,14 +137,7 @@ namespace boost { namespace locale { namespace impl_std {
             } else {
                 if(loadable(lid)) {
                     name_ = lid;
-                    utf_mode_ = utf8_support::native_with_wide;
-#if defined(BOOST_WINDOWS)
-                    // This isn't fully correct:
-                    // It will treat the 2-Byte wchar_t as UTF-16 encoded while it may be UCS-2
-                    // std::basic_filebuf explicitely disallows using suche multi-byte codecvts
-                    // but it works in practice so far, so use it instead of failing for codepoints above U+FFFF
-                    utf_mode_ = utf8_support::from_wide;
-#endif
+                    utf_mode_ = utf8_support::native;
                 } else {
                     std::vector<std::string> alt_names;
                     if(l_win)

--- a/test/test_std_collate.cpp
+++ b/test/test_std_collate.cpp
@@ -62,13 +62,19 @@ void test_char()
 #if defined(_LIBCPP_VERSION) && (defined(__APPLE__) || defined(__FreeBSD__))
     std::cout << "- Collation is broken on this OS's standard C++ library, skipping\n";
 #else
-    for(const std::string name : {"en_US.UTF-8", "en_US.ISO8859-1"}) {
+    for(const std::string name : {"en_US.UTF-8", "sv_SE.UTF-8", "en_US.ISO8859-1"}) {
         const std::string std_name = get_std_name(name);
         if(!std_name.empty()) {
             std::cout << "- Testing " << std_name << std::endl;
             l = gen(std_name);
             test_one<CharType>(l, "a", "ç", -1);
             test_one<CharType>(l, "ç", "d", -1);
+            const auto& info = std::use_facet<boost::locale::info>(l);
+            if(info.utf8()) {
+                // In Swedish locale the collation/ordering of this is different than in English
+                // This makes this a nice test case that the correct collation is used.
+                test_one<CharType>(l, "ängel", "år", info.language() == "sv" ? 1 : -1);
+            }
         } else
             std::cout << "- " << name << " not supported, skipping" << std::endl;
     }


### PR DESCRIPTION
Document the meaning of the `utf8_support` enum and refactor/change usages to be consistent and logical.   
Add comments where required.

- Remove the unused `utf8_support::native` which is only checked for but never set
- Rename `native_with_wide` to `native` after that is now free for use. This makes the meaning clear as there is no `native_without_wide`.
- Move the Windows-codecvt workaround directly where it matters/is used to not abuse `utf8_support` for this which was confusing

Closes #171 

@artyom-beilis Please do a quick check that I didn't miss anything or misunderstood something you wrote in #171