### PR TITLE
Fix possible type confusion with `boost::locale::collator`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(boost_locale
   src/boost/locale/shared/localization_backend.cpp
   src/boost/locale/shared/message.cpp
   src/boost/locale/shared/mo_lambda.cpp
+  src/boost/locale/shared/std_collate_adapter.hpp
   src/boost/locale/util/codecvt_converter.cpp
   src/boost/locale/util/default_locale.cpp
   src/boost/locale/util/encoding.cpp

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2021-2023 Alexander Grund
+// Copyright (c) 2021-2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -8,6 +8,9 @@
 /*!
 \page changelog Changelog
 
+- 1.85.0
+    - Breaking changes
+        - `collator` does no longer derive from `std::collator` avoiding possible type confusion
 - 1.84.0
     - Breaking changes
         - `to_title` for the WinAPI backend returns the string unchanged instead of an empty string

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -53,7 +53,7 @@ namespace boost { namespace locale {
         /// Type of string used with this facet
         typedef std::basic_string<CharType> string_type;
 
-        /// Compare two strings in rage [b1,e1),  [b2,e2) according using a collation level \a level. Calls do_compare
+        /// Compare two strings in range [b1,e1),  [b2,e2) according to collation level \a level. Calls do_compare
         ///
         /// Returns -1 if the first of the two strings sorts before the seconds, returns 1 if sorts after and 0 if
         /// they considered equal.
@@ -107,7 +107,7 @@ namespace boost { namespace locale {
         /// Create a binary string from string \a s, that can be compared to other, useful for collation of multiple
         /// strings.
         ///
-        /// The transformation follows these rules:
+        /// The transformation follows this rule:
         /// \code
         ///   compare(level,s1,s2) == sign( transform(level,s1).compare(transform(level,s2)) );
         /// \endcode
@@ -121,7 +121,7 @@ namespace boost { namespace locale {
         collator(size_t refs = 0) : std::collate<CharType>(refs) {}
 
         /// This function is used to override default collation function that does not take in account collation level.
-        /// Uses primary level
+        /// Uses identical level
         int
         do_compare(const char_type* b1, const char_type* e1, const char_type* b2, const char_type* e2) const override
         {
@@ -129,14 +129,14 @@ namespace boost { namespace locale {
         }
 
         /// This function is used to override default collation function that does not take in account collation level.
-        /// Uses primary level
+        /// Uses identical level
         string_type do_transform(const char_type* b, const char_type* e) const override
         {
             return do_transform(collate_level::identical, b, e);
         }
 
         /// This function is used to override default collation function that does not take in account collation level.
-        /// Uses primary level
+        /// Uses identical level
         long do_hash(const char_type* b, const char_type* e) const override
         {
             return do_hash(collate_level::identical, b, e);
@@ -157,7 +157,7 @@ namespace boost { namespace locale {
     };
 
     /// \brief This class can be used in STL algorithms and containers for comparison of strings
-    /// with a level other than primary
+    /// with a level other than identical
     ///
     /// For example:
     ///
@@ -169,7 +169,7 @@ namespace boost { namespace locale {
     template<typename CharType, collate_level default_level = collate_level::identical>
     struct comparator {
     public:
-        /// Create a comparator class for locale \a l and with collation leval \a level
+        /// Create a comparator class for locale \a l and with collation level \a level
         ///
         /// \throws std::bad_cast: \a l does not have \ref collator facet installed
         comparator(const std::locale& l = std::locale(), collate_level level = default_level) :

--- a/include/boost/locale/collator.hpp
+++ b/include/boost/locale/collator.hpp
@@ -173,17 +173,18 @@ namespace boost { namespace locale {
         ///
         /// \throws std::bad_cast: \a l does not have \ref collator facet installed
         comparator(const std::locale& l = std::locale(), collate_level level = default_level) :
-            locale_(l), level_(level)
+            locale_(l), collator_(std::use_facet<collator<CharType>>(locale_)), level_(level)
         {}
 
         /// Compare two strings -- equivalent to return left < right according to collation rules
         bool operator()(const std::basic_string<CharType>& left, const std::basic_string<CharType>& right) const
         {
-            return std::use_facet<collator<CharType>>(locale_).compare(level_, left, right) < 0;
+            return collator_.compare(level_, left, right) < 0;
         }
 
     private:
         std::locale locale_;
+        const collator<CharType>& collator_;
         collate_level level_;
     };
 

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -185,10 +185,10 @@ namespace boost { namespace locale { namespace impl_icu {
                 return std::locale(in, new collate_impl<char8_t>(cd)); // std-facet not available (yet)
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char_facet_t::char16_f: : return impl::create_collators<char16_t, collate_impl>(in, cd);
+            case char_facet_t::char16_f: return impl::create_collators<char16_t, collate_impl>(in, cd);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char_facet_t::char32_f: : return impl::create_collators<char32_t, collate_impl>(in, cd);
+            case char_facet_t::char32_f: return impl::create_collators<char32_t, collate_impl>(in, cd);
 #endif
         }
         return in;

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -13,6 +13,7 @@
 #include "boost/locale/shared/mo_hash.hpp"
 #include <boost/thread.hpp>
 #include <limits>
+#include <memory>
 #include <unicode/coll.h>
 #include <vector>
 #if BOOST_LOCALE_ICU_VERSION >= 402
@@ -51,7 +52,7 @@ namespace boost { namespace locale { namespace impl_icu {
         {
             icu::StringPiece left(b1, e1 - b1);
             icu::StringPiece right(b2, e2 - b2);
-            return get_collator(level)->compareUTF8(left, right, status);
+            return get_collator(level).compareUTF8(left, right, status);
         }
 #endif
 
@@ -64,7 +65,7 @@ namespace boost { namespace locale { namespace impl_icu {
         {
             icu::UnicodeString left = cvt_.icu(b1, e1);
             icu::UnicodeString right = cvt_.icu(b2, e2);
-            return get_collator(level)->compare(left, right, status);
+            return get_collator(level).compare(left, right, status);
         }
 
         int do_real_compare(collate_level level,
@@ -101,11 +102,11 @@ namespace boost { namespace locale { namespace impl_icu {
             icu::UnicodeString str = cvt_.icu(b, e);
             std::vector<uint8_t> tmp;
             tmp.resize(str.length() + 1u);
-            icu::Collator* collate = get_collator(level);
-            const int len = collate->getSortKey(str, tmp.data(), tmp.size());
+            icu::Collator& collate = get_collator(level);
+            const int len = collate.getSortKey(str, tmp.data(), tmp.size());
             if(len > int(tmp.size())) {
                 tmp.resize(len);
-                collate->getSortKey(str, tmp.data(), tmp.size());
+                collate.getSortKey(str, tmp.data(), tmp.size());
             } else
                 tmp.resize(len);
             return tmp;
@@ -126,7 +127,7 @@ namespace boost { namespace locale { namespace impl_icu {
 
         collate_impl(const cdata& d) : cvt_(d.encoding()), locale_(d.locale()), is_utf8_(d.is_utf8()) {}
 
-        icu::Collator* get_collator(collate_level level) const
+        icu::Collator& get_collator(collate_level level) const
         {
             const int lvl_idx = level_to_int(level);
             constexpr icu::Collator::ECollationStrength levels[level_count] = {icu::Collator::PRIMARY,
@@ -136,18 +137,17 @@ namespace boost { namespace locale { namespace impl_icu {
                                                                                icu::Collator::IDENTICAL};
 
             icu::Collator* col = collates_[lvl_idx].get();
-            if(col)
-                return col;
+            if(!col) {
+                UErrorCode status = U_ZERO_ERROR;
+                std::unique_ptr<icu::Collator> tmp_col(icu::Collator::createInstance(locale_, status));
+                if(U_FAILURE(status))
+                    throw std::runtime_error(std::string("Creation of collate failed:") + u_errorName(status));
 
-            UErrorCode status = U_ZERO_ERROR;
-
-            collates_[lvl_idx].reset(icu::Collator::createInstance(locale_, status));
-
-            if(U_FAILURE(status))
-                throw std::runtime_error(std::string("Creation of collate failed:") + u_errorName(status));
-
-            collates_[lvl_idx]->setStrength(levels[lvl_idx]);
-            return collates_[lvl_idx].get();
+                tmp_col->setStrength(levels[lvl_idx]);
+                col = tmp_col.release();
+                collates_[lvl_idx].reset(col);
+            }
+            return *col;
         }
 
     private:

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -11,6 +11,7 @@
 #include "boost/locale/icu/icu_util.hpp"
 #include "boost/locale/icu/uconv.hpp"
 #include "boost/locale/shared/mo_hash.hpp"
+#include "boost/locale/shared/std_collate_adapter.hpp"
 #include <boost/thread.hpp>
 #include <limits>
 #include <memory>
@@ -173,21 +174,21 @@ namespace boost { namespace locale { namespace impl_icu {
             return do_ustring_compare(level, b1, e1, b2, e2, status);
     }
 #endif
-
     std::locale create_collate(const std::locale& in, const cdata& cd, char_facet_t type)
     {
         switch(type) {
             case char_facet_t::nochar: break;
-            case char_facet_t::char_f: return std::locale(in, new collate_impl<char>(cd));
-            case char_facet_t::wchar_f: return std::locale(in, new collate_impl<wchar_t>(cd));
+            case char_facet_t::char_f: return impl::create_collators<char, collate_impl>(in, cd);
+            case char_facet_t::wchar_f: return impl::create_collators<wchar_t, collate_impl>(in, cd);
 #ifdef __cpp_char8_t
-            case char_facet_t::char8_f: break; // std-facet not available (yet)
+            case char_facet_t::char8_f:
+                return std::locale(in, new collate_impl<char8_t>(cd)); // std-facet not available (yet)
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-            case char_facet_t::char16_f: return std::locale(in, new collate_impl<char16_t>(cd));
+            case char_facet_t::char16_f: : return impl::create_collators<char16_t, collate_impl>(in, cd);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-            case char_facet_t::char32_f: return std::locale(in, new collate_impl<char32_t>(cd));
+            case char_facet_t::char32_f: : return impl::create_collators<char32_t, collate_impl>(in, cd);
 #endif
         }
         return in;

--- a/src/boost/locale/shared/ids.cpp
+++ b/src/boost/locale/shared/ids.cpp
@@ -6,6 +6,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/boundary.hpp>
+#include <boost/locale/collator.hpp>
 #include <boost/locale/conversion.hpp>
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/info.hpp>
@@ -24,6 +25,7 @@ namespace boost { namespace locale {
     BOOST_LOCALE_DEFINE_ID(calendar_facet);
 
 #define BOOST_LOCALE_INSTANTIATE(CHARTYPE)            \
+    BOOST_LOCALE_DEFINE_ID(collator<CHARTYPE>);       \
     BOOST_LOCALE_DEFINE_ID(converter<CHARTYPE>);      \
     BOOST_LOCALE_DEFINE_ID(message_format<CHARTYPE>); \
     BOOST_LOCALE_DEFINE_ID(boundary::boundary_indexing<CHARTYPE>);
@@ -48,6 +50,7 @@ namespace boost { namespace locale {
             void init_by(const std::locale& l)
             {
                 init_facet<boundary::boundary_indexing<Char>>(l);
+                init_facet<collator<Char>>(l);
                 init_facet<converter<Char>>(l);
                 init_facet<message_format<Char>>(l);
             }

--- a/src/boost/locale/shared/ids.cpp
+++ b/src/boost/locale/shared/ids.cpp
@@ -1,11 +1,11 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/boundary.hpp>
-#include <boost/locale/collator.hpp>
 #include <boost/locale/conversion.hpp>
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/info.hpp>

--- a/src/boost/locale/shared/mo_lambda.cpp
+++ b/src/boost/locale/shared/mo_lambda.cpp
@@ -22,7 +22,7 @@ namespace boost { namespace locale { namespace gnu_gettext { namespace lambda {
 
     namespace { // anon
         template<class TExp, typename... Ts>
-        expr_ptr make_expr(Ts... ts)
+        expr_ptr make_expr(Ts&&... ts)
         {
             return expr_ptr(new TExp(std::forward<Ts>(ts)...));
         }

--- a/src/boost/locale/shared/std_collate_adapter.hpp
+++ b/src/boost/locale/shared/std_collate_adapter.hpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2024 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_STD_COLLATE_ADAPTER_HPP
+#define BOOST_LOCALE_STD_COLLATE_ADAPTER_HPP
+
+#include <boost/locale/collator.hpp>
+#include <locale>
+#include <utility>
+
+namespace boost { namespace locale { namespace impl {
+
+    template<typename CharT, class Base>
+    class BOOST_SYMBOL_VISIBLE std_collate_adapter : public std::collate<CharT> {
+    public:
+        using typename std::collate<CharT>::string_type;
+
+        template<typename... TArgs>
+        explicit std_collate_adapter(TArgs&&... args) : base_(std::forward<TArgs>(args)...)
+        {}
+
+    protected:
+        int do_compare(const CharT* beg1, const CharT* end1, const CharT* beg2, const CharT* end2) const override
+        {
+            return base_.compare(collate_level::identical, beg1, end1, beg2, end2);
+        }
+
+        string_type do_transform(const CharT* beg, const CharT* end) const override
+        {
+            return base_.transform(collate_level::identical, beg, end);
+        }
+        long do_hash(const CharT* beg, const CharT* end) const override
+        {
+            return base_.hash(collate_level::identical, beg, end);
+        }
+        Base base_;
+    };
+
+    template<typename CharType, class CollatorImpl, typename... TArgs>
+    static std::locale create_collators(const std::locale& in, TArgs&&... args)
+    {
+        static_assert(std::is_base_of<collator<CharType>, CollatorImpl>::value, "Must be a collator implementation");
+        std::locale res(in, new CollatorImpl(args...));
+        return std::locale(res, new std_collate_adapter<CharType, CollatorImpl>(args...));
+    }
+
+    template<typename CharType, template<typename> class CollatorImpl, typename... TArgs>
+    static std::locale create_collators(const std::locale& in, TArgs&&... args)
+    {
+        return create_collators<CharType, CollatorImpl<CharType>>(in, args...);
+    }
+
+}}} // namespace boost::locale::impl
+
+#endif

--- a/src/boost/locale/win32/all_generator.hpp
+++ b/src/boost/locale/win32/all_generator.hpp
@@ -12,7 +12,7 @@
 
 namespace boost { namespace locale { namespace impl_win {
 
-    class winlocale;
+    struct winlocale;
 
     std::locale create_convert(const std::locale& in, const winlocale& lc, char_facet_t type);
 

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -48,15 +48,13 @@ namespace boost { namespace locale { namespace impl_win {
         return 0;
     }
 
-    class winlocale {
-    public:
-        winlocale() : lcid(0) {}
-
-        winlocale(const std::string& name) { lcid = locale_to_lcid(name); }
-
-        unsigned lcid;
+    struct winlocale {
+        explicit winlocale(unsigned locale_id = 0) : lcid(locale_id) {}
+        explicit winlocale(const std::string& name) { lcid = locale_to_lcid(name); }
 
         bool is_c() const { return lcid == 0; }
+
+        unsigned lcid;
     };
 
     ////////////////////////////////////////////////////////////////////////
@@ -195,8 +193,7 @@ namespace boost { namespace locale { namespace impl_win {
 
     inline std::wstring wcsfold(const wchar_t* begin, const wchar_t* end)
     {
-        winlocale l;
-        l.lcid = 0x0409; // en-US
+        const winlocale l(0x0409); // en-US
         return win_map_string_l(LCMAP_LOWERCASE, begin, end, l);
     }
 

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace locale { namespace impl_win {
             case collate_level::quaternary:
             case collate_level::identical: return 0;
         }
-        return 0;
+        return 0; // LCOV_EXCL_LINE
     }
 
     struct winlocale {
@@ -86,7 +86,7 @@ namespace boost { namespace locale { namespace impl_win {
            || GetLocaleInfoW(lcid, LOCALE_SDECIMAL, de, de_size) == 0
            || GetLocaleInfoW(lcid, LOCALE_SGROUPING, gr, gr_size) == 0)
         {
-            return res;
+            return res; // LCOV_EXCL_LINE
         }
         res.decimal_point = de;
         res.thousands_sep = th;
@@ -117,7 +117,7 @@ namespace boost { namespace locale { namespace impl_win {
             throw std::length_error("String to long for int type");
         int len = LCMapStringW(l.lcid, flags, begin, static_cast<int>(end - begin), 0, 0);
         if(len == 0)
-            return res;
+            return res; // LCOV_EXCL_LINE
         if(len == std::numeric_limits<int>::max())
             throw std::length_error("String to long for int type");
         std::vector<wchar_t> buf(len + 1);
@@ -215,7 +215,7 @@ namespace boost { namespace locale { namespace impl_win {
             throw std::length_error("String to long for int type");
         int len = FoldStringW(flags, begin, static_cast<int>(end - begin), nullptr, 0);
         if(len == 0)
-            return std::wstring();
+            return std::wstring(); // LCOV_EXCL_LINE
         if(len == std::numeric_limits<int>::max())
             throw std::length_error("String to long for int type");
         std::vector<wchar_t> v(len + 1);

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -27,6 +27,7 @@
 
 #include <boost/locale/collator.hpp>
 #include <boost/locale/conversion.hpp>
+#include <boost/assert.hpp>
 
 namespace boost { namespace locale { namespace impl_win {
 
@@ -147,6 +148,7 @@ namespace boost { namespace locale { namespace impl_win {
                                           static_cast<int>(le - lb),
                                           rb,
                                           static_cast<int>(re - rb));
+        BOOST_ASSERT_MSG(result != 0, "CompareStringW failed");
         return result - 2; // Subtract 2 to get the meaning of <0, ==0, and >0
     }
 
@@ -211,7 +213,7 @@ namespace boost { namespace locale { namespace impl_win {
 
         if(end - begin > std::numeric_limits<int>::max())
             throw std::length_error("String to long for int type");
-        int len = FoldStringW(flags, begin, static_cast<int>(end - begin), 0, 0);
+        int len = FoldStringW(flags, begin, static_cast<int>(end - begin), nullptr, 0);
         if(len == 0)
             return std::wstring();
         if(len == std::numeric_limits<int>::max())
@@ -223,9 +225,7 @@ namespace boost { namespace locale { namespace impl_win {
 
     inline std::wstring wcsxfrm_l(collate_level level, const wchar_t* begin, const wchar_t* end, const winlocale& l)
     {
-        int flag = LCMAP_SORTKEY | collation_level_to_flag(level);
-
-        return win_map_string_l(flag, begin, end, l);
+        return win_map_string_l(LCMAP_SORTKEY | collation_level_to_flag(level), begin, end, l);
     }
 
     inline std::wstring towupper_l(const wchar_t* begin, const wchar_t* end, const winlocale& l)

--- a/src/boost/locale/win32/collate.cpp
+++ b/src/boost/locale/win32/collate.cpp
@@ -7,33 +7,71 @@
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/generator.hpp>
 #include "boost/locale/shared/mo_hash.hpp"
+#include "boost/locale/shared/std_collate_adapter.hpp"
 #include "boost/locale/win32/api.hpp"
 #include <ios>
 #include <locale>
 #include <string>
+#include <type_traits>
 
 namespace boost { namespace locale { namespace impl_win {
+    template<typename CharT, typename Result>
+    using enable_if_sizeof_wchar_t = typename std::enable_if<sizeof(CharT) == sizeof(wchar_t), Result>::type;
+    template<typename CharT, typename Result>
+    using disable_if_sizeof_wchar_t = typename std::enable_if<sizeof(CharT) != sizeof(wchar_t), Result>::type;
 
-    class utf8_collator : public collator<char> {
-    public:
-        utf8_collator(winlocale lc, size_t refs = 0) : collator<char>(refs), lc_(lc) {}
-        int
-        do_compare(collate_level level, const char* lb, const char* le, const char* rb, const char* re) const override
+    namespace {
+        template<typename CharT>
+        enable_if_sizeof_wchar_t<CharT, int> compare_impl(collate_level level,
+                                                          const CharT* lb,
+                                                          const CharT* le,
+                                                          const CharT* rb,
+                                                          const CharT* re,
+                                                          const winlocale& wl)
+        {
+            return wcscoll_l(level,
+                             reinterpret_cast<const wchar_t*>(lb),
+                             reinterpret_cast<const wchar_t*>(le),
+                             reinterpret_cast<const wchar_t*>(rb),
+                             reinterpret_cast<const wchar_t*>(re),
+                             wl);
+        }
+
+        template<typename CharT>
+        disable_if_sizeof_wchar_t<CharT, int> compare_impl(collate_level level,
+                                                           const CharT* lb,
+                                                           const CharT* le,
+                                                           const CharT* rb,
+                                                           const CharT* re,
+                                                           const winlocale& wl)
         {
             const std::wstring l = conv::utf_to_utf<wchar_t>(lb, le);
             const std::wstring r = conv::utf_to_utf<wchar_t>(rb, re);
-            return wcscoll_l(level, l.c_str(), l.c_str() + l.size(), r.c_str(), r.c_str() + r.size(), lc_);
+            return wcscoll_l(level, l.c_str(), l.c_str() + l.size(), r.c_str(), r.c_str() + r.size(), wl);
         }
-        long do_hash(collate_level level, const char* b, const char* e) const override
+
+        template<typename CharT>
+        enable_if_sizeof_wchar_t<CharT, std::wstring>
+        normalize_impl(collate_level level, const CharT* b, const CharT* e, const winlocale& l)
         {
-            const std::string key = do_transform(level, b, e);
-            return gnu_gettext::pj_winberger_hash_function(key.c_str(), key.c_str() + key.size());
+            return wcsxfrm_l(level, reinterpret_cast<const wchar_t*>(b), reinterpret_cast<const wchar_t*>(e), l);
         }
-        std::string do_transform(collate_level level, const char* b, const char* e) const override
+
+        template<typename CharT>
+        disable_if_sizeof_wchar_t<CharT, std::wstring>
+        normalize_impl(collate_level level, const CharT* b, const CharT* e, const winlocale& l)
         {
             const std::wstring tmp = conv::utf_to_utf<wchar_t>(b, e);
-            const std::wstring wkey = wcsxfrm_l(level, tmp.c_str(), tmp.c_str() + tmp.size(), lc_);
-            std::string key;
+            return wcsxfrm_l(level, tmp.c_str(), tmp.c_str() + tmp.size(), l);
+        }
+
+        template<typename CharT>
+        typename std::enable_if<sizeof(CharT) == 1, std::basic_string<CharT>>::type
+        transform_impl(collate_level level, const CharT* b, const CharT* e, const winlocale& l)
+        {
+            const std::wstring wkey = normalize_impl(level, b, e, l);
+
+            std::basic_string<CharT> key;
             BOOST_LOCALE_START_CONST_CONDITION
             if(sizeof(wchar_t) == 2)
                 key.reserve(wkey.size() * 2);
@@ -42,46 +80,61 @@ namespace boost { namespace locale { namespace impl_win {
             for(const wchar_t c : wkey) {
                 if(sizeof(wchar_t) == 2) {
                     const uint16_t tv = static_cast<uint16_t>(c);
-                    key += char(tv >> 8);
-                    key += char(tv & 0xFF);
+                    key += CharT(tv >> 8);
+                    key += CharT(tv & 0xFF);
                 } else { // 4
                     const uint32_t tv = static_cast<uint32_t>(c);
                     // 21 bit
-                    key += char((tv >> 16) & 0xFF);
-                    key += char((tv >> 8) & 0xFF);
-                    key += char(tv & 0xFF);
+                    key += CharT((tv >> 16) & 0xFF);
+                    key += CharT((tv >> 8) & 0xFF);
+                    key += CharT(tv & 0xFF);
                 }
             }
             BOOST_LOCALE_END_CONST_CONDITION
             return key;
         }
 
-    private:
-        winlocale lc_;
-    };
+        template<typename CharT>
+        typename std::enable_if<std::is_same<CharT, wchar_t>::value, std::wstring>::type
+        transform_impl(collate_level level, const CharT* b, const CharT* e, const winlocale& l)
+        {
+            return normalize_impl(level, b, e, l);
+        }
 
-    class utf16_collator : public collator<wchar_t> {
+        template<typename CharT>
+        typename std::enable_if<sizeof(CharT) >= sizeof(wchar_t) && !std::is_same<CharT, wchar_t>::value,
+                                std::basic_string<CharT>>::type
+        transform_impl(collate_level level, const CharT* b, const CharT* e, const winlocale& l)
+        {
+            const std::wstring wkey = normalize_impl(level, b, e, l);
+            return std::basic_string<CharT>(wkey.begin(), wkey.end());
+        }
+    } // namespace
+
+    template<typename CharT>
+    class utf_collator : public collator<CharT> {
     public:
-        typedef std::collate<wchar_t> wfacet;
-        utf16_collator(winlocale lc, size_t refs = 0) : collator<wchar_t>(refs), lc_(lc) {}
+        using typename collator<CharT>::string_type;
+
+        explicit utf_collator(winlocale lc) : collator<CharT>(), lc_(lc) {}
+
         int do_compare(collate_level level,
-                       const wchar_t* lb,
-                       const wchar_t* le,
-                       const wchar_t* rb,
-                       const wchar_t* re) const override
+                       const CharT* lb,
+                       const CharT* le,
+                       const CharT* rb,
+                       const CharT* re) const override
         {
-            return wcscoll_l(level, lb, le, rb, re, lc_);
+            return compare_impl(level, lb, le, rb, re, lc_);
         }
-        long do_hash(collate_level level, const wchar_t* b, const wchar_t* e) const override
+        long do_hash(collate_level level, const CharT* b, const CharT* e) const override
         {
-            std::wstring key = do_transform(level, b, e);
-            const char* begin = reinterpret_cast<const char*>(key.c_str());
-            const char* end = begin + key.size() * sizeof(wchar_t);
-            return gnu_gettext::pj_winberger_hash_function(begin, end);
+            const std::wstring key = normalize_impl(level, b, e, lc_);
+            return gnu_gettext::pj_winberger_hash_function(reinterpret_cast<const char*>(key.c_str()),
+                                                           reinterpret_cast<const char*>(key.c_str() + key.size()));
         }
-        std::wstring do_transform(collate_level level, const wchar_t* b, const wchar_t* e) const override
+        string_type do_transform(collate_level level, const CharT* b, const CharT* e) const override
         {
-            return wcsxfrm_l(level, b, e, lc_);
+            return transform_impl(level, b, e, lc_);
         }
 
     private:
@@ -108,16 +161,17 @@ namespace boost { namespace locale { namespace impl_win {
         } else {
             switch(type) {
                 case char_facet_t::nochar: break;
-                case char_facet_t::char_f: return std::locale(in, new utf8_collator(lc));
-                case char_facet_t::wchar_f: return std::locale(in, new utf16_collator(lc));
+                case char_facet_t::char_f: return impl::create_collators<char, utf_collator<char>>(in, lc);
+                case char_facet_t::wchar_f: return impl::create_collators<wchar_t, utf_collator<wchar_t>>(in, lc);
 #ifdef __cpp_char8_t
-                case char_facet_t::char8_f: break; // std-facet not available (yet)
+                case char_facet_t::char8_f:
+                    return std::locale(in, new utf_collator<char8_t>(lc)); // std-facet not available (yet)
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-                case char_facet_t::char16_f: break;
+                case char_facet_t::char16_f: return impl::create_collators<char16_t, utf_collator<char16_t>>(in, lc);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR32_T
-                case char_facet_t::char32_f: break;
+                case char_facet_t::char32_f: return impl::create_collators<char32_t, utf_collator<char32_t>>(in, lc);
 #endif
             }
         }

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -247,6 +247,49 @@ void test_install_chartype(const std::string& backendName)
     }
 }
 
+template<typename Char>
+struct dummy_collate : std::collate<Char> {};
+
+template<typename Char>
+bool has_dummy_collate(const std::locale& l)
+{
+    const auto& col = std::use_facet<std::collate<Char>>(l); // Implicitely require existance of std::collate
+    return blt::is_facet<dummy_collate<Char>>(&col);
+}
+
+void test_std_collate_replaced(const std::string& /*backendName*/)
+{
+    std::locale origLocale = std::locale::classic();
+    origLocale = std::locale(origLocale, new dummy_collate<char>);
+    origLocale = std::locale(origLocale, new dummy_collate<wchar_t>);
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    origLocale = std::locale(origLocale, new dummy_collate<char16_t>);
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    origLocale = std::locale(origLocale, new dummy_collate<char32_t>);
+#endif
+
+    // Use ASCII and UTF-8 encoding
+    for(const std::string localeName : {"C", "en_US.UTF-8"}) {
+        std::cout << "--- Locale: " << localeName << std::endl;
+        bl::generator g;
+        g.categories(boost::locale::category_t::collation);
+        const std::locale l = g.generate(origLocale, localeName);
+        TEST(has_dummy_collate<char>(origLocale));
+        TEST(!has_dummy_collate<char>(l));
+        TEST(has_dummy_collate<wchar_t>(origLocale));
+        TEST(!has_dummy_collate<wchar_t>(l));
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+        TEST(has_dummy_collate<char16_t>(origLocale));
+        TEST(!has_dummy_collate<char16_t>(l));
+#endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+        TEST(has_dummy_collate<char32_t>(origLocale));
+        TEST(!has_dummy_collate<char32_t>(l));
+#endif
+    }
+}
+
 void test_main(int /*argc*/, char** /*argv*/)
 {
     {
@@ -320,9 +363,11 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST_HAS_FACETS(std::collate, l);
             if(backendName == "icu" || (backendName == "winapi" && std::use_facet<bl::info>(l).utf8())) {
                 TEST_HAS_FACETS(bl::collator, l);
+                TEST_HAS_FACET_STRING8(bl::collator, l);
             } else {
                 TEST(blt::has_not_facet<bl::collator<char>>(l));
                 TEST(blt::has_not_facet<bl::collator<wchar_t>>(l));
+                TEST_FOR_STRING8(blt::has_not_facet<bl::collator<char8_t>>(l));
                 TEST_FOR_CHAR16(blt::has_not_facet<bl::collator<char16_t>>(l));
                 TEST_FOR_CHAR32(blt::has_not_facet<bl::collator<char32_t>>(l));
             }
@@ -425,6 +470,7 @@ void test_main(int /*argc*/, char** /*argv*/)
         TEST(!std::use_facet<bl::info>(g("en_US.ISO8859-1")).utf8());
 
         test_install_chartype(backendName);
+        test_std_collate_replaced(backendName);
     }
     std::cout << "Test special locales" << std::endl;
     test_special_locales();

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -115,7 +115,7 @@ template<class T>
 using has_ctype = decltype(is_complete_impl(std::declval<std::ctype<T>*>()));
 
 template<typename Char, typename... Ts>
-typename std::enable_if<has_ctype<Char>::value, bool>::type stream_translate(std::basic_ostream<Char>& ss, Ts... args)
+typename std::enable_if<has_ctype<Char>::value, bool>::type stream_translate(std::basic_ostream<Char>& ss, Ts&&... args)
 {
     ss << bl::translate(args...);
     return true;
@@ -124,7 +124,7 @@ typename std::enable_if<has_ctype<Char>::value, bool>::type stream_translate(std
 // Required for char types not fully supported by the standard library
 // e.g.: error: implicit instantiation of undefined template 'std::ctype<char8_t>'
 template<typename Char, typename... Ts>
-typename std::enable_if<!has_ctype<Char>::value, bool>::type stream_translate(std::basic_ostream<Char>&, Ts...)
+typename std::enable_if<!has_ctype<Char>::value, bool>::type stream_translate(std::basic_ostream<Char>&, Ts&&...)
 {
     return false; // LCOV_EXCL_LINE
 }


### PR DESCRIPTION
The class derived from `std::collate` which is always present in `std::locale`.
So checks for the `boost::locale::collator` facet may return wrongly true.

As a fix make this an independent facet with its own ID.
Use an adapter such that a std::collate derived class can use its abilities.

Add tests to detect the issue and verify the fix.

Fixes #215