### PR TITLE
GHA: Run apt-get update before adding repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,8 @@ jobs:
                     curl -sSL --retry ${NET_RETRY_COUNT:-5} "$key" | sudo gpg --dearmor > /etc/apt/trusted.gpg.d/${keyfilename} && break || sleep 10
                 done
             done
+            # Initial update before adding sources required to get e.g. keys
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
             for source in "${SOURCES[@]}"; do
                 for i in {1..$NET_RETRY_COUNT}; do
                     sudo add-apt-repository $source && break || sleep 10


### PR DESCRIPTION
Currently GHA fails on Ubuntu 18.04 with 

```
Err:3 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1E9377A2BA9EF27F

W: GPG error: http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1E9377A2BA9EF27F
E: The repository 'http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic InRelease' is not signed.
```