### PR TITLE
Improve tests

### DIFF
--- a/include/boost/locale/generator.hpp
+++ b/include/boost/locale/generator.hpp
@@ -182,12 +182,6 @@ namespace locale {
         /// Shortcut to generate(id)
         std::locale operator()(const std::string& id) const { return generate(id); }
 
-        /// Set backend specific option
-        void set_option(const std::string& name, const std::string& value);
-
-        /// Clear backend specific options
-        void clear_options();
-
     private:
         void set_all_options(localization_backend& backend, const std::string& id) const;
 

--- a/include/boost/locale/localization_backend.hpp
+++ b/include/boost/locale/localization_backend.hpp
@@ -78,19 +78,18 @@ namespace boost { namespace locale {
         /// Destructor
         ~localization_backend_manager();
 
-        /// Create new localization backend according to current settings.
-        std::unique_ptr<localization_backend> get() const;
+        /// Create new localization backend according to current settings. Ownership is passed to caller
+        std::unique_ptr<localization_backend> create() const;
 
-        BOOST_DEPRECATED("This function is deprecated, use 'get()' instead")
-        std::unique_ptr<localization_backend> get_unique_ptr() const { return get(); }
+        BOOST_DEPRECATED("This function is deprecated, use 'create()' instead")
+        std::unique_ptr<localization_backend> get() const { return create(); }
+        BOOST_DEPRECATED("This function is deprecated, use 'create()' instead")
+        std::unique_ptr<localization_backend> get_unique_ptr() const { return create(); }
 
         /// Add new backend to the manager, each backend should be uniquely defined by its name.
         ///
         /// This library provides: "icu", "posix", "winapi" and "std" backends.
         void add_backend(const std::string& name, std::unique_ptr<localization_backend> backend);
-
-        /// Create new localization backend according to current settings. Ownership is passed to caller
-        localization_backend* create() const;
 
         /// Add new backend to the manager, each backend should be uniquely defined by its name.
         /// ownership on backend is transfered

--- a/src/boost/locale/shared/generator.cpp
+++ b/src/boost/locale/shared/generator.cpp
@@ -106,7 +106,7 @@ namespace boost { namespace locale {
             if(p != d->cached.end())
                 return p->second;
         }
-        hold_ptr<localization_backend> backend(d->backend_manager.create());
+        auto backend = d->backend_manager.create();
         set_all_options(*backend, id);
 
         std::locale result = base;

--- a/src/boost/locale/shared/generator.cpp
+++ b/src/boost/locale/shared/generator.cpp
@@ -156,8 +156,7 @@ namespace boost { namespace locale {
     void generator::set_all_options(localization_backend& backend, const std::string& id) const
     {
         backend.set_option("locale", id);
-        if(d->use_ansi_encoding)
-            backend.set_option("use_ansi_encoding", "true");
+        backend.set_option("use_ansi_encoding", d->use_ansi_encoding ? "true" : "false");
         for(const std::string& domain : d->domains)
             backend.set_option("message_application", domain);
         for(const std::string& path : d->paths)

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -167,7 +167,7 @@ namespace boost { namespace locale {
     localization_backend_manager&
     localization_backend_manager::operator=(localization_backend_manager&&) noexcept = default;
 
-    std::unique_ptr<localization_backend> localization_backend_manager::get() const
+    std::unique_ptr<localization_backend> localization_backend_manager::create() const
     {
         return std::unique_ptr<localization_backend>(pimpl_->create());
     }
@@ -177,10 +177,6 @@ namespace boost { namespace locale {
         pimpl_->adopt_backend(name, backend.release());
     }
 
-    localization_backend* localization_backend_manager::create() const
-    {
-        return pimpl_->create();
-    }
     void localization_backend_manager::adopt_backend(const std::string& name, localization_backend* backend)
     {
         pimpl_->adopt_backend(name, backend);

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -159,7 +159,7 @@ void test_install_chartype(const std::string& backendName)
     for(const std::string localeName : {"C", "en_US.UTF-8"}) {
         std::cout << "--- Locale: " << localeName << std::endl;
         const std::locale origLocale = bl::generator{}(localeName);
-        const auto backend = bl::localization_backend_manager::global().get();
+        const auto backend = bl::localization_backend_manager::global().create();
         backend->set_option("locale", localeName);
         for(auto category = bl::per_character_facet_first; category <= bl::per_character_facet_last; ++category) {
             std::cout << "---- Testing category " << static_cast<unsigned>(category) << '\n';

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -80,7 +80,23 @@ void test_special_locales()
         backend.select(backendName);
         bl::localization_backend_manager::global(backend);
 
+        {
+            const auto utf8LocaleName = bl::util::get_system_locale(true);
+            const auto ansiLocaleName = bl::util::get_system_locale(false);
+            bl::generator g;
+            g.use_ansi_encoding(true);
+            std::locale l = g("");
+            TEST_EQ(std::use_facet<bl::info>(l).name(), ansiLocaleName);
+            g.use_ansi_encoding(false);
+            l = g("");
+            TEST_EQ(std::use_facet<bl::info>(l).name(), utf8LocaleName);
+            g.use_ansi_encoding(true);
+            l = g("");
+            TEST_EQ(std::use_facet<bl::info>(l).name(), ansiLocaleName);
+        }
+
         bl::generator g;
+
         namespace as = bl::as;
         constexpr time_t datetime = 60 * 60 * 24 * (31 + 4) // Feb 5th
                                     + (15 * 60 + 42) * 60;  // 15:42


### PR DESCRIPTION
Add test for the char-type argument of `backend::install`: Make sure it is used when it should and ignored when it shouldn't.

Add a test for `use_ansi_encoding` (might not set/reset correctly)

Cleanup: Remove `localization_backend_manager::get` and unimplemented generator methods.