### PR TITLE
Test improvements - Filename and text context

### DIFF
--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -31,10 +31,8 @@ void test_plural_expr_rand(const T& ref, const char* expr)
         const auto n = getRandValue(minVal, maxVal);
         const auto result = ptr(n);
         const auto refResult = ref(n);
-        if(result != refResult) {
-            std::cerr << "Expression: " << expr << "; n=" << n << '\n'; // LCOV_EXCL_LINE
-            TEST_EQ(result, refResult);                                 // LCOV_EXCL_LINE
-        }
+        TEST_CONTEXT("Expression: " << expr << "; n=" << n);
+        TEST_EQ(result, refResult);
     }
 }
 

--- a/test/test_catalog.cpp
+++ b/test/test_catalog.cpp
@@ -47,7 +47,7 @@ void test_plural_expr()
         TEST(ptr);                \
         return ptr;               \
     }()
-#define TEST_EQ_EXPR(expr, rhs) test_eq_impl(COMPILE_PLURAL_EXPR(expr)(0), rhs, expr, __LINE__)
+#define TEST_EQ_EXPR(expr, rhs) test_eq_impl(COMPILE_PLURAL_EXPR(expr)(0), rhs, expr, __FILE__, __LINE__)
     // Number only
     TEST_EQ_EXPR("0", 0);
     TEST_EQ_EXPR("42", 42);

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -53,10 +53,8 @@ void test_codecvt_in_n_m(const cvt_type& cvt, int n, int m)
         std::mbstate_t mb2 = mb;
         std::codecvt_base::result r = cvt.in(mb, from, end, from_next, to, to_end, to_next);
 
-        int count = cvt.length(mb2, from, end, to_end - to);
+        const int count = cvt.length(mb2, from, end, to_end - to);
         TEST_EQ(memcmp(&mb, &mb2, sizeof(mb)), 0);
