### PR TITLE
Remove UBSAN workaround related to `charset_converter`

### DIFF
--- a/include/boost/locale/detail/encoding.hpp
+++ b/include/boost/locale/detail/encoding.hpp
@@ -16,15 +16,15 @@
 /// \cond INTERNAL
 namespace boost { namespace locale { namespace conv { namespace detail {
     template<typename CharIn, typename CharOut>
-    class BOOST_LOCALE_DECL charset_converter {
+    class BOOST_SYMBOL_VISIBLE charset_converter {
     public:
         using char_out_type = CharOut;
         using char_in_type = CharIn;
         using string_type = std::basic_string<CharOut>;
 
-        virtual ~charset_converter();
+        virtual ~charset_converter() = default;
         virtual string_type convert(const CharIn* begin, const CharIn* end) = 0;
-        BOOST_LOCALE_NO_SANITIZE("vptr") string_type convert(const boost::basic_string_view<CharIn>& text)
+        string_type convert(const boost::basic_string_view<CharIn>& text)
         {
             return convert(text.data(), text.data() + text.length());
         }
@@ -52,15 +52,6 @@ namespace boost { namespace locale { namespace conv { namespace detail {
                           method_type how,
                           conv_backend impl = conv_backend::Default);
 }}}} // namespace boost::locale::conv::detail
-
-namespace std {
-/// Specialization to avoid UBSAN false positives when using charset_converter in std::unique_ptr
-template<typename CharIn, typename CharOut>
-struct default_delete<::boost::locale::conv::detail::charset_converter<CharIn, CharOut>> {
-    using pointer = ::boost::locale::conv::detail::charset_converter<CharIn, CharOut>*;
-    BOOST_LOCALE_NO_SANITIZE("vptr") void operator()(pointer ptr) { delete ptr; }
-};
-} // namespace std
 
 /// \endcond
 

--- a/include/boost/locale/encoding.hpp
+++ b/include/boost/locale/encoding.hpp
@@ -236,17 +236,11 @@ namespace boost { namespace locale {
             /// Convert text in range [begin,end) to UTF
             ///
             /// \throws conversion_error: Conversion failed
-            BOOST_LOCALE_NO_SANITIZE("vptr") string_type convert(const char* begin, const char* end) const
-            {
-                return impl_->convert(begin, end);
-            }
+            string_type convert(const char* begin, const char* end) const { return impl_->convert(begin, end); }
             /// Convert \a text to UTF
             ///
             /// \throws conversion_error: Conversion failed
-            BOOST_LOCALE_NO_SANITIZE("vptr") string_type convert(const boost::string_view& text) const
-            {
-                return impl_->convert(text);
-            }
+            string_type convert(const boost::string_view& text) const { return impl_->convert(text); }
             /// Convert \a text to UTF
             ///
             /// \throws conversion_error: Conversion failed
@@ -273,17 +267,11 @@ namespace boost { namespace locale {
             /// Convert UTF text in range [begin,end) to local encoding
             ///
             /// \throws conversion_error: Conversion failed
-            BOOST_LOCALE_NO_SANITIZE("vptr") std::string convert(const CharType* begin, const CharType* end) const
-            {
-                return impl_->convert(begin, end);
-            }
+            std::string convert(const CharType* begin, const CharType* end) const { return impl_->convert(begin, end); }
             /// Convert \a text from UTF to local encoding
             ///
             /// \throws conversion_error: Conversion failed
-            BOOST_LOCALE_NO_SANITIZE("vptr") std::string convert(const stringview_type& text) const
-            {
-                return impl_->convert(text);
-            }
+            std::string convert(const stringview_type& text) const { return impl_->convert(text); }
             /// Convert \a text from UTF to local encoding
             ///
             /// \throws conversion_error: Conversion failed
@@ -306,17 +294,11 @@ namespace boost { namespace locale {
             /// Convert text in range [begin,end)
             ///
             /// \throws conversion_error: Conversion failed
-            BOOST_LOCALE_NO_SANITIZE("vptr") std::string convert(const char* begin, const char* end) const
-            {
-                return impl_->convert(begin, end);
-            }
+            std::string convert(const char* begin, const char* end) const { return impl_->convert(begin, end); }
             /// Convert \a text
             ///
             /// \throws conversion_error: Conversion failed
-            BOOST_LOCALE_NO_SANITIZE("vptr") std::string convert(const boost::string_view& text) const
-            {
-                return impl_->convert(text);
-            }
+            std::string convert(const boost::string_view& text) const { return impl_->convert(text); }
             /// Convert \a text
             ///
             /// \throws conversion_error: Conversion failed

--- a/src/boost/locale/encoding/codepage.cpp
+++ b/src/boost/locale/encoding/codepage.cpp
@@ -107,9 +107,6 @@ namespace boost { namespace locale { namespace conv {
     }
 
     namespace detail {
-        template<typename CharIn, typename CharOut>
-        charset_converter<CharIn, CharOut>::~charset_converter() = default;
-
         template<class T>
         static std::unique_ptr<utf_encoder<typename T::char_out_type>> make_encoder_ptr(T& enc)
         {

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -46,7 +46,6 @@ std::ostream& operator<<(std::ostream& s, boost::locale::conv::detail::conv_back
 #define TEST_FAIL_CONVERSION(X) TEST_THROWS(X, boost::locale::conv::conversion_error)
 
 template<typename Char>
-BOOST_LOCALE_NO_SANITIZE("vptr")
 void test_to_utf_for_impls(const std::string& source,
                            const std::basic_string<Char>& target,
                            const std::string& encoding,
@@ -81,7 +80,6 @@ void test_to_utf_for_impls(const std::string& source,
 }
 
 template<typename Char>
-BOOST_LOCALE_NO_SANITIZE("vptr")
 void test_from_utf_for_impls(const std::basic_string<Char>& source,
                              const std::string& target,
                              const std::string& encoding,
@@ -181,7 +179,6 @@ std::basic_string<char> utf(const std::string& s)
 }
 
 template<typename Char>
-BOOST_LOCALE_NO_SANITIZE("vptr")
 void test_with_0()
 {
     std::cout << "-- Test string containing NULL chars" << std::endl;
@@ -472,7 +469,6 @@ void test_latin1_conversions()
 #endif
 }
 
-BOOST_LOCALE_NO_SANITIZE("vptr")
 void test_between_for_impls(const std::string& source,
                             const std::string& target,
                             const std::string& to_encoding,


### PR DESCRIPTION
To avoid the UBSAN failure it is enough to mark the class as VISIBLE similar to e.g. exception types.
This allows to remove the workaround with custom deleter and UBSAN-supression macros which makes the code more readable