### PR TITLE
Fix issue with negative times in `date_time` and add tests for full coverage

### DIFF
--- a/include/boost/locale/date_time.hpp
+++ b/include/boost/locale/date_time.hpp
@@ -707,6 +707,11 @@ namespace boost { namespace locale {
         hold_ptr<abstract_calendar> impl_;
     };
 
+    inline void swap(date_time& left, date_time& right) noexcept
+    {
+        left.swap(right);
+    }
+
     /// Writes date_time \a t to output stream \a out.
     ///
     /// This function uses locale, calendar and time zone of the target stream \a in.

--- a/include/boost/locale/hold_ptr.hpp
+++ b/include/boost/locale/hold_ptr.hpp
@@ -71,12 +71,7 @@ namespace boost { namespace locale {
         }
 
         /// Swap two pointers
-        void swap(hold_ptr& other) noexcept
-        {
-            T* tmp = other.ptr_;
-            other.ptr_ = ptr_;
-            ptr_ = tmp;
-        }
+        void swap(hold_ptr& other) noexcept { ptr_ = exchange(other.ptr_, ptr_); }
 
     private:
         T* ptr_;

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -112,6 +112,18 @@ void test_main(int /*argc*/, char** /*argv*/)
             t2_ref = std::move(t2);
             TEST_EQ(t2.time(), 42);
             TEST_EQ(mock_calendar::num_instances, 2);
+            // Swap
+            t1 = date_time();
+            TEST_EQ(t1.time(), 99);
+            TEST_EQ(t2.time(), 42);
+            using std::swap;
+            swap(t1, t2);
+            TEST_EQ(t1.time(), 42);
+            TEST_EQ(t2.time(), 99);
+            swap(t1, t1);
+            TEST_EQ(t1.time(), 42);
+            swap(t2, t2);
+            TEST_EQ(t2.time(), 99);
         }
         TEST_EQ(mock_calendar::num_instances, 0); // No leaks
         mock_cal.reset(new calendar());

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2022-2023 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -174,6 +175,12 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ(t1.time(), 42);
             swap(t2, t2);
             TEST_EQ(t2.time(), 99);
+
+            // Negative times
+            t1 = date_time(-1.25);
+            TEST_EQ(t1.time(), -1.25);
+            t1 = date_time(-0.25);
+            TEST_EQ(t1.time(), -0.25);
         }
         TEST_EQ(mock_calendar::num_instances, 0); // No leaks
         mock_cal.reset(new calendar());
@@ -449,6 +456,16 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST(!(time_point < time_point - second()));
             TEST(time_point > time_point - second());
             TEST(!(time_point > time_point + second()));
+            // Difference in ns
+            {
+                const double sec = std::trunc(time_point.time()) + 0.5; // Stay inside current second
+                if(backend_name == "icu") {                             // Only ICU supports sub-second times
+                    TEST(date_time(sec - 0.25) < date_time(sec));
+                    TEST(date_time(sec + 0.25) > date_time(sec));
+                }
+                TEST(date_time(sec - 0.25) <= date_time(sec));
+                TEST(date_time(sec + 0.25) >= date_time(sec));
+            }
 
             TEST_EQ(time_point.get(day()), 5);
             TEST_EQ(time_point.get(year()), 1970);
@@ -652,5 +669,3 @@ void test_main(int /*argc*/, char** /*argv*/)
         }
     } // for loop
 }
-
-// boostinspect:noascii

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -14,6 +14,7 @@
 #include <ctime>
 #include <iomanip>
 #include <limits>
+#include <sstream>
 
 #ifdef BOOST_LOCALE_WITH_ICU
 #    include <unicode/uversion.h>
