### PR TITLE
Add support for ISO-15924 abbreviation script code to locale_data

### DIFF
--- a/include/boost/locale/util/locale_data.hpp
+++ b/include/boost/locale/util/locale_data.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2023 Alexander Grund
+// Copyright (c) 2023-2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -21,6 +21,7 @@ namespace boost { namespace locale { namespace util {
     /// Holder and parser for locale names/identifiers
     class BOOST_LOCALE_DECL locale_data {
         std::string language_;
+        std::string script_;
         std::string country_;
         std::string encoding_;
         std::string variant_;
@@ -36,6 +37,8 @@ namespace boost { namespace locale { namespace util {
 
         /// Return language (usually 2 lowercase letters, i.e. ISO-639 or 'C')
         const std::string& language() const { return language_; }
+        /// Return the ISO-15924 abbreviation script code if present
+        const std::string& script() const { return script_; }
         /// Return country (usually 2 uppercase letters, i.e. ISO-3166)
         const std::string& country() const { return country_; }
         /// Return encoding/codeset, e.g. ISO8859-1 or UTF-8
@@ -48,12 +51,13 @@ namespace boost { namespace locale { namespace util {
         /// Return iff the encoding is UTF-8
         bool is_utf8() const { return utf8_; }
 
-        /// Parse a locale identifier of the form `[language[_territory][.codeset][@modifier]]`
+        /// Parse a locale identifier of the form `[language[_script][_territory][.codeset][@modifier]]`
         ///
         /// Allows a dash as the delimiter: `[language-territory]`
         /// Return true if the identifier is valid:
         ///   - `language` is given and consists of ASCII letters
-        ///   - `territory`, if given, consists of ASCII letters
+        ///   - `script` is only considered if it consists of exactly 4 ASCII letters
+        ///   - `territory`, if given, consists of ASCII letters (usually ISO-3166)
         ///   - Any field started by a delimiter (`_`, `-`, `.`, `@`) is not empty
         /// Otherwise parsing is aborted. Valid values already parsed stay set, other are defaulted.
         bool parse(const std::string& locale_name);
@@ -65,6 +69,7 @@ namespace boost { namespace locale { namespace util {
     private:
         void reset();
         bool parse_from_lang(const std::string& input);
+        bool parse_from_script(const std::string& input);
         bool parse_from_country(const std::string& input);
         bool parse_from_encoding(const std::string& input);
         bool parse_from_variant(const std::string& input);

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2022-2023 Alexander Grund
+// Copyright (c) 2022-2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -14,6 +14,26 @@
 #include <string>
 
 namespace boost { namespace locale { namespace util {
+    /// Convert uppercase ASCII to lower case, return true if converted
+    static bool make_lower(char& c)
+    {
+        if(is_upper_ascii(c)) {
+            c += 'a' - 'A';
+            return true;
+        } else
+            return false;
+    }
+
+    /// Convert lowercase ASCII to upper case, return true if converted
+    static bool make_upper(char& c)
+    {
+        if(is_lower_ascii(c)) {
+            c += 'A' - 'a';
+            return true;
+        } else
+            return false;
+    }
+
     locale_data::locale_data()
     {
         reset();
@@ -28,6 +48,7 @@ namespace boost { namespace locale { namespace util {
     void locale_data::reset()
     {
         language_ = "C";
+        script_.clear();
         country_.clear();
         encoding_ = "US-ASCII";
         variant_.clear();
@@ -37,6 +58,8 @@ namespace boost { namespace locale { namespace util {
     std::string locale_data::to_string() const
     {
         std::string result = language_;
+        if(!script_.empty())
+            (result += '_') += script_;
         if(!country_.empty())
             (result += '_') += country_;
         if(!encoding_.empty() && !util::are_encodings_equal(encoding_, "US-ASCII"))
@@ -60,13 +83,38 @@ namespace boost { namespace locale { namespace util {
             return false;
         // lowercase ASCII
         for(char& c : tmp) {
-            if(is_upper_ascii(c))
-                c += 'a' - 'A';
-            else if(!is_lower_ascii(c))
+            if(!is_lower_ascii(c) && !make_lower(c))
                 return false;
         }
         if(tmp != "c" && tmp != "posix") // Keep default
             language_ = tmp;
+
+        if(end >= input.size())
+            return true;
+        else if(input[end] == '-' || input[end] == '_')
+            return parse_from_script(input.substr(end + 1));
+        else if(input[end] == '.')
+            return parse_from_encoding(input.substr(end + 1));
+        else {
+            BOOST_ASSERT_MSG(input[end] == '@', "Unexpected delimiter");
+            return parse_from_variant(input.substr(end + 1));
+        }
+    }
+
+    bool locale_data::parse_from_script(const std::string& input)
+    {
+        const auto end = input.find_first_of("-_@.");
+        std::string tmp = input.substr(0, end);
+        // Script is exactly 4 ASCII characters, otherwise it is not present
+        if(tmp.length() != 4)
+            return parse_from_country(input);
+
+        for(char& c : tmp) {
+            if(!is_lower_ascii(c) && !make_lower(c))
+                return parse_from_country(input);
+        }
+        make_upper(tmp[0]); // Capitalize first letter only
+        script_ = tmp;
 
         if(end >= input.size())
             return true;
@@ -91,10 +139,9 @@ namespace boost { namespace locale { namespace util {
             return false;
 
         // Make uppercase
-        for(char& c : tmp) {
-            if(util::is_lower_ascii(c))
-                c += 'A' - 'a';
-        }
+        for(char& c : tmp)
+            make_upper(c);
+
         // If it's ALL uppercase ASCII, assume ISO 3166 country id
         if(std::find_if_not(tmp.begin(), tmp.end(), util::is_upper_ascii) != tmp.end()) {
             // else handle special cases:
@@ -142,20 +189,16 @@ namespace boost { namespace locale { namespace util {
             return false;
         variant_ = input;
         // No assumptions, just make it lowercase
-        for(char& c : variant_) {
-            if(util::is_upper_ascii(c))
-                c += 'a' - 'A';
-        }
+        for(char& c : variant_)
+            make_lower(c);
         return true;
     }
 
     locale_data& locale_data::encoding(std::string new_encoding, const bool uppercase)
     {
         if(uppercase) {
-            for(char& c : new_encoding) {
-                if(util::is_lower_ascii(c))
-                    c += 'A' - 'a';
-            }
+            for(char& c : new_encoding)
+                make_upper(c);
         }
         encoding_ = std::move(new_encoding);
         utf8_ = util::normalize_encoding(encoding_) == "utf8";


### PR DESCRIPTION
The value is (currently) ignored but this allows to parse locale names returned by ICU.