### PR TITLE
Fix ICU boundary detection

### DIFF
--- a/src/boost/locale/icu/formatter.cpp
+++ b/src/boost/locale/icu/formatter.cpp
@@ -15,6 +15,10 @@
 #include "boost/locale/util/foreach_char.hpp"
 #include <limits>
 #include <memory>
+#ifdef BOOST_MSVC
+#    pragma warning(push)
+#    pragma warning(disable : 4251) // "identifier" : class "type" needs to have dll-interface...
+#endif
 #include <unicode/datefmt.h>
 #include <unicode/decimfmt.h>
 #include <unicode/numfmt.h>
@@ -22,6 +26,7 @@
 #include <unicode/smpdtfmt.h>
 
 #ifdef BOOST_MSVC
+#    pragma warning(pop)
 #    pragma warning(disable : 4244) // lose data
 #endif
 

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2022-2023 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -9,6 +10,7 @@
 #include <boost/locale/utf8_codecvt.hpp>
 #include <boost/locale/util.hpp>
 #include <boost/locale/util/string.hpp>
+#include <boost/assert.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
@@ -186,14 +188,18 @@ namespace boost { namespace locale { namespace util {
         }
     } // namespace
 
-    bool check_is_simple_encoding(const std::string& encoding)
+    std::vector<std::string> get_simple_encodings()
+    {
+        return std::vector<std::string>(simple_encoding_table, std::end(simple_encoding_table));
+    }
+
+    bool is_simple_encoding(const std::string& encoding)
     {
         std::string norm = util::normalize_encoding(encoding);
-        return std::binary_search<const char**>(simple_encoding_table,
-                                                simple_encoding_table
-                                                  + sizeof(simple_encoding_table) / sizeof(const char*),
-                                                norm.c_str(),
-                                                compare_strings);
+        return std::binary_search(simple_encoding_table,
+                                  std::end(simple_encoding_table),
+                                  norm.c_str(),
+                                  compare_strings);
     }
 
     std::unique_ptr<base_converter> create_simple_converter(const std::string& encoding)
@@ -202,7 +208,7 @@ namespace boost { namespace locale { namespace util {
     }
     base_converter* create_simple_converter_new_ptr(const std::string& encoding)
     {
-        if(check_is_simple_encoding(encoding))
+        if(is_simple_encoding(encoding))
             return new simple_converter(encoding);
         return nullptr;
     }
@@ -298,7 +304,7 @@ namespace boost { namespace locale { namespace util {
 
     std::locale create_simple_codecvt(const std::locale& in, const std::string& encoding, char_facet_t type)
     {
-        if(!check_is_simple_encoding(encoding))
+        if(!is_simple_encoding(encoding))
             throw boost::locale::conv::invalid_charset_error("Invalid simple encoding " + encoding);
 
         switch(type) {

--- a/src/boost/locale/util/encoding.hpp
+++ b/src/boost/locale/util/encoding.hpp
@@ -12,6 +12,7 @@
 #include <boost/utility/string_view.hpp>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace boost { namespace locale { namespace util {
 
@@ -44,6 +45,8 @@ namespace boost { namespace locale { namespace util {
     {
         return normalize_encoding(l) == normalize_encoding(r);
     }
+
+    BOOST_LOCALE_DECL std::vector<std::string> get_simple_encodings();
 
 #if BOOST_LOCALE_USE_WIN32_API
     int encoding_to_windows_codepage(string_view encoding);

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -574,6 +574,7 @@ void test_between()
 }
 
 void test_utf_name();
+void test_simple_encodings();
 void test_win_codepages();
 
 void test_main(int /*argc*/, char** /*argv*/)
@@ -585,6 +586,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     TEST_THROWS(to<char>("€"), std::logic_error);
     // Sanity check internal details
     test_utf_name();
+    test_simple_encodings();
     test_win_codepages();
 
     test_latin1_conversions();
@@ -638,6 +640,23 @@ void test_utf_name()
 #endif
     TEST_EQ(boost::locale::util::utf_name<char16_t>(), std::string(isLittleEndian() ? "UTF-16LE" : "UTF-16BE"));
     TEST_EQ(boost::locale::util::utf_name<char32_t>(), std::string(isLittleEndian() ? "UTF-32LE" : "UTF-32BE"));
+}
+
+void test_simple_encodings()
+{
+    using namespace boost::locale::util;
+    const auto encodings = get_simple_encodings();
+    for(auto it = encodings.begin(), end = encodings.end(); it != end; ++it) {
+        TEST_EQ(normalize_encoding(*it), *it); // Must be normalized
+        const auto it2 = std::find(it + 1, end, *it);
+        TEST(it2 == end);
+        if(it2 != end)
+            std::cerr << "Duplicate entry: " << *it << '\n'; // LCOV_EXCL_LINE
+    }
+    const auto it = std::is_sorted_until(encodings.begin(), encodings.end());
+    TEST(it == encodings.end());
+    if(it != encodings.end())
+        std::cerr << "First wrongly sorted element: " << *it << '\n'; // LCOV_EXCL_LINE
 }
 
 void test_win_codepages()

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -429,23 +429,23 @@ void test_manip(std::string e_charset = "UTF-8")
     const std::string icu_long = get_ICU_datetime(as::time_long, a_datetime);
     const std::string icu_full = get_ICU_datetime(as::time_full, a_datetime);
 
-    TEST_PARSE(as::datetime >> as::gmt, "Feb 5, 1970, 3:33:13 PM", a_datetime);
+    TEST_PARSE(as::datetime >> as::gmt, "Feb 5, 1970 3:33:13 PM", a_datetime);
     TEST_FMT_PARSE_2(as::datetime, as::gmt, a_datetime, icu_def);
 
-    TEST_PARSE(as::datetime >> as::date_short >> as::time_short >> as::gmt, "2/5/70, 3:33 PM", a_date + a_time);
+    TEST_PARSE(as::datetime >> as::date_short >> as::time_short >> as::gmt, "2/5/70 3:33 PM", a_date + a_time);
     TEST_FMT_PARSE_4_2(as::datetime, as::date_short, as::time_short, as::gmt, a_datetime, icu_short, a_date + a_time);
 
-    TEST_PARSE(as::datetime >> as::date_medium >> as::time_medium >> as::gmt, "Feb 5, 1970, 3:33:13 PM", a_datetime);
+    TEST_PARSE(as::datetime >> as::date_medium >> as::time_medium >> as::gmt, "Feb 5, 1970 3:33:13 PM", a_datetime);
     TEST_FMT_PARSE_4(as::datetime, as::date_medium, as::time_medium, as::gmt, a_datetime, icu_medium);
 
     TEST_PARSE(as::datetime >> as::date_long >> as::time_long >> as::gmt,
-               "February 5, 1970 at 3:33:13 PM GMT",
+               "February 5, 1970 3:33:13 PM GMT",
                a_datetime);
     TEST_FMT_PARSE_4(as::datetime, as::date_long, as::time_long, as::gmt, a_datetime, icu_long);
 #if BOOST_LOCALE_ICU_VERSION_EXACT != 40800
     // ICU 4.8.0 has a bug which makes parsing the full time fail when anything follows the time zone
     TEST_PARSE(as::datetime >> as::date_full >> as::time_full >> as::gmt,
-               "Thursday, February 5, 1970 at 3:33:13 PM Greenwich Mean Time",
+               "Thursday, February 5, 1970 3:33:13 PM Greenwich Mean Time",
                a_datetime);
     TEST_FMT_PARSE_4(as::datetime, as::date_full, as::time_full, as::gmt, a_datetime, icu_full);
 #endif


### PR DESCRIPTION
With the fix for #44 in #154 a bug in older ICU versions (i.e. up to 54.x) is triggered by using the UTF-8 string  in-place via `UText*`

`test_boundary` detects that but such ICU versions are rare due to the age.

- Restrict the optimization to ICU >= 55.2 which has the bug fixed
- Use RAII for `UText*`
- Fix test_formatting failures in older ICU versions after #184
- Fix a possible warning on MSVC caused by ICU headers