-        if(count != from_next - from)
-            std::cout << count << " " << from_next - from << std::endl; // LCOV_EXCL_LINE
         TEST_EQ(count, from_next - from);
 
         if(r == cvt_type::partial) {

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -30,7 +30,7 @@
 
 #define TEST_EQ_FMT(t, X)    \
     empty_stream(ss) << (t); \
-    test_eq_impl(ss.str(), X, #t "==" #X, __LINE__)
+    test_eq_impl(ss.str(), X, #t "==" #X, __FILE__, __LINE__)
 
 // Very simple container for a part of the tests. Counts its instances
 struct mock_calendar : public boost::locale::abstract_calendar {

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -832,10 +832,9 @@ void test_simple_encodings()
     const auto encodings = get_simple_encodings();
     for(auto it = encodings.begin(), end = encodings.end(); it != end; ++it) {
         TEST_EQ(normalize_encoding(*it), *it); // Must be normalized
-        const auto it2 = std::find(it + 1, end, *it);
-        TEST(it2 == end);
-        if(it2 != end)
-            std::cerr << "Duplicate entry: " << *it << '\n'; // LCOV_EXCL_LINE
+        TEST_CONTEXT("Entry: " << *it);
+        // Must be unique
+        TEST(std::find(it + 1, end, *it) == end);
     }
     const auto it = std::is_sorted_until(encodings.begin(), encodings.end());
     TEST(it == encodings.end());
@@ -852,10 +851,9 @@ void test_win_codepages()
         auto is_same_win_codepage = [&it](const windows_encoding& rhs) -> bool {
             return it->codepage == rhs.codepage && std::strcmp(it->name, rhs.name) == 0;
         };
-        const auto* it2 = std::find_if(it + 1, end, is_same_win_codepage);
-        TEST(it2 == end);
-        if(it2 != end)
-            std::cerr << "Duplicate entry: " << it->name << ':' << it->codepage << '\n'; // LCOV_EXCL_LINE
+        TEST_CONTEXT("Entry: " << it->name << ':' << it->codepage);
+        // Must be unique
+        TEST(std::find_if(it + 1, end, is_same_win_codepage) == end);
     }
     const auto cmp = [](const windows_encoding& rhs, const windows_encoding& lhs) -> bool { return rhs < lhs.name; };
     const auto* it = std::is_sorted_until(all_windows_encodings, std::end(all_windows_encodings), cmp);

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -300,6 +300,7 @@ void test_parse_fail_impl(std::basic_istringstream<CharType>& ss, int line)
 
 #define TEST_MIN_MAX_POSIX(type)                                                      \
     do {                                                                              \
+        TEST_CONTEXT(#type);                                                          \
         const std::string minval = as_posix_string(std::numeric_limits<type>::min()); \
         const std::string maxval = as_posix_string(std::numeric_limits<type>::max()); \
         TEST_MIN_MAX_FMT(as::posix, type, minval, maxval);                            \
@@ -340,6 +341,7 @@ void test_as_posix(const std::string& e_charset = "UTF-8")
         localization_backend_manager::global(backend);
         for(const std::string name : {"en_US", "ru_RU", "de_DE"}) {
             const std::locale loc = boost::locale::generator{}(name + "." + e_charset);
+            TEST_CONTEXT("Locale " << (name + "." + e_charset));
             TEST_MIN_MAX_POSIX(int16_t);
             TEST_MIN_MAX_POSIX(uint16_t);
 

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -159,17 +159,17 @@ void test_fmt_impl(std::basic_ostringstream<CharType>& ss,
                    const std::basic_string<CharType>& expected,
                    int line)
 {
-    ss << value;
-    test_eq_impl(ss.str(), expected, "", line);
+    test_impl(!!(ss << value), "Formatting failed", __FILE__, line);
+    test_eq_impl(ss.str(), expected, "", __FILE__, line);
 }
 
 template<typename T, typename CharType>
 void test_parse_impl(std::basic_istringstream<CharType>& ss, const T& expected, int line)
 {
     T v;
-    ss >> v >> std::ws;
-    test_eq_impl(v, expected, "v == expected", line);
-    test_eq_impl(ss.eof(), true, "ss.eof()", line);
+    test_impl(!!(ss >> v), "Parsing failed", __FILE__, line);
+    test_eq_impl(v, expected, "v == expected", __FILE__, line);
+    test_eq_impl((ss >> std::ws).eof(), true, "ss.eof()", __FILE__, line);
 }
 
 template<typename T, typename CharType>
@@ -178,8 +178,9 @@ void test_parse_at_impl(std::basic_istringstream<CharType>& ss, const T& expecte
     T v;
     CharType c_at;
     ss >> v >> std::skipws >> c_at;
-    test_eq_impl(v, expected, "v == expected", line);
-    test_eq_impl(c_at, '@', "c_at == @", line);
+    test_impl(!!ss, "Parsing failed", __FILE__, line);
+    test_eq_impl(v, expected, "v == expected", __FILE__, line);
+    test_eq_impl(c_at, '@', "c_at == @", __FILE__, line);
 }
 
 template<typename T, typename CharType>
@@ -187,7 +188,7 @@ void test_parse_fail_impl(std::basic_istringstream<CharType>& ss, int line)
 {
     T v;
     ss >> v;
-    test_eq_impl(ss.fail(), true, "ss.fail()", line);
+    test_eq_impl(ss.fail(), true, "ss.fail()", __FILE__, line);
 }
 
 #define TEST_FMT(manip, value, expected)                                                  \
@@ -641,7 +642,7 @@ void test_format_class_impl(const std::string& fmt_string,
     format_type fmt(std::basic_string<CharType>(fmt_string.begin(), fmt_string.end()));
     fmt % value;
     std::basic_string<CharType> expected_str_loc(to_correct_string<CharType>(expected_str, loc));
-    test_eq_impl(fmt.str(loc), expected_str_loc, ("Format: " + fmt_string).c_str(), line);
+    test_eq_impl(fmt.str(loc), expected_str_loc, ("Format: " + fmt_string).c_str(), __FILE__, line);
 }
 
 template<typename CharType>


### PR DESCRIPTION
To better determine the position of a failed test print the filename in the error message and add support for context-messages:

The first is useful for tests in commonly used headers, the latter in loops over different test inputs