### PR TITLE
Catch OSX sonoma iconv issue

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -50,8 +50,9 @@ def main(ctx):
     job(compiler='clang',     cxxstd='11,14,17,2a',    os='osx-xcode-12'),
     job(compiler='clang',     cxxstd='11,14,17,20',    os='osx-xcode-12.5.1'),
     job(compiler='clang',     cxxstd='11,14,17,20',    os='osx-xcode-13.4.1'),
-    job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-14.3.1'),
-    job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-15.0.1'),
+    # Don't work yet -> #206 ?
+    # job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-14.3.1'),
+    # job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-15.0.1'),
     # ARM64
     job(compiler='clang-12',  cxxstd='11,14,17,20', os='ubuntu-20.04', arch='arm64', add_llvm=True),
     job(compiler='gcc-11',    cxxstd='11,14,17,20', os='ubuntu-20.04', arch='arm64'),

--- a/.drone.star
+++ b/.drone.star
@@ -50,9 +50,8 @@ def main(ctx):
     job(compiler='clang',     cxxstd='11,14,17,2a',    os='osx-xcode-12'),
     job(compiler='clang',     cxxstd='11,14,17,20',    os='osx-xcode-12.5.1'),
     job(compiler='clang',     cxxstd='11,14,17,20',    os='osx-xcode-13.4.1'),
-    # Don't work yet -> #206 ?
-    # job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-14.3.1'),
-    # job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-15.0.1'),
+    job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-14.3.1'),
+    job(compiler='clang',     cxxstd='11,14,17,20,2b', os='osx-xcode-15.0.1'),
     # ARM64
     job(compiler='clang-12',  cxxstd='11,14,17,20', os='ubuntu-20.04', arch='arm64', add_llvm=True),
     job(compiler='gcc-11',    cxxstd='11,14,17,20', os='ubuntu-20.04', arch='arm64'),

--- a/src/boost/locale/encoding/iconv_converter.hpp
+++ b/src/boost/locale/encoding/iconv_converter.hpp
@@ -74,8 +74,9 @@ namespace boost { namespace locale { namespace conv { namespace impl {
                         } else
                             break;
                     } else if(err == E2BIG) {
-                        BOOST_VERIFY_MSG(in_left != old_in_left || output_count != 0, "No progress, IConv is faulty!");
-                        continue;
+                        if(in_left != old_in_left || out_ptr != out_start) // Check to avoid infinite loop
+                            continue;
+                        throw std::runtime_error("No progress, IConv is faulty!"); // LCOV_EXCL_LINE
                     } else                        // Invalid error code, shouldn't ever happen or iconv has a bug
                         throw conversion_error(); // LCOV_EXCL_LINE
                 }

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -19,6 +19,26 @@ const bool test_iso_8859_8 =
   hasWinCodepage(28598);
 #endif
 
+#if defined(BOOST_LOCALE_WITH_ICONV)
+// Reproduce issue #206 to detect faulty IConv
+static bool isFaultyIconv()
+{
+    namespace blc = boost::locale::conv;
+    auto from_utf = blc::detail::make_utf_decoder<char>("ISO-2022-CN", blc::skip, blc::detail::conv_backend::IConv);
+    try {
+        from_utf->convert("实");
+    } catch(const std::runtime_error& e) {                                         // LCOV_EXCL_LINE
+        return std::string(e.what()).find("IConv is faulty") != std::string::npos; // LCOV_EXCL_LINE
+    }
+    return false;
+}
+#else
+constexpr bool isFaultyIconv()
+{
+    return false;
+}
+#endif
+
 constexpr boost::locale::conv::detail::conv_backend all_conv_backends[] = {
 #ifdef BOOST_LOCALE_WITH_ICONV
   boost::locale::conv::detail::conv_backend::IConv,
@@ -318,10 +338,12 @@ void test_utf_for()
     } catch(const invalid_charset_error&) { // LCOV_EXCL_LINE
         std::cout << "--- not supported\n"; // LCOV_EXCL_LINE
     }
-    // Testing a codepage which may crash with IConv on macOS, see issue #196
-    test_to_from_utf<Char>("\xa1\xad\xa1\xad", utf<Char>("……"), "gbk", false);
-    // This might cause a bogus E2BIG on macOS, see issue #206
-    test_to_from_utf<Char>("\x1b\x24\x29\x41\x0e\x4a\x35\xf", utf<Char>("实"), "ISO-2022-CN", false);
+    if(!isFaultyIconv()) {
+        // Testing a codepage which may crash with IConv on macOS, see issue #196
+        test_to_from_utf<Char>("\xa1\xad\xa1\xad", utf<Char>("……"), "gbk", false);
+        // This might cause a bogus E2BIG on macOS, see issue #206
+        test_to_from_utf<Char>("\x1b\x24\x29\x41\x0e\x4a\x35\xf", utf<Char>("实"), "ISO-2022-CN", false);
+    }
 
     std::cout << "- Testing correct invalid bytes skipping\n";
     {


### PR DESCRIPTION
E2BIG shall be returned if the output buffer is too small.
We pass a 64 byte buffer which should be enough to do *something*

However it is observed on MacOS Sonoma that iconv returns E2BIG without
doing any progress leading to an infinite loop as the same inputs will
be passed over and over.
Instead raise an exception when this case is detected.

Closes #206