### PR TITLE
Reimplement `string_set` as `any_string`

### DIFF
--- a/include/boost/locale/detail/any_string.hpp
+++ b/include/boost/locale/detail/any_string.hpp
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2023 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_DETAIL_ANY_STRING_HPP_INCLUDED
+#define BOOST_LOCALE_DETAIL_ANY_STRING_HPP_INCLUDED
+
+#include <boost/locale/config.hpp>
+#include <boost/assert.hpp>
+#include <boost/utility/string_view.hpp>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+/// \cond INTERNAL
+namespace boost { namespace locale { namespace detail {
+    /// Type-erased std::basic_string
+    class any_string {
+        struct BOOST_SYMBOL_VISIBLE base {
+            virtual ~base() = default;
+            virtual base* clone() const = 0;
+
+        protected:
+            base() = default;
+            base(const base&) = default;
+            base(base&&) = delete;
+            base& operator=(const base&) = default;
+            base& operator=(base&&) = delete;
+        };
+        template<typename Char>
+        struct BOOST_SYMBOL_VISIBLE impl : base {
+            explicit impl(const boost::basic_string_view<Char> value) : s(value) {}
+            impl* clone() const override { return new impl(*this); }
+            std::basic_string<Char> s;
+        };
+
+        std::unique_ptr<const base> s_;
+
+    public:
+        any_string() = default;
+        any_string(const any_string& other) : s_(other.s_ ? other.s_->clone() : nullptr) {}
+        any_string(any_string&&) = default;
+        any_string& operator=(any_string other) // Covers the copy and move assignment
+        {
+            s_.swap(other.s_);
+            return *this;
+        }
+
+        template<typename Char>
+        void set(const boost::basic_string_view<Char> s)
+        {
+            BOOST_ASSERT(!s.empty());
+            s_.reset(new impl<Char>(s));
+        }
+
+        template<typename Char>
+        std::basic_string<Char> get() const
+        {
+            if(!s_)
+                throw std::bad_cast();
+            return dynamic_cast<const impl<Char>&>(*s_).s;
+        }
+    };
+
+}}} // namespace boost::locale::detail
+
+/// \endcond
+
+#endif

--- a/include/boost/locale/formatting.hpp
+++ b/include/boost/locale/formatting.hpp
@@ -8,15 +8,13 @@
 #ifndef BOOST_LOCALE_FORMATTING_HPP_INCLUDED
 #define BOOST_LOCALE_FORMATTING_HPP_INCLUDED
 
+#include <boost/locale/detail/any_string.hpp>
 #include <boost/locale/time_zone.hpp>
-#include <boost/assert.hpp>
-#include <boost/utility/string_view.hpp>
 #include <cstdint>
 #include <cstring>
 #include <istream>
 #include <ostream>
 #include <string>
-#include <typeinfo>
 
 #ifdef BOOST_MSVC
 #    pragma warning(push)
@@ -130,13 +128,13 @@ namespace boost { namespace locale {
         template<typename CharType>
         void date_time_pattern(const std::basic_string<CharType>& str)
         {
-            date_time_pattern_set().set<CharType>(str);
+            datetime_.set<CharType>(str);
         }
         /// Get date/time pattern (strftime like)
         template<typename CharType>
         std::basic_string<CharType> date_time_pattern() const
         {
-            return date_time_pattern_set().get<CharType>();
+            return datetime_.get<CharType>();
         }
 
         /// \cond INTERNAL
@@ -144,51 +142,10 @@ namespace boost { namespace locale {
         /// \endcond
 
     private:
-        class string_set;
-
-        const string_set& date_time_pattern_set() const;
-        string_set& date_time_pattern_set();
-
-        class BOOST_LOCALE_DECL string_set {
-        public:
-            string_set();
-            ~string_set();
-            string_set(const string_set& other);
-            string_set& operator=(string_set other);
-            void swap(string_set& other);
-
-            template<typename Char>
-            void set(const boost::basic_string_view<Char> s)
-            {
-                BOOST_ASSERT(!s.empty());
-                delete[] ptr;
-                ptr = nullptr;
-                type = &typeid(Char);
-                size = sizeof(Char) * s.size();
-                ptr = size ? new char[size] : nullptr;
-                memcpy(ptr, s.data(), size);
-            }
-
-            template<typename Char>
-            std::basic_string<Char> get() const
-            {
-                if(type == nullptr || *type != typeid(Char))
-                    throw std::bad_cast();
-                std::basic_string<Char> result(size / sizeof(Char), Char(0));
-                memcpy(&result.front(), ptr, size);
-                return result;
-            }
-
-        private:
-            const std::type_info* type;
-            size_t size;
-            char* ptr;
-        };
-
         uint64_t flags_;
         int domain_id_;
         std::string time_zone_;
-        string_set datetime_;
+        detail::any_string datetime_;
     };
 
     /// \brief This namespace includes all manipulators that can be used on IO streams

--- a/src/boost/locale/shared/formatting.cpp
+++ b/src/boost/locale/shared/formatting.cpp
@@ -7,43 +7,8 @@
 #include <boost/locale/date_time.hpp>
 #include <boost/locale/formatting.hpp>
 #include "boost/locale/shared/ios_prop.hpp"
-#include <algorithm>
-#include <typeinfo>
 
 namespace boost { namespace locale {
-
-    ios_info::string_set::string_set() : type(nullptr), size(0), ptr(nullptr) {}
-    ios_info::string_set::~string_set()
-    {
-        delete[] ptr;
-    }
-    ios_info::string_set::string_set(const string_set& other)
-    {
-        if(other.ptr != nullptr) {
-            ptr = new char[other.size];
-            size = other.size;
-            type = other.type;
-            memcpy(ptr, other.ptr, size);
-        } else {
-            ptr = nullptr;
-            size = 0;
-            type = nullptr;
-        }
-    }
-
-    void ios_info::string_set::swap(string_set& other)
-    {
-        std::swap(type, other.type);
-        std::swap(size, other.size);
-        std::swap(ptr, other.ptr);
-    }
-
-    ios_info::string_set& ios_info::string_set::operator=(string_set other)
-    {
-        swap(other);
-        return *this;
-    }
-
     ios_info::ios_info() : flags_(0), domain_id_(0), time_zone_(time_zone::global()) {}
 
     ios_info::~ios_info() = default;
@@ -103,16 +68,6 @@ namespace boost { namespace locale {
     std::string ios_info::time_zone() const
     {
         return time_zone_;
-    }
-
-    const ios_info::string_set& ios_info::date_time_pattern_set() const
-    {
-        return datetime_;
-    }
-
-    ios_info::string_set& ios_info::date_time_pattern_set()
-    {
-        return datetime_;
     }
 
     ios_info& ios_info::get(std::ios_base& ios)


### PR DESCRIPTION
Use a better name for a type-erased string implemented using `dynamic_cast` instead of storing&comparing the `typeid` of the char type used.
This is a workaround for missing typeinfo for `char8_t` on e.g. libc++ on FreeBSD 13.1.
It also simplifies memory management size calc/copy implementation.