### PR TITLE
Ensure that UTF-8 encoding is used when requested in std backend

### DIFF
--- a/include/boost/locale/util/locale_data.hpp
+++ b/include/boost/locale/util/locale_data.hpp
@@ -40,9 +40,9 @@ namespace boost { namespace locale { namespace util {
         const std::string& country() const { return country_; }
         /// Return encoding/codeset, e.g. ISO8859-1 or UTF-8
         const std::string& encoding() const { return encoding_; }
-        /// Set encoding, will be made uppercase as-if it was parsed
+        /// Set encoding, will be made uppercase by default as-if it was parsed
         /// Returns \c *this for chaining
-        locale_data& encoding(std::string new_encoding);
+        locale_data& encoding(std::string new_encoding, bool uppercase = true);
         /// Return variant/modifier, e.g. euro or stroke
         const std::string& variant() const { return variant_; }
         /// Return iff the encoding is UTF-8

--- a/include/boost/locale/util/locale_data.hpp
+++ b/include/boost/locale/util/locale_data.hpp
@@ -40,6 +40,9 @@ namespace boost { namespace locale { namespace util {
         const std::string& country() const { return country_; }
         /// Return encoding/codeset, e.g. ISO8859-1 or UTF-8
         const std::string& encoding() const { return encoding_; }
+        /// Set encoding, will be made uppercase as-if it was parsed
+        /// Returns \c *this for chaining
+        locale_data& encoding(std::string new_encoding);
         /// Return variant/modifier, e.g. euro or stroke
         const std::string& variant() const { return variant_; }
         /// Return iff the encoding is UTF-8

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -108,13 +108,13 @@ namespace boost { namespace locale { namespace impl_std {
             }
             in_use_id_ = lid;
             data_.parse(lid);
-            name_ = "C";
 
 #if BOOST_LOCALE_USE_WIN32_API
             const auto l_win = to_windows_name(lid);
 #endif
 
             if(!data_.is_utf8()) {
+                utf_mode_ = utf8_support::none;
                 if(loadable(lid))
                     name_ = lid;
 #if BOOST_LOCALE_USE_WIN32_API
@@ -127,11 +127,13 @@ namespace boost { namespace locale { namespace impl_std {
                            && codepage_int == util::encoding_to_windows_codepage(data_.encoding()))
                         {
                             name_ = l_win.name;
-                        }
+                        } else
+                            name_ = "C";
                     }
                 }
 #endif
-                utf_mode_ = utf8_support::none;
+                else
+                    name_ = "C";
             } else {
                 if(loadable(lid)) {
                     name_ = lid;
@@ -154,16 +156,8 @@ namespace boost { namespace locale { namespace impl_std {
                 else
                 {
                     const std::string non_utf8 = util::locale_data(data_).encoding("").to_string();
-                    if(loadable(non_utf8))) {
-                        name_ = non_utf8;
-                        utf_mode_ = utf8_support::from_wide;
-                    } else {
-                        throw std::runtime_error("Can't load UTF-8 locale " + lid
-    #if BOOST_LOCALE_USE_WIN32_API
-                                                + " or " + l_win.name
-    #endif
-                        );
-                    }
+                    name_ = loadable(non_utf8) ? non_utf8 : "C";
+                    utf_mode_ = utf8_support::from_wide;
                 }
             }
         }

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -28,8 +28,8 @@
 namespace {
 #if BOOST_LOCALE_USE_WIN32_API
 struct windows_name {
-    windows_name() : name("C"), codepage("0") {}
     std::string name, codepage;
+    explicit operator bool() const { return !name.empty() && !codepage.empty(); }
 };
 
 windows_name to_windows_name(const std::string& l)
@@ -118,7 +118,7 @@ namespace boost { namespace locale { namespace impl_std {
                 if(loadable(lid))
                     name_ = lid;
 #if BOOST_LOCALE_USE_WIN32_API
-                else if(loadable(l_win.name)) {
+                else if(l_win && loadable(l_win.name)) {
                     if(util::are_encodings_equal(l_win.codepage, data_.encoding()))
                         name_ = l_win.name;
                     else {
@@ -147,7 +147,7 @@ namespace boost { namespace locale { namespace impl_std {
 #endif
                 }
 #if BOOST_LOCALE_USE_WIN32_API
-                else if(loadable(l_win.name))
+                else if(l_win && loadable(l_win.name))
                 {
                     name_ = l_win.name;
                     utf_mode_ = utf8_support::from_wide;

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -152,11 +152,19 @@ namespace boost { namespace locale { namespace impl_std {
                 }
 #endif
                 else
-                    throw std::runtime_error("Can't load UTF-8 locale " + lid
-#if BOOST_LOCALE_USE_WIN32_API
-                                             + " or " + l_win.name
-#endif
-                    );
+                {
+                    const std::string non_utf8 = util::locale_data(data_).encoding("").to_string();
+                    if(loadable(non_utf8))) {
+                        name_ = non_utf8;
+                        utf_mode_ = utf8_support::from_wide;
+                    } else {
+                        throw std::runtime_error("Can't load UTF-8 locale " + lid
+    #if BOOST_LOCALE_USE_WIN32_API
+                                                + " or " + l_win.name
+    #endif
+                        );
+                    }
+                }
             }
         }
 

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -152,7 +152,11 @@ namespace boost { namespace locale { namespace impl_std {
                 }
 #endif
                 else
-                    utf_mode_ = utf8_support::none;
+                    throw std::runtime_error("Can't load UTF-8 locale " + lid
+#if BOOST_LOCALE_USE_WIN32_API
+                                             + " or " + l_win.name
+#endif
+                    );
             }
         }
 

--- a/src/boost/locale/util/encoding.cpp
+++ b/src/boost/locale/util/encoding.cpp
@@ -18,27 +18,17 @@
 #include <cstring>
 
 namespace boost { namespace locale { namespace util {
-    static std::string do_normalize_encoding(const char* encoding, const size_t len)
+    std::string normalize_encoding(const string_view encoding)
     {
         std::string result;
-        result.reserve(len);
-        for(char c = *encoding; c != 0; c = *(++encoding)) {
+        result.reserve(encoding.length());
+        for(char c : encoding) {
             if(is_lower_ascii(c) || is_numeric_ascii(c))
                 result += c;
             else if(is_upper_ascii(c))
                 result += char(c - 'A' + 'a');
         }
         return result;
-    }
-
-    std::string normalize_encoding(const std::string& encoding)
-    {
-        return do_normalize_encoding(encoding.c_str(), encoding.size());
-    }
-
-    std::string normalize_encoding(const char* encoding)
-    {
-        return do_normalize_encoding(encoding, std::strlen(encoding));
     }
 
 #if BOOST_LOCALE_USE_WIN32_API
@@ -61,12 +51,7 @@ namespace boost { namespace locale { namespace util {
         return -1;
     }
 
-    int encoding_to_windows_codepage(const char* encoding)
-    {
-        return normalized_encoding_to_windows_codepage(normalize_encoding(encoding));
-    }
-
-    int encoding_to_windows_codepage(const std::string& encoding)
+    int encoding_to_windows_codepage(const string_view encoding)
     {
         return normalized_encoding_to_windows_codepage(normalize_encoding(encoding));
     }

--- a/src/boost/locale/util/encoding.hpp
+++ b/src/boost/locale/util/encoding.hpp
@@ -9,6 +9,7 @@
 #define BOOST_LOCALE_UTIL_ENCODING_HPP
 
 #include <boost/locale/config.hpp>
+#include <boost/utility/string_view.hpp>
 #include <cstdint>
 #include <string>
 
@@ -37,8 +38,7 @@ namespace boost { namespace locale { namespace util {
     }
 
     /// Make encoding lowercase and remove all non-alphanumeric characters
-    BOOST_LOCALE_DECL std::string normalize_encoding(const std::string& encoding);
-    BOOST_LOCALE_DECL std::string normalize_encoding(const char* encoding);
+    BOOST_LOCALE_DECL std::string normalize_encoding(string_view encoding);
     /// True if the normalized encodings are equal
     inline bool are_encodings_equal(const std::string& l, const std::string& r)
     {
@@ -46,8 +46,13 @@ namespace boost { namespace locale { namespace util {
     }
 
 #if BOOST_LOCALE_USE_WIN32_API
-    int encoding_to_windows_codepage(const char* encoding);
-    int encoding_to_windows_codepage(const std::string& encoding);
+    int encoding_to_windows_codepage(string_view encoding);
+#else
+    // Requires WinAPI -> Dummy returning invalid
+    inline int encoding_to_windows_codepage(string_view) // LCOV_EXCL_LINE
+    {
+        return -1; // LCOV_EXCL_LINE
+    }
 #endif
 
 }}} // namespace boost::locale::util

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -124,15 +124,7 @@ namespace boost { namespace locale { namespace util {
         std::string tmp = input.substr(0, end);
         if(tmp.empty())
             return false;
-        // No assumptions, but uppercase
-        for(char& c : tmp) {
-            if(util::is_lower_ascii(c))
-                c += 'A' - 'a';
-        }
-        encoding_ = tmp;
-
-        utf8_ = util::normalize_encoding(encoding_) == "utf8";
-
+        encoding(std::move(tmp));
         if(end >= input.size())
             return true;
         else {
@@ -154,6 +146,18 @@ namespace boost { namespace locale { namespace util {
                 c += 'a' - 'A';
         }
         return true;
+    }
+
+    locale_data& locale_data::encoding(std::string new_encoding)
+    {
+        // No assumptions, but uppercase
+        for(char& c : new_encoding) {
+            if(util::is_lower_ascii(c))
+                c += 'A' - 'a';
+        }
+        encoding_ = std::move(new_encoding);
+        utf8_ = util::normalize_encoding(encoding_) == "utf8";
+        return *this;
     }
 
 }}} // namespace boost::locale::util

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -124,6 +124,7 @@ namespace boost { namespace locale { namespace util {
         std::string tmp = input.substr(0, end);
         if(tmp.empty())
             return false;
+        // No assumptions, but uppercase
         encoding(std::move(tmp));
         if(end >= input.size())
             return true;
@@ -148,12 +149,13 @@ namespace boost { namespace locale { namespace util {
         return true;
     }
 
-    locale_data& locale_data::encoding(std::string new_encoding)
+    locale_data& locale_data::encoding(std::string new_encoding, const bool uppercase)
     {
-        // No assumptions, but uppercase
-        for(char& c : new_encoding) {
-            if(util::is_lower_ascii(c))
-                c += 'A' - 'a';
+        if(uppercase) {
+            for(char& c : new_encoding) {
+                if(util::is_lower_ascii(c))
+                    c += 'A' - 'a';
+            }
         }
         encoding_ = std::move(new_encoding);
         utf8_ = util::normalize_encoding(encoding_) == "utf8";


### PR DESCRIPTION
When a locale doesn't exist on the system don't simply fall back to the classic locale but try to preserve the UTF-8 encoding if requested.

For the std backend this means trying e.g. `"C.UTF-8"` and using `utf8_support::from_wide` as a best-effort

Related to #172 especially as the `to_windows_name` function can now report failure.