@@ -35,35 +36,46 @@ struct mock_calendar : public boost::locale::abstract_calendar {
     using period_mark = boost::locale::period::marks::period_mark;
 
     mock_calendar() : time(0) { ++num_instances; }
-    mock_calendar(const mock_calendar& other) : time(other.time), is_dst_(other.is_dst_) { ++num_instances; }
+    mock_calendar(const mock_calendar& other) : time(other.time), tz_(other.tz_), is_dst_(other.is_dst_)
+    {
+        ++num_instances;
+    }
     ~mock_calendar() { --num_instances; }
 
     abstract_calendar* clone() const override { return new mock_calendar(*this); }
     void set_value(period_mark, int) override {}                        // LCOV_EXCL_LINE
     void normalize() override {}                                        // LCOV_EXCL_LINE
     int get_value(period_mark, value_type) const override { return 0; } // LCOV_EXCL_LINE
-    void set_time(const boost::locale::posix_time&) override {}         // LCOV_EXCL_LINE
-    boost::locale::posix_time get_time() const override { return {}; }  // LCOV_EXCL_LINE
+    void set_time(const boost::locale::posix_time& t) override { time = t.seconds * 1e3 + t.nanoseconds / 1e6; }
+    boost::locale::posix_time get_time() const override { return {}; } // LCOV_EXCL_LINE
     double get_time_ms() const override { return time; }
     void set_option(calendar_option_type, int) override {} // LCOV_EXCL_LINE
     int get_option(calendar_option_type opt) const override { return opt == is_dst ? is_dst_ : false; }
     void adjust_value(period_mark, update_type, int) override {}                       // LCOV_EXCL_LINE
     int difference(const abstract_calendar&, period_mark) const override { return 0; } // LCOV_EXCL_LINE
-    void set_timezone(const std::string&) override {}
-    std::string get_timezone() const override { return "mock TZ"; }
+    void set_timezone(const std::string& tz) override { tz_ = tz; }
+    std::string get_timezone() const override { return tz_; }
     bool same(const abstract_calendar* other) const override
     {
         return dynamic_cast<const mock_calendar*>(other) != nullptr;
     }
 
     static int num_instances;
+    /// Time in ms
     double time;
-    bool is_dst_;
+    std::string tz_ = "mock TZ";
+    bool is_dst_ = false;
 };
 int mock_calendar::num_instances = 0;
 struct mock_calendar_facet : boost::locale::calendar_facet {
     boost::locale::abstract_calendar* create_calendar() const override { return proto_cal.clone(); }
     mock_calendar proto_cal;
+};
+
+struct scoped_timezone {
+    std::string old_tz_;
+    explicit scoped_timezone(const std::string& tz) : old_tz_(boost::locale::time_zone::global(tz)) {}
+    ~scoped_timezone() { boost::locale::time_zone::global(old_tz_); }
 };
 
 void test_main(int /*argc*/, char** /*argv*/)
@@ -76,17 +88,21 @@ void test_main(int /*argc*/, char** /*argv*/)
         std::locale old_loc = std::locale::global(std::locale(std::locale(), cal_facet));
         mock_calendar::num_instances = 0;
         {
+            scoped_timezone _("global TZ");
             cal_facet->proto_cal.time = 42 * 1e3;
             cal_facet->proto_cal.is_dst_ = false;
             date_time t1;
             TEST_EQ(t1.time(), 42);
-            TEST_EQ(t1.timezone(), "mock TZ");
+            TEST_EQ(t1.timezone(), "global TZ");
             TEST(!t1.is_in_daylight_saving_time());
             TEST_EQ(mock_calendar::num_instances, 1);
             cal_facet->proto_cal.time = 99 * 1e3;
             cal_facet->proto_cal.is_dst_ = true;
+            boost::locale::time_zone::global("global TZ2");
             date_time t2;
+            boost::locale::time_zone::global("global TZ3");
             TEST_EQ(t2.time(), 99);
+            TEST_EQ(t2.timezone(), "global TZ2");
             TEST(t2.is_in_daylight_saving_time());
             TEST_EQ(mock_calendar::num_instances, 2);
             // Copy construct
@@ -94,31 +110,60 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_EQ(t1.time(), 42);
             TEST_EQ(t2.time(), 99);
             TEST_EQ(t3.time(), 42);
+            TEST_EQ(t3.timezone(), "global TZ");
             TEST_EQ(mock_calendar::num_instances, 3);
             // Copy assign
             t3 = t2;
             TEST_EQ(t3.time(), 99);
+            TEST_EQ(t3.timezone(), "global TZ2");
             TEST_EQ(mock_calendar::num_instances, 3); // No new
             {
                 // Move construct
                 date_time t4 = std::move(t1);
                 TEST_EQ(t4.time(), 42);
+                TEST_EQ(t4.timezone(), "global TZ");
                 TEST_EQ(mock_calendar::num_instances, 3); // No new
                 // Move assign
                 t2 = std::move(t4);
                 TEST_EQ(t2.time(), 42);
+                TEST_EQ(t2.timezone(), "global TZ");
                 TEST_LE(mock_calendar::num_instances, 3); // maybe destroy old t2
             }
             // Unchanged after t4 (or old t2) is destroyed
             TEST_EQ(t2.time(), 42);
+            TEST_EQ(t2.timezone(), "global TZ");
             TEST_EQ(mock_calendar::num_instances, 2);
             // Self move, via reference to avoid triggering a compiler warning
             date_time& t2_ref = t2;
             t2_ref = std::move(t2);
             TEST_EQ(t2.time(), 42);
             TEST_EQ(mock_calendar::num_instances, 2);
+
+            // Construct from calendar
+            {
+                const double t = 1337;
+                cal_facet->proto_cal.time = t * 1e3;
+
+                const calendar cal;
+                TEST_EQ(date_time(cal).time(), t);
+                TEST_EQ(date_time(42, cal).time(), 42);
+            }
+            // Constructor from calendar uses calendars TZ
+            {
+                const std::string globalTZ = boost::locale::time_zone::global();
+                TEST_EQ(date_time().timezone(), globalTZ);
+                TEST_EQ(date_time(101).timezone(), globalTZ);
+                TEST_EQ(date_time(year(2001)).timezone(), globalTZ);
+                const std::string calTZ = "calTZ";
+                const calendar cal(calTZ);
+                TEST_EQ(date_time(cal).timezone(), calTZ);
+                TEST_EQ(date_time(101, cal).timezone(), calTZ);
+                TEST_EQ(date_time(year(2001), cal).timezone(), calTZ);
+            }
+
             // Swap
-            t1 = date_time();
+            t1 = date_time(99);
+            t2 = date_time(42);
             TEST_EQ(t1.time(), 99);
             TEST_EQ(t2.time(), 42);
             using std::swap;
@@ -184,6 +229,24 @@ void test_main(int /*argc*/, char** /*argv*/)
                 TEST(cal_tmp == cal_loc2);
                 TEST_EQ(cal_tmp.get_time_zone(), tz);
                 TEST(cal_tmp.get_locale() == loc2);
+
+                // Stream constructors
+                std::ostringstream ss;
+                calendar cal_s(ss);
+                TEST(cal_s == cal);
+                TEST(cal_s != cal_loc2);
+                TEST(cal_s != cal_tz2);
+                ss.imbue(loc2);
+                cal_s = calendar(ss);
+                TEST(cal_s != cal);
+                TEST(cal_s == cal_loc2);
+                TEST(cal_s != cal_tz2);
+                ss.imbue(loc);
+                ss << boost::locale::as::time_zone("GMT+01:00");
+                cal_s = calendar(ss);
+                TEST(cal_s != cal);
+                TEST(cal_s != cal_loc2);
+                TEST(cal_s == cal_tz2);
             }
             {
                 calendar cal2;
@@ -567,6 +630,25 @@ void test_main(int /*argc*/, char** /*argv*/)
             // Adding the hour automatically handles the overflow, so this works too
             tp_gmt += hour();
             TEST_EQ(tp_gmt.get(hour()), tp_gmt1.get(hour()));
+        }
+        // Construction from time-set and calendar/time_point normalizes (e.g. invalid day of month)
+        {
+            const calendar cal;
+            date_time tp1(cal);
+            date_time tp2(year(2001) + march() + day(34), cal);
+            TEST_EQ(tp2 / year(), 2001);
+            TEST_EQ(tp2 / month(), 3);
+            TEST_EQ(tp2 / day(), 3);
+            TEST_EQ(tp2 / hour(), tp1 / hour());
+            TEST_EQ(tp2 / minute(), tp1 / minute());
+            TEST_EQ(tp2 / second(), tp1 / second());
+            date_time tp3(tp2, year(2002) + january() + day(35));
+            TEST_EQ(tp3 / year(), 2002);
+            TEST_EQ(tp3 / month(), 1);
+            TEST_EQ(tp3 / day(), 4);
+            TEST_EQ(tp3 / hour(), tp2 / hour());
+            TEST_EQ(tp3 / minute(), tp2 / minute());
+            TEST_EQ(tp3 / second(), tp2 / second());
         }
     } // for loop
 }


### PR DESCRIPTION
When handling negative times (`double` value) the fractional part (i.e. nanoseconds) is subtracted from the seconds to make the nanoseconds positive. However the subtraction happened on a temporary value, not the result struct leading to off-by-one errors

Also add some more tests to fully cover `date_time.cpp` (which led to the discovery of the above bug),
especially the `date_time` constructors taking a `calendar` and the handling of the "active" time-zone were not sufficiently tested