### PR TITLE
Make std backend fall back to classic locale instead of system locale

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -11,6 +11,7 @@
 - Unreleased
     - Breaking changes
         - Bitwise/binary operators (left/right shift, binary and/or/xor/not) are no longer supported in message catalog files matching GNU gettext behavior
+        - Std backend on Windows uses the classic locale instead of the system locale when the requested locale does not exist (now same as on other OSs)
     - Other improvements and fixes
         - Introduce converter classes as alternative to `to_utf`/`from_utf`/`between`
         - Fix UB on invalid index in format strings

--- a/include/boost/locale.hpp
+++ b/include/boost/locale.hpp
@@ -21,5 +21,6 @@
 #include <boost/locale/localization_backend.hpp>
 #include <boost/locale/message.hpp>
 #include <boost/locale/util.hpp>
+#include <boost/locale/util/locale_data.hpp>
 
 #endif

--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -73,7 +73,7 @@
 #    define BOOST_LOCALE_USE_WIN32_API 0
 #endif
 
-// To be used to supress false positives of UBSAN
+// To be used to suppress false positives of UBSAN
 #if defined(__clang__) && defined(__has_attribute)
 #    if __has_attribute(no_sanitize)
 #        define BOOST_LOCALE_NO_SANITIZE(what) __attribute__((no_sanitize(what)))

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -13,7 +13,7 @@
 #include <iterator>
 #include <vector>
 
-#if defined(BOOST_WINDOWS)
+#if BOOST_LOCALE_USE_WIN32_API
 #    ifndef NOMINMAX
 #        define NOMINMAX
 #    endif
@@ -26,7 +26,7 @@
 #include "boost/locale/util/numeric.hpp"
 
 namespace {
-#if defined(BOOST_WINDOWS)
+#if BOOST_LOCALE_USE_WIN32_API
 std::pair<std::string, std::string> to_windows_name(const std::string& l)
 {
     std::pair<std::string, std::string> res("C", "0");
@@ -105,7 +105,7 @@ namespace boost { namespace locale { namespace impl_std {
             data_.parse(lid);
             name_ = "C";
 
-#if defined(BOOST_WINDOWS)
+#if BOOST_LOCALE_USE_WIN32_API
             const std::pair<std::string, std::string> wl_inf = to_windows_name(lid);
             const std::string& win_name = wl_inf.first;
             const auto& win_codepage = wl_inf.second;
@@ -114,7 +114,7 @@ namespace boost { namespace locale { namespace impl_std {
             if(!data_.is_utf8()) {
                 if(loadable(lid))
                     name_ = lid;
-#if defined(BOOST_WINDOWS)
+#if BOOST_LOCALE_USE_WIN32_API
                 else if(loadable(win_name)) {
                     if(util::are_encodings_equal(win_codepage, data_.encoding()))
                         name_ = win_name;
@@ -140,7 +140,7 @@ namespace boost { namespace locale { namespace impl_std {
                     utf_mode_ = utf8_support::from_wide;
 #endif
                 }
-#if defined(BOOST_WINDOWS)
+#if BOOST_LOCALE_USE_WIN32_API
                 else if(loadable(win_name))
                 {
                     name_ = win_name;

--- a/test/boostLocale/test/tools.hpp
+++ b/test/boostLocale/test/tools.hpp
@@ -173,8 +173,8 @@ std::string get_std_name(const std::string& name, std::string* real_name = nullp
         return name;
     }
 
-#ifdef BOOST_WINDOWS
-    bool utf8 = name.find("UTF-8") != std::string::npos;
+#if BOOST_LOCALE_USE_WIN32_API
+    const bool utf8 = name.find("UTF-8") != std::string::npos;
 
     if(name == "en_US.UTF-8" || name == "en_US.ISO8859-1") {
         if(has_std_locale("English_United States.1252")) {


### PR DESCRIPTION
Partial fix of https://github.com/boostorg/locale/issues/172

Also enable the same fallback-handling for Cygwin