### PR TITLE
Add assertions to IConv converter

### DIFF
--- a/src/boost/locale/encoding/iconv_converter.hpp
+++ b/src/boost/locale/encoding/iconv_converter.hpp
@@ -10,6 +10,7 @@
 #include <boost/locale/encoding.hpp>
 #include "boost/locale/util/encoding.hpp"
 #include "boost/locale/util/iconv.hpp"
+#include <boost/assert.hpp>
 #include <cerrno>
 #include <string>
 
@@ -47,6 +48,7 @@ namespace boost { namespace locale { namespace conv { namespace impl {
                 if(in_left == 0)
                     is_unshifting = true;
 
+                const auto old_in_left = in_left;
                 const size_t res = (!is_unshifting) ? conv(&begin, &in_left, &out_ptr, &out_left) :
                                                       conv(nullptr, nullptr, &out_ptr, &out_left);
 
@@ -60,6 +62,7 @@ namespace boost { namespace locale { namespace conv { namespace impl {
 
                 if(res == (size_t)(-1)) {
                     const int err = errno;
+                    BOOST_ASSERT_MSG(err == EILSEQ || err == EINVAL || err == E2BIG, "Invalid error code from IConv");
                     if(err == EILSEQ || err == EINVAL) {
                         if(how_ == stop)
                             throw conversion_error();
@@ -70,9 +73,10 @@ namespace boost { namespace locale { namespace conv { namespace impl {
                                 break;
                         } else
                             break;
-                    } else if(err == E2BIG)
+                    } else if(err == E2BIG) {
+                        BOOST_VERIFY_MSG(in_left != old_in_left || output_count != 0, "No progress, IConv is faulty!");
                         continue;
-                    else                          // Invalid error code, shouldn't ever happen or iconv has a bug
+                    } else                        // Invalid error code, shouldn't ever happen or iconv has a bug
                         throw conversion_error(); // LCOV_EXCL_LINE
                 }
                 if(is_unshifting)

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -307,6 +307,8 @@ void test_utf_for()
     }
     // Testing a codepage which may crash with IConv on macOS, see issue #196
     test_to_from_utf<Char>("\xa1\xad\xa1\xad", utf<Char>("……"), "gbk");
+    // This might cause a bogus E2BIG on macOS, see issue #206
+    test_to_from_utf<Char>("\x1b\x24\x29\x41\x0e\x4a\x35\xf", utf<Char>("实"), "ISO-2022-CN");
 
     std::cout << "- Testing correct invalid bytes skipping\n";
     {


### PR DESCRIPTION
Assert post-conditions of calling `iconv` and add test for a possible violation of that.