### PR TITLE
Add support for custom allocators to boost::locale::conv::utf_to_utf 

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -8,6 +8,9 @@
 /*!
 \page changelog Changelog
 
+- 1.86.0
+    - Make ICU implementation of `to_title` threadsafe
+    - Add allocator support to `utf_to_utf`
 - 1.85.0
     - Breaking changes
         - `collator` does no longer derive from `std::collator` avoiding possible type confusion

--- a/include/boost/locale/detail/allocator_traits.hpp
+++ b/include/boost/locale/detail/allocator_traits.hpp
@@ -16,9 +16,13 @@ namespace boost { namespace locale { namespace conv { namespace detail {
     template<class Alloc, typename T>
     using rebind_alloc = typename std::allocator_traits<Alloc>::template rebind_alloc<T>;
 
-    template<class Alloc, typename T, typename Result>
+    template<class Alloc, typename T, typename Result = void>
     using enable_if_allocator_for =
       typename std::enable_if<std::is_same<typename Alloc::value_type, T>::value, Result>::type;
+    template<class Alloc, typename T, class Alloc2, typename T2, typename Result = void>
+    using enable_if_allocator_for2 = typename std::enable_if<std::is_same<typename Alloc::value_type, T>::value
+                                                               && std::is_same<typename Alloc2::value_type, T2>::value,
+                                                             Result>::type;
 }}}} // namespace boost::locale::conv::detail
 
 /// \endcond

--- a/include/boost/locale/detail/allocator_traits.hpp
+++ b/include/boost/locale/detail/allocator_traits.hpp
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2024 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_DETAIL_ALLOCATOR_TRAITS_HPP_INCLUDED
+#define BOOST_LOCALE_DETAIL_ALLOCATOR_TRAITS_HPP_INCLUDED
+
+#include <boost/locale/config.hpp>
+#include <memory>
+#include <type_traits>
+
+/// \cond INTERNAL
+namespace boost { namespace locale { namespace conv { namespace detail {
+    template<class Alloc, typename T>
+    using rebind_alloc = typename std::allocator_traits<Alloc>::template rebind_alloc<T>;
+
+    template<class Alloc, typename T, typename Result>
+    using enable_if_allocator_for =
+      typename std::enable_if<std::is_same<typename Alloc::value_type, T>::value, Result>::type;
+}}}} // namespace boost::locale::conv::detail
+
+/// \endcond
+
+#endif

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -47,6 +47,15 @@ namespace boost { namespace locale { namespace conv {
         return result;
     }
 
+    /// Convert a Unicode string \a str to other Unicode encoding.
+    /// Invalid characters are skipped.
+    template<typename CharOut, typename CharIn, class Alloc>
+    std::basic_string<CharOut, std::char_traits<CharOut>, Alloc>
+    utf_to_utf(const CharIn* begin, const CharIn* end, const Alloc& alloc)
+    {
+        return utf_to_utf<CharOut>(begin, end, skip, alloc);
+    }
+
     /// Convert a Unicode NULL terminated string \a str to other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
@@ -55,6 +64,14 @@ namespace boost { namespace locale { namespace conv {
     utf_to_utf(const CharIn* str, method_type how = default_method, const Alloc& alloc = Alloc())
     {
         return utf_to_utf<CharOut>(str, util::str_end(str), how, alloc);
+    }
+
+    /// Convert a Unicode string \a str to other Unicode encoding.
+    /// Invalid characters are skipped.
+    template<typename CharOut, typename CharIn, class Alloc>
+    std::basic_string<CharOut, std::char_traits<CharOut>, Alloc> utf_to_utf(const CharIn* str, const Alloc& alloc)
+    {
+        return utf_to_utf<CharOut>(str, skip, alloc);
     }
 
     /// Convert a Unicode string \a str to other Unicode encoding
@@ -95,6 +112,22 @@ namespace boost { namespace locale { namespace conv {
                const AllocOut& alloc = AllocOut())
     {
         return utf_to_utf<CharOut>(str.c_str(), str.c_str() + str.size(), how, alloc);
+    }
+
+    /// Convert a Unicode string \a str to other Unicode encoding.
+    /// Invalid characters are skipped.
+    template<typename CharOut, typename CharIn, class AllocOut, class AllocIn>
+#ifndef BOOST_LOCALE_DOXYGEN
+    detail::enable_if_allocator_for<AllocIn,
+                                    CharIn,
+#endif
+                                    std::basic_string<CharOut, std::char_traits<CharOut>, AllocOut>
+#ifndef BOOST_LOCALE_DOXYGEN
+                                    >
+#endif
+    utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, AllocIn>& str, const AllocOut& alloc)
+    {
+        return utf_to_utf<CharOut>(str, skip, alloc);
     }
 
     /// @}

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -28,7 +28,8 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method, const TAlloc& alloc = TAlloc())
+    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc>
+    utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method, const TAlloc& alloc = TAlloc())
     {
         std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> result(alloc);
         result.reserve(end - begin);
@@ -48,7 +49,8 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> utf_to_utf(const CharIn* str, method_type how = default_method, const TAlloc& alloc = TAlloc())
+    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc>
+    utf_to_utf(const CharIn* str, method_type how = default_method, const TAlloc& alloc = TAlloc())
     {
         return utf_to_utf<CharOut, CharIn, TAlloc>(str, util::str_end(str), how, alloc);
     }
@@ -57,9 +59,18 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, typename TAlloc>
-    typename std::enable_if<std::is_same<CharIn, typename TAlloc::value_type>::value, std::basic_string<CharOut, std::char_traits<CharOut>, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>>::type utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, TAlloc>& str, method_type how = default_method)
+    typename std::enable_if<
+      std::is_same<CharIn, typename TAlloc::value_type>::value,
+      std::basic_string<CharOut,
+                        std::char_traits<CharOut>,
+                        typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>>::type
+    utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, TAlloc>& str, method_type how = default_method)
     {
-        return utf_to_utf<CharOut, CharIn, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>(str.c_str(), str.c_str() + str.size(), how, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>(str.get_allocator()));
+        return utf_to_utf<CharOut, CharIn, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>(
+          str.c_str(),
+          str.c_str() + str.size(),
+          how,
+          typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>(str.get_allocator()));
     }
 
     /// @}

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -47,7 +47,7 @@ namespace boost { namespace locale { namespace conv {
         return result;
     }
 
-    /// Convert a Unicode NULL terminated string \a str other Unicode encoding
+    /// Convert a Unicode NULL terminated string \a str to other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, class Alloc = std::allocator<CharOut>>
@@ -57,7 +57,7 @@ namespace boost { namespace locale { namespace conv {
         return utf_to_utf<CharOut>(str, util::str_end(str), how, alloc);
     }
 
-    /// Convert a Unicode string \a str other Unicode encoding
+    /// Convert a Unicode string \a str to other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, class Alloc>
@@ -78,7 +78,7 @@ namespace boost { namespace locale { namespace conv {
                                    detail::rebind_alloc<Alloc, CharOut>(str.get_allocator()));
     }
 
-    /// Convert a Unicode string \a str other Unicode encoding
+    /// Convert a Unicode string \a str to other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, class AllocOut, class AllocIn>

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -61,10 +61,15 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, class Alloc>
+#ifndef BOOST_LOCALE_DOXYGEN
     detail::enable_if_allocator_for<
       Alloc,
       CharIn,
-      std::basic_string<CharOut, std::char_traits<CharOut>, detail::rebind_alloc<Alloc, CharOut>>>
+#endif
+      std::basic_string<CharOut, std::char_traits<CharOut>, detail::rebind_alloc<Alloc, CharOut>>
+#ifndef BOOST_LOCALE_DOXYGEN
+      >
+#endif
     utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, Alloc>& str, method_type how = default_method)
     {
         return utf_to_utf<CharOut>(str.c_str(),
@@ -77,7 +82,14 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, class AllocOut, class AllocIn>
-    detail::enable_if_allocator_for<AllocIn, CharIn, std::basic_string<CharOut, std::char_traits<CharOut>, AllocOut>>
+#ifndef BOOST_LOCALE_DOXYGEN
+    detail::enable_if_allocator_for<AllocIn,
+                                    CharIn,
+#endif
+                                    std::basic_string<CharOut, std::char_traits<CharOut>, AllocOut>
+#ifndef BOOST_LOCALE_DOXYGEN
+                                    >
+#endif
     utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, AllocIn>& str,
                method_type how = default_method,
                const AllocOut& alloc = AllocOut())

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -11,6 +11,7 @@
 #include <boost/locale/utf.hpp>
 #include <boost/locale/util/string.hpp>
 #include <iterator>
+#include <memory>
 
 #ifdef BOOST_MSVC
 #    pragma warning(push)
@@ -25,12 +26,12 @@ namespace boost { namespace locale { namespace conv {
     /// Convert a Unicode text in range [begin,end) to other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn>
-    std::basic_string<CharOut> utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method)
+    template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
+    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method)
     {
-        std::basic_string<CharOut> result;
+        std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> result;
         result.reserve(end - begin);
-        std::back_insert_iterator<std::basic_string<CharOut>> inserter(result);
+        std::back_insert_iterator<std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc>> inserter(result);
         while(begin != end) {
             const utf::code_point c = utf::utf_traits<CharIn>::decode(begin, end);
             if(c == utf::illegal || c == utf::incomplete) {
@@ -45,19 +46,19 @@ namespace boost { namespace locale { namespace conv {
     /// Convert a Unicode NULL terminated string \a str other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn>
+    template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
     std::basic_string<CharOut> utf_to_utf(const CharIn* str, method_type how = default_method)
     {
-        return utf_to_utf<CharOut, CharIn>(str, util::str_end(str), how);
+        return utf_to_utf<CharOut, CharIn, TAlloc>(str, util::str_end(str), how);
     }
 
     /// Convert a Unicode string \a str other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn>
+    template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
     std::basic_string<CharOut> utf_to_utf(const std::basic_string<CharIn>& str, method_type how = default_method)
     {
-        return utf_to_utf<CharOut, CharIn>(str.c_str(), str.c_str() + str.size(), how);
+        return utf_to_utf<CharOut, CharIn, TAlloc>(str.c_str(), str.c_str() + str.size(), how);
     }
 
     /// @}

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -27,9 +27,9 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method)
+    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method, const TAlloc& alloc = TAlloc())
     {
-        std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> result;
+        std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> result(alloc);
         result.reserve(end - begin);
         std::back_insert_iterator<std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc>> inserter(result);
         while(begin != end) {
@@ -47,18 +47,18 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut> utf_to_utf(const CharIn* str, method_type how = default_method)
+    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> utf_to_utf(const CharIn* str, method_type how = default_method, const TAlloc& alloc = TAlloc())
     {
-        return utf_to_utf<CharOut, CharIn, TAlloc>(str, util::str_end(str), how);
+        return utf_to_utf<CharOut, CharIn, TAlloc>(str, util::str_end(str), how, alloc);
     }
 
     /// Convert a Unicode string \a str other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut> utf_to_utf(const std::basic_string<CharIn>& str, method_type how = default_method)
+    template<typename CharOut, typename CharIn, typename TAlloc>
+    std::basic_string<CharOut, std::char_traits<CharOut>, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>> utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, TAlloc>& str, method_type how = default_method)
     {
-        return utf_to_utf<CharOut, CharIn, TAlloc>(str.c_str(), str.c_str() + str.size(), how);
+        return utf_to_utf<CharOut, CharIn, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>(str.c_str(), str.c_str() + str.size(), how, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>(str.get_allocator()));
     }
 
     /// @}

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -12,6 +12,7 @@
 #include <boost/locale/util/string.hpp>
 #include <iterator>
 #include <memory>
+#include <type_traits>
 
 #ifdef BOOST_MSVC
 #    pragma warning(push)
@@ -56,7 +57,7 @@ namespace boost { namespace locale { namespace conv {
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
     template<typename CharOut, typename CharIn, typename TAlloc>
-    std::basic_string<CharOut, std::char_traits<CharOut>, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>> utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, TAlloc>& str, method_type how = default_method)
+    typename std::enable_if<std::is_same<CharIn, typename TAlloc::value_type>::value, std::basic_string<CharOut, std::char_traits<CharOut>, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>>::type utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, TAlloc>& str, method_type how = default_method)
     {
         return utf_to_utf<CharOut, CharIn, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>>(str.c_str(), str.c_str() + str.size(), how, typename std::allocator_traits<TAlloc>::template rebind_alloc<CharOut>(str.get_allocator()));
     }

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -69,7 +69,15 @@ namespace boost { namespace locale { namespace conv {
     /// Convert a Unicode string \a str to other Unicode encoding.
     /// Invalid characters are skipped.
     template<typename CharOut, typename CharIn, class Alloc>
-    std::basic_string<CharOut, std::char_traits<CharOut>, Alloc> utf_to_utf(const CharIn* str, const Alloc& alloc)
+#ifndef BOOST_LOCALE_DOXYGEN
+    detail::enable_if_allocator_for<Alloc,
+                                    CharOut,
+#endif
+                                    std::basic_string<CharOut, std::char_traits<CharOut>, Alloc>
+#ifndef BOOST_LOCALE_DOXYGEN
+                                    >
+#endif
+    utf_to_utf(const CharIn* str, const Alloc& alloc)
     {
         return utf_to_utf<CharOut>(str, skip, alloc);
     }
@@ -118,12 +126,14 @@ namespace boost { namespace locale { namespace conv {
     /// Invalid characters are skipped.
     template<typename CharOut, typename CharIn, class AllocOut, class AllocIn>
 #ifndef BOOST_LOCALE_DOXYGEN
-    detail::enable_if_allocator_for<AllocIn,
-                                    CharIn,
+    detail::enable_if_allocator_for2<AllocIn,
+                                     CharIn,
+                                     AllocOut,
+                                     CharOut,
 #endif
-                                    std::basic_string<CharOut, std::char_traits<CharOut>, AllocOut>
+                                     std::basic_string<CharOut, std::char_traits<CharOut>, AllocOut>
 #ifndef BOOST_LOCALE_DOXYGEN
-                                    >
+                                     >
 #endif
     utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, AllocIn>& str, const AllocOut& alloc)
     {

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -29,11 +29,11 @@ namespace boost { namespace locale { namespace conv {
     /// Convert a Unicode text in range [begin,end) to other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc>
-    utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method, const TAlloc& alloc = TAlloc())
+    template<typename CharOut, typename CharIn, class Alloc = std::allocator<CharOut>>
+    std::basic_string<CharOut, std::char_traits<CharOut>, Alloc>
+    utf_to_utf(const CharIn* begin, const CharIn* end, method_type how = default_method, const Alloc& alloc = Alloc())
     {
-        std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc> result(alloc);
+        std::basic_string<CharOut, std::char_traits<CharOut>, Alloc> result(alloc);
         result.reserve(end - begin);
         auto inserter = std::back_inserter(result);
         while(begin != end) {
@@ -50,9 +50,9 @@ namespace boost { namespace locale { namespace conv {
     /// Convert a Unicode NULL terminated string \a str other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn, typename TAlloc = std::allocator<CharOut>>
-    std::basic_string<CharOut, std::char_traits<CharOut>, TAlloc>
-    utf_to_utf(const CharIn* str, method_type how = default_method, const TAlloc& alloc = TAlloc())
+    template<typename CharOut, typename CharIn, class Alloc = std::allocator<CharOut>>
+    std::basic_string<CharOut, std::char_traits<CharOut>, Alloc>
+    utf_to_utf(const CharIn* str, method_type how = default_method, const Alloc& alloc = Alloc())
     {
         return utf_to_utf<CharOut>(str, util::str_end(str), how, alloc);
     }
@@ -60,17 +60,17 @@ namespace boost { namespace locale { namespace conv {
     /// Convert a Unicode string \a str other Unicode encoding
     ///
     /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
-    template<typename CharOut, typename CharIn, typename TAlloc>
+    template<typename CharOut, typename CharIn, class Alloc>
     detail::enable_if_allocator_for<
-      TAlloc,
+      Alloc,
       CharIn,
-      std::basic_string<CharOut, std::char_traits<CharOut>, detail::rebind_alloc<TAlloc, CharOut>>>
-    utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, TAlloc>& str, method_type how = default_method)
+      std::basic_string<CharOut, std::char_traits<CharOut>, detail::rebind_alloc<Alloc, CharOut>>>
+    utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, Alloc>& str, method_type how = default_method)
     {
         return utf_to_utf<CharOut>(str.c_str(),
                                    str.c_str() + str.size(),
                                    how,
-                                   detail::rebind_alloc<TAlloc, CharOut>(str.get_allocator()));
+                                   detail::rebind_alloc<Alloc, CharOut>(str.get_allocator()));
     }
 
     /// @}

--- a/include/boost/locale/encoding_utf.hpp
+++ b/include/boost/locale/encoding_utf.hpp
@@ -73,6 +73,18 @@ namespace boost { namespace locale { namespace conv {
                                    detail::rebind_alloc<Alloc, CharOut>(str.get_allocator()));
     }
 
+    /// Convert a Unicode string \a str other Unicode encoding
+    ///
+    /// \throws conversion_error: Conversion failed (e.g. \a how is \c stop and any character cannot be decoded)
+    template<typename CharOut, typename CharIn, class AllocOut, class AllocIn>
+    detail::enable_if_allocator_for<AllocIn, CharIn, std::basic_string<CharOut, std::char_traits<CharOut>, AllocOut>>
+    utf_to_utf(const std::basic_string<CharIn, std::char_traits<CharIn>, AllocIn>& str,
+               method_type how = default_method,
+               const AllocOut& alloc = AllocOut())
+    {
+        return utf_to_utf<CharOut>(str.c_str(), str.c_str() + str.size(), how, alloc);
+    }
+
     /// @}
 
 }}} // namespace boost::locale::conv

--- a/test/boostLocale/test/unit_test.hpp
+++ b/test/boostLocale/test/unit_test.hpp
@@ -164,8 +164,8 @@ void stream_char(std::ostream& s, const Char c)
           << static_cast<unsigned>(c);
 }
 
-template<typename Char>
-std::string to_string(const std::basic_string<Char>& s)
+template<typename Char, class Alloc>
+std::string to_string(const std::basic_string<Char, std::char_traits<Char>, Alloc>& s)
 {
     std::stringstream ss;
     for(const Char c : s)

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -517,12 +517,18 @@ void test_utf_to_utf_allocator_support()
     Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(sBegin, sEnd, method, Alloc(2)), output);
     TEST_EQ(Alloc::usedId, 2);
-    Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(sBegin, method, Alloc(3)), output);
-    TEST_EQ(Alloc::usedId, 3);
-    Alloc::usedId = 0;
+    TEST_EQ(Alloc::usedId, 5);
     TEST_EQ(utf_to_utf<wchar_t>(inputWithAlloc, method, Alloc(4)), output);
-    TEST_EQ(Alloc::usedId, 4);
+    TEST_EQ(Alloc::usedId, 9);
+    // Same with using the default method
+    Alloc::usedId = 0;
+    TEST_EQ(utf_to_utf<wchar_t>(sBegin, sEnd, Alloc(2)), output);
+    TEST_EQ(Alloc::usedId, 2);
+    TEST_EQ(utf_to_utf<wchar_t>(sBegin, Alloc(3)), output);
+    TEST_EQ(Alloc::usedId, 5);
+    TEST_EQ(utf_to_utf<wchar_t>(inputWithAlloc, Alloc(4)), output);
+    TEST_EQ(Alloc::usedId, 9);
 
     // Use allocator from input
     Alloc::usedId = 0;

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -486,7 +486,11 @@ struct CustomAllocator {
 
     T* allocate(size_t n)
     {
-        usedId += id;
+        // Only count allocations of (w)chars, not e.g. internal proxy instances
+        BOOST_LOCALE_START_CONST_CONDITION
+        if(std::is_same<T, char>::value || std::is_same<T, wchar_t>::value)
+            usedId += id;
+        BOOST_LOCALE_END_CONST_CONDITION
         return base.allocate(n);
     }
 
@@ -550,25 +554,30 @@ void test_utf_to_utf_allocator_support()
     Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(sBegin, sEnd, method, Alloc(2)), output);
     TEST_EQ(Alloc::usedId, 2);
+    Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(sBegin, method, Alloc(3)), output);
-    TEST_EQ(Alloc::usedId, 5);
+    TEST_EQ(Alloc::usedId, 3);
+    Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(inputWithAlloc, method, Alloc(4)), output);
-    TEST_EQ(Alloc::usedId, 9);
+    TEST_EQ(Alloc::usedId, 4);
     // Same with using the default method
     Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(sBegin, sEnd, Alloc(2)), output);
     TEST_EQ(Alloc::usedId, 2);
+    Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(sBegin, Alloc(3)), output);
-    TEST_EQ(Alloc::usedId, 5);
+    TEST_EQ(Alloc::usedId, 3);
+    Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(inputWithAlloc, Alloc(4)), output);
-    TEST_EQ(Alloc::usedId, 9);
+    TEST_EQ(Alloc::usedId, 4);
 
     // Use allocator from input
     Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(inputWithAlloc), output);
     TEST_EQ(Alloc::usedId, inputAllocator.id);
+    Alloc::usedId = 0;
     TEST_EQ(utf_to_utf<wchar_t>(inputWithAlloc, method), output);
-    TEST_EQ(Alloc::usedId, inputAllocator.id * 2);
+    TEST_EQ(Alloc::usedId, inputAllocator.id);
 
     // Unchanged allocator for string overloads to check for ambiguous overloads
     AllocIn::usedId = 0;

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -461,6 +461,7 @@ void test_utf_to_utf()
 }
 
 /// Allocator that reports when it has been used in a static variable
+int globalUsedId = 0;
 template<typename T>
 struct CustomAllocator {
     using value_type = T;
@@ -491,7 +492,7 @@ struct CustomAllocator {
 
     void deallocate(T* p, size_t n) { return base.deallocate(p, n); }
 
-    static int usedId;
+    static int& usedId;
     int id;
 
 private:
@@ -508,8 +509,13 @@ bool operator!=(const CustomAllocator<T>&, const CustomAllocator<U>&)
 {
     return false;
 }
+
+namespace detail {
+// Note that using a static class variable does not work due to possible rebinds
+int allocUsedId = 0;
+} // namespace detail
 template<typename T>
-int CustomAllocator<T>::usedId = 0;
+int& CustomAllocator<T>::usedId = detail::allocUsedId;
 
 void test_utf_to_utf_allocator_support()
 {

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -464,6 +464,15 @@ void test_utf_to_utf()
 template<typename T>
 struct CustomAllocator {
     using value_type = T;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using propagate_on_container_move_assignment = std::true_type;
+    using is_always_equal = std::false_type;
+
     template<typename U>
     struct rebind {
         typedef CustomAllocator<U> other;


### PR DESCRIPTION
Add new optional parameter such that the use of custom allocators is supported by `boost::locale::conv::utf_to_utf.`

Based on (stale) PR #231 with

- Fixed formatting
- Add tests
- Allow passing an allocator instance to string overload
- Allow passing allocator instances without passing the method

Closes #231