### PR TITLE
Appveyor: Drop MinGW32 for MinGW64-32Bit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -112,11 +112,11 @@ environment:
       B2_CXXSTD: 11,1z
       B2_TOOLSET: gcc
 
-    - FLAVOR: mingw32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - FLAVOR: mingw64 (32-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ADDPATH: C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32\bin;
       B2_ADDRESS_MODEL: 32
-      ADDPATH: C:\mingw\bin;
-      B2_CXXSTD: 11,14,1z
+      B2_CXXSTD: 03,11,14,17,2a
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw64


### PR DESCRIPTION
The old MinGW32 doesn't properly support C++11