### PR TITLE
GHA-CI: Show library config on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,12 +361,26 @@ jobs:
         shell: pwsh
         run: 'Add-Content $Env:BOOST_ROOT/project-config.jam "path-constant ICU_PATH : `"$($pwd.Path)\ICU`" ;"'
 
-      - name: Run tests
+      - name: Run tests (without coverage)
         if: '!matrix.coverage'
         run: |
           set B2_FLAGS=boost.locale.icu=off boost.locale.iconv=off
           ci\build.bat
-          set B2_FLAGS=-a
+          rmdir /s /q bin.v2
+          set B2_FLAGS=
+          set B2_TARGETS=libs/%SELF%/test//show_config --verbose-test
+          ci\build.bat
+          set B2_TARGETS=
+          ci\build.bat
+        env:
+          B2_TOOLSET: ${{matrix.toolset}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+      - name: Show config before collection coverage
+        if: matrix.coverage
+        run: |
+          set B2_TARGETS=libs/%SELF%/test//show_config --verbose-test
           ci\build.bat
         env:
           B2_TOOLSET: ${{matrix.toolset}}

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -109,7 +109,7 @@ void test_main(int /*argc*/, char** /*argv*/)
 #else
         std::cout << "- C++ locale: " << loc.name() << std::endl;
 #endif
-    } catch(const std::exception&) {
+    } catch(const std::exception&) {                     // LCOV_EXCL_LINE
         std::cout << "- C++ locale: is not supported\n"; // LCOV_EXCL_LINE
     }
 


### PR DESCRIPTION
For debugging especially the available locales are important. So run `show_config` with `--verbose-test` also on Windows similar to the POSIX jobs.