### PR TITLE
ICU: Store time in second resolution

### DIFF
--- a/src/boost/locale/icu/date_time.cpp
+++ b/src/boost/locale/icu/date_time.cpp
@@ -63,6 +63,9 @@ namespace boost { namespace locale { namespace impl_icu {
         {
             UErrorCode err = U_ZERO_ERROR;
             calendar_.reset(icu::Calendar::createInstance(dat.locale(), err));
+            // Use accuracy of seconds, see #221
+            const double rounded_time = std::floor(calendar_->getTime(err) / U_MILLIS_PER_SECOND) * U_MILLIS_PER_SECOND;
+            calendar_->setTime(rounded_time, err);
             check_and_throw_dt(err);
 #if BOOST_LOCALE_ICU_VERSION < 402
             // workaround old/invalid data, it should be 4 in general
@@ -121,7 +124,10 @@ namespace boost { namespace locale { namespace impl_icu {
 
         void set_time(const posix_time& p) override
         {
-            double utime = p.seconds * 1000.0 + p.nanoseconds / 1000000.0;
+            // Ignore `p.nanoseconds / 1e6` for simplicity of users as there is no
+            // easy way to set the sub-seconds via `date_time`.
+            // Matches behavior of other backends that only have seconds resolution
+            const double utime = p.seconds * 1e3;
             UErrorCode code = U_ZERO_ERROR;
             calendar_->setTime(utime, code);
             check_and_throw_dt(code);


### PR DESCRIPTION
ICU was the only backend storing subseconds in its calendar and hence reported fractional times in `date_time::time()`
However outside of `date_time::time(floor(time))` there was no way setting those milli/nanoseconds.
This leads to unexpected behavior for comparisons of seemingly identical time points, especially as it depends on the backend.

Closes https://github.com/boostorg/locale/issues/221