### PR TITLE
Update GHA CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,47 +86,48 @@ jobs:
         include:
           # Linux, gcc
           # GCC 5 is the first to have enough C++11 support, so don't test anything older except for one to verify the checks
-          - { compiler: gcc-4.9,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-5,     cxxstd: '03,11,14,1z',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-6,     cxxstd: '11,14,17',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-7,     cxxstd: '11,14,17',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-8,     cxxstd: '11,14,17,2a',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-9,     cxxstd: '11,14,17,2a',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: gcc-10,    cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
-          - { compiler: gcc-11,    cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
+          - { compiler: gcc-4.9,   cxxstd: '03,11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-5,     cxxstd: '03,11,14,1z', os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-6,     cxxstd: '11,14,17',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-7,     cxxstd: '11,14,17',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-8,     cxxstd: '11,14,17,2a', os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-9,     cxxstd: '11,14,17,2a', os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: gcc-10,    cxxstd: '11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: gcc-11,    cxxstd: '11,14,17,20', os: ubuntu-20.04 }
           - { name: GCC w/ sanitizers, sanitize: yes,
-              compiler: gcc-12,    cxxstd: '11,14,17,20',    os: ubuntu-22.04 }
+              compiler: gcc-12,    cxxstd: '11,14,17,20', os: ubuntu-22.04 }
           - { name: Collect coverage, coverage: yes,
-              compiler: gcc-8,     cxxstd: '11,2a',          os: ubuntu-20.04, install: 'g++-8-multilib', address-model: '32,64' }
+              compiler: gcc-8,     cxxstd: '11,2a',       os: ubuntu-20.04, install: 'g++-8-multilib', address-model: '32,64' }
 
           # Linux, clang
-          - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.6, cxxstd: '11,14',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.7, cxxstd: '11,14',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.8, cxxstd: '11,14',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.9, cxxstd: '11,14',          os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: clang-4.0, cxxstd: '11,14',          os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: clang-5.0, cxxstd: '11,14,1z',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: clang-6.0, cxxstd: '11,14,17',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
-          - { compiler: clang-7,   cxxstd: '11,14,17',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-3.5, cxxstd: '03,11',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.6, cxxstd: '11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.7, cxxstd: '11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.8, cxxstd: '11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.9, cxxstd: '11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-4.0, cxxstd: '11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-5.0, cxxstd: '11,14,1z',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-6.0, cxxstd: '11,14,17',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
+          - { compiler: clang-7,   cxxstd: '11,14,17',    os: ubuntu-22.04, container: 'ubuntu:18.04' }
           # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
-          - { compiler: clang-8,   cxxstd: '11,14,17,2a',    os: ubuntu-22.04, container: 'ubuntu:18.04', install: 'clang-8 g++-7', gcc_toolchain: 7 }
-          - { compiler: clang-9,   cxxstd: '11,14,17,2a',    os: ubuntu-20.04 }
-          - { compiler: clang-10,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
-          - { compiler: clang-11,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
-          - { compiler: clang-12,  cxxstd: '11,14,17,20',    os: ubuntu-20.04 }
-          - { compiler: clang-13,  cxxstd: '11,14,17,20',    os: ubuntu-22.04 }
-          - { compiler: clang-14,  cxxstd: '11,14,17,20',    os: ubuntu-22.04 }
-          - { compiler: clang-15,  cxxstd: '11,14,17,20',    os: ubuntu-22.04 }
+          - { compiler: clang-8,   cxxstd: '11,14,17,2a', os: ubuntu-22.04, container: 'ubuntu:18.04', install: 'clang-8 g++-7', gcc_toolchain: 7 }
+          - { compiler: clang-9,   cxxstd: '11,14,17,2a', os: ubuntu-20.04 }
+          - { compiler: clang-10,  cxxstd: '11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-11,  cxxstd: '11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-12,  cxxstd: '11,14,17,20', os: ubuntu-20.04 }
+          # Clang isn't compatible with libstdc++-13, so use the slightly older one
+          - { compiler: clang-13,  cxxstd: '11,14,17,20', os: ubuntu-22.04, install: 'clang-13 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-14,  cxxstd: '11,14,17,20', os: ubuntu-22.04, install: 'clang-14 g++-12', gcc_toolchain: 12 }
+          - { compiler: clang-15,  cxxstd: '11,14,17,20', os: ubuntu-22.04, install: 'clang-15 g++-12', gcc_toolchain: 12 }
 
           # libc++
-          - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04', stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
+          - { compiler: clang-6.0, cxxstd: '11,14',       os: ubuntu-22.04, container: 'ubuntu:18.04', stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
           - { name: Clang w/ sanitizers, sanitize: yes,
-              compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
+              compiler: clang-12,  cxxstd: '11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
 
           # OSX, clang
           - { name: MacOS w/ clang and sanitizers,
-              compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-11, ubsan: yes }
+              compiler: clang,     cxxstd: '11,14,17,2a', os: macos-11, ubsan: yes }
 
     timeout-minutes: 120
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
Remove C++03 jobs from newer compilers
Fix after GHA Ubuntu 22 image update
Add Clang 16