### PR TITLE
Add test for formatting large (u)int64 numbers

### DIFF
--- a/test/formatting_common.hpp
+++ b/test/formatting_common.hpp
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2024 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/locale/formatting.hpp>
+#include <boost/locale/generator.hpp>
+#include <cstdint>
+#include <limits>
+#include <sstream>
+
+#include "boostLocale/test/tools.hpp"
+#include "boostLocale/test/unit_test.hpp"
+
+
+template<typename CharType>
+void test_format_large_number_by_char(const std::locale& locale)
+{
+    std::basic_ostringstream<CharType> output;
+    output.imbue(locale);
+    output << boost::locale::as::number;
+
+    constexpr int64_t high_signed64 = 9223372036854775807;
+    static_assert(high_signed64 == std::numeric_limits<int64_t>::max());
+
+    empty_stream(output) << high_signed64;
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,775,807"));
+    empty_stream(output) << static_cast<uint64_t>(high_signed64);
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,775,807"));
+    empty_stream(output) << (static_cast<uint64_t>(high_signed64) + 1u);
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,775,808"));
+}
+
+void test_format_large_number()
+{
+    const auto locale = boost::locale::generator{}("en_US.UTF-8");
+
+    std::cout << "Testing char" << std::endl;
+    test_format_large_number_by_char<char>(locale);
+
+    std::cout << "Testing wchar_t" << std::endl;
+    test_format_large_number_by_char<wchar_t>(locale);
+
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    std::cout << "Testing char16_t" << std::endl;
+    test_format_large_number_by_char<char16_t>(locale);
+#endif
+}

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -21,6 +21,7 @@
 
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
+#include "formatting_common.hpp"
 
 const std::string test_locale_name = "en_US";
 std::string message_path = "./";
@@ -928,6 +929,8 @@ void test_main(int argc, char** argv)
     test_manip<char32_t>();
     test_format_class<char32_t>();
 #endif
+
+    test_format_large_number();
 }
 
 // boostinspect:noascii

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -19,6 +19,7 @@
 #endif
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
+#include "formatting_common.hpp"
 
 #ifdef BOOST_LOCALE_NO_POSIX_BACKEND
 // Dummy just to make it compile
@@ -185,6 +186,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST(v == "12345,45" || v == "12 345,45" || v == "12.345,45");
         }
     }
+    test_format_large_number();
 }
 
 // boostinspect:noascii

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -14,6 +14,7 @@
 
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
+#include "formatting_common.hpp"
 
 template<typename CharType, typename RefCharType>
 void test_by_char(const std::locale& l, const std::locale& lreal)
@@ -230,6 +231,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             }
         }
     }
+    test_format_large_number();
 }
 
 // boostinspect:noascii

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -23,6 +23,7 @@
 #include "../src/boost/locale/win32/lcid.hpp"
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
+#include "formatting_common.hpp"
 
 template<typename CharType>
 void test_by_char(const std::locale& l, std::string name, int lcid)
@@ -176,6 +177,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             test_by_char<wchar_t>(l, name, name_lcid.second);
         }
     }
+    test_format_large_number();
     std::cout << "- Testing strftime" << std::endl;
     test_date_time(gen("en_US.UTF-8"));
 }


### PR DESCRIPTION
As reported in #235 formatting the first number which doesn't fit into int64_t anymore fails to add the thousands separators. I.e.:
`9223372036854775807` -> `9,223,372,036,854,775,807`   
`9223372036854775808` -> `9223372036854775808`

Add a test reproducing that that for all backends.