### PR TITLE
resolving argument usage check in examples/performance

### DIFF
--- a/examples/performance/perf_collate.cpp
+++ b/examples/performance/perf_collate.cpp
@@ -14,7 +14,7 @@ using namespace boost::locale;
 
 int main(int argc, char** argv)
 {
-    if(argc != 2) {
+    if(argc != 3) {
         std::cerr << "Usage backend locale\n";
         return 1;
     } else {

--- a/examples/performance/perf_convert.cpp
+++ b/examples/performance/perf_convert.cpp
@@ -14,7 +14,7 @@ using namespace boost::locale;
 
 int main(int argc, char** argv)
 {
-    if(argc != 2) {
+    if(argc != 3) {
         std::cerr << "Usage backend locale\n";
         return 1;
     }

--- a/examples/performance/perf_format.cpp
+++ b/examples/performance/perf_format.cpp
@@ -14,7 +14,7 @@ using namespace boost::locale;
 
 int main(int argc, char** argv)
 {
-    if(argc != 2) {
+    if(argc != 3) {
         std::cerr << "Usage backend locale\n";
         return 1;
     }


### PR DESCRIPTION
The check for the correct number of arguments for perf_collate.cpp, perf_convert.cpp, and perf_format.cpp did not match the indices of `argv` that are accessed. This resulted in a crash if the previous check was satisfied on access to `argv[2]`. This change allows for backend and locale options to be provided as intended.