### PR TITLE
Use super project to build locale and its dependencies in cmake(-subdir)-test

### DIFF
--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -12,65 +12,8 @@ if(DEFINED BOOST_CI_INSTALL_TEST AND BOOST_CI_INSTALL_TEST)
     find_package(boost_locale REQUIRED)
 else()
     message("Building Boost")
-    add_subdirectory(../.. boostorg/locale)
-    set(deps
-      # Primary dependencies
-      assert
-      config
-      core
-      iterator
-      predef
-      thread
-      utility
-
-      # Secondary dependencies
-      algorithm
-      align
-      array
-      atomic
-      bind
-      chrono
-      concept_check
-      container
-      container_hash
-      conversion
-      date_time
-      describe
-      detail
-      exception
-      function
-      function_types
-      functional
-      fusion
-      integer
-      intrusive
-      io
-      lexical_cast
-      move
-      mp11
-      mpl
-      numeric/conversion
-      optional
-      preprocessor
-      range
-      ratio
-      regex
-      smart_ptr
-      static_assert
-      system
-      throw_exception
-      tokenizer
-      tuple
-      type_traits
-      typeof
-      unordered
-      variant2
-      winapi
-    )
-
-    foreach(dep IN LISTS deps)
-      add_subdirectory(../../../${dep} boostorg/${dep})
-    endforeach()
+    set(BOOST_INCLUDE_LIBRARIES locale)
+    add_subdirectory(../../../.. deps/boost EXCLUDE_FROM_ALL)
 endif()
 
 add_executable(main main.cpp)


### PR DESCRIPTION


The transitive dependencies of Boost.Locale are many and might be changing. To avoid frequently required updates use the super-project with `BOOST_INCLUDE_LIBRARIES` to auto-select the required libs.