### PR TITLE
fix build error after #include <windows.h>

### DIFF
--- a/include/boost/locale/util/string.hpp
+++ b/include/boost/locale/util/string.hpp
@@ -38,7 +38,7 @@ namespace boost { namespace locale { namespace util {
     /// Cast an unsigned char to a (possibly signed) char avoiding implementation defined behavior
     constexpr char to_char(unsigned char c)
     {
-        return static_cast<char>((c - std::numeric_limits<char>::min()) + std::numeric_limits<char>::min());
+        return static_cast<char>((c - (std::numeric_limits<char>::min)()) + (std::numeric_limits<char>::min)());
     }
 
 }}} // namespace boost::locale::util


### PR DESCRIPTION
The following code under MSVC on Windows gives a compilation error.

```cpp
#include <windows.h>
#include <boost/locale.hpp>

int main()
{
    return 0;
}
```
```
error message
error C2589: '(' : illegal token on right side of '::'
```
This problem occurs because windows.h contains a macro definition for min().
The conflict is caused by the use of the min keyword in include/boost/locale/util/string.hpp.

This PR solves that problem.