### PR TITLE
Add test for UTF<->GBK conversion

### DIFF
--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -305,6 +305,8 @@ void test_utf_for()
     } catch(const invalid_charset_error&) { // LCOV_EXCL_LINE
         std::cout << "--- not supported\n"; // LCOV_EXCL_LINE
     }
+    // Testing a codepage which may crash with IConv on macOS, see issue #196
+    test_to_from_utf<Char>("\xa1\xad\xa1\xad", utf<Char>("……"), "gbk");
 
     std::cout << "- Testing correct invalid bytes skipping\n";
     {


### PR DESCRIPTION
Test for #196, should pass, especially without crashing.

Result is based on observed values verified via https://www.fileformat.info/info/charset/GBK/list.htm

> … | [HORIZONTAL ELLIPSIS (U+2026)](https://www.fileformat.info/info/unicode/char/2026/index.htm) | a1ad