### PR TITLE
Implement support for uint64_t values in ICU backend 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
       - name: Test output
         if: '!matrix.coverity && always()'
         run: |
-          for f in $(find "$BOOST_ROOT/bin.v2/libs/$SELF/test" -type f -name 'test_*.run'); do
+          for f in $(find "$BOOST_ROOT/bin.v2/libs/$SELF/test" -type f -name '*.run'); do
               name=$(basename "$f")
               name=${name%.run}
               config=$(dirname "$f")

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,6 +1,6 @@
 # Copyright 2003 John Maddock
 # Copyright 2010 Artyom Beilis
-# Copyright 2021 - 2022 Alexander Grund
+# Copyright 2021 - 2024 Alexander Grund
 #
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt.

--- a/src/icu/formatter.cpp
+++ b/src/icu/formatter.cpp
@@ -14,8 +14,9 @@
 #include "time_zone.hpp"
 #include "uconv.hpp"
 #include <boost/assert.hpp>
-#include <boost/charconv/from_chars.hpp>
+#include <boost/charconv/detail/parser.hpp>
 #include <boost/charconv/to_chars.hpp>
+#include <array>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -37,6 +38,30 @@
 namespace boost { namespace locale { namespace impl_icu {
 
     namespace {
+
+        // Create lookup table where: powers_of_10[i] == 10**i
+        constexpr uint64_t pow10(unsigned exponent)
+        {
+            return (exponent == 0) ? 1 : pow10(exponent - 1) * 10u;
+        }
+        template<bool condition, std::size_t Length>
+        using array_if_true = typename std::enable_if<condition, std::array<uint64_t, Length>>::type;
+
+        template<std::size_t Length, typename... Values>
+        constexpr array_if_true<sizeof...(Values) == Length, Length> make_powers_of_10(Values... values)
+        {
+            return {values...};
+        }
+        template<std::size_t Length, typename... Values>
+        constexpr array_if_true<sizeof...(Values) < Length, Length> make_powers_of_10(Values... values)
+        {
+            return make_powers_of_10<Length>(values..., pow10(sizeof...(Values)));
+        }
+        constexpr auto powers_of_10 = make_powers_of_10<std::numeric_limits<uint64_t>::digits10 + 1>();
+        static_assert(powers_of_10[0] == 1u, "!");
+        static_assert(powers_of_10[1] == 10u, "!");
+        static_assert(powers_of_10[5] == 100000u, "!");
+
         // Set the min/max fraction digits for the NumberFormat
         void set_fraction_digits(icu::NumberFormat& nf, const std::ios_base::fmtflags how, std::streamsize precision)
         {
@@ -80,6 +105,7 @@ namespace boost { namespace locale { namespace impl_icu {
             char buffer[std::numeric_limits<uint64_t>::digits10 + 2];
             auto res = boost::charconv::to_chars(buffer, std::end(buffer), value);
             BOOST_ASSERT(res);
+            BOOST_ASSERT(res.ptr < std::end(buffer));
             *res.ptr = '\0'; // ICU expects a NULL-terminated string even for the StringPiece
             icu::UnicodeString tmp;
             UErrorCode err = U_ZERO_ERROR;
@@ -120,8 +146,26 @@ namespace boost { namespace locale { namespace impl_icu {
             const auto decimals = fmt.getDecimalNumber(err);
             if(U_FAILURE(err))
                 return false; // Not a number
-            const auto res = boost::charconv::from_chars({decimals.data(), static_cast<size_t>(decimals.length())}, v);
-            return static_cast<bool>(res);
+
+            // Parse raw value as ICU might return 9223372036854775810 as 9.22337203685477581E+18
+            uint64_t sig;
+            int32_t exp;
+            bool sign;
+            const char* end_decimal = decimals.data() + decimals.length();
+            const auto res = boost::charconv::detail::parser(decimals.data(), end_decimal, sign, sig, exp);
+            // The ICU value should always be valid
+            BOOST_ASSERT_MSG(res, "Failed to parse integer representation of ICU");
+            BOOST_ASSERT_MSG(res.ptr == end_decimal, "Did not fully parse integer representation of ICU");
+            BOOST_ASSERT_MSG(exp >= 0, "ICU truncated parsed integer");
+            // Gracefully handle if it is not the case, i.e. likely a bug in ICU
+            if(BOOST_UNLIKELY(!res || res.ptr != end_decimal || exp < 0))
+                return false; // LCOV_EXCL_LINE
+            if(sign)          // Negative value
+                return false;
+            if(exp >= powers_of_10.size())
+                return false; // Out of range
+            v = sig * powers_of_10[exp];
+            return true;
         }
 
         bool get_value(int32_t& v, icu::Formattable& fmt) const

--- a/src/icu/formatter.cpp
+++ b/src/icu/formatter.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2021-2023 Alexander Grund
+// Copyright (c) 2021-2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -13,8 +13,12 @@
 #include "icu_util.hpp"
 #include "time_zone.hpp"
 #include "uconv.hpp"
+#include <boost/assert.hpp>
+#include <boost/charconv/from_chars.hpp>
+#include <boost/charconv/to_chars.hpp>
 #include <limits>
 #include <memory>
+#include <sstream>
 #ifdef BOOST_MSVC
 #    pragma warning(push)
 #    pragma warning(disable : 4251) // "identifier" : class "type" needs to have dll-interface...
@@ -62,35 +66,69 @@ namespace boost { namespace locale { namespace impl_icu {
         string_type format(int64_t value, size_t& code_points) const override { return do_format(value, code_points); }
         string_type format(int32_t value, size_t& code_points) const override { return do_format(value, code_points); }
         size_t parse(const string_type& str, double& value) const override { return do_parse(str, value); }
+        size_t parse(const string_type& str, uint64_t& value) const override { return do_parse(str, value); }
         size_t parse(const string_type& str, int64_t& value) const override { return do_parse(str, value); }
         size_t parse(const string_type& str, int32_t& value) const override { return do_parse(str, value); }
+
+        string_type format(const uint64_t value, size_t& code_points) const override
+        {
+            // ICU only supports int64_t as the largest integer type
+            if(value <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+                return format(static_cast<int64_t>(value), code_points);
+
+            // Fallback to using a StringPiece (decimal number) as input
+            char buffer[std::numeric_limits<uint64_t>::digits10 + 2];
+            auto res = boost::charconv::to_chars(buffer, std::end(buffer), value);
+            BOOST_ASSERT(res);
+            *res.ptr = '\0'; // ICU expects a NULL-terminated string even for the StringPiece
+            icu::UnicodeString tmp;
+            UErrorCode err = U_ZERO_ERROR;
+            icu_fmt_.format(icu::StringPiece(buffer, res.ptr - buffer), tmp, nullptr, err);
+            check_and_throw_icu_error(err);
+            code_points = tmp.countChar32();
+            return cvt_.std(tmp);
+        }
 
     private:
         bool get_value(double& v, icu::Formattable& fmt) const
         {
             UErrorCode err = U_ZERO_ERROR;
             v = fmt.getDouble(err);
-            if(U_FAILURE(err))
-                return false;
-            return true;
+            return U_SUCCESS(err);
         }
 
         bool get_value(int64_t& v, icu::Formattable& fmt) const
         {
             UErrorCode err = U_ZERO_ERROR;
             v = fmt.getInt64(err);
+            return U_SUCCESS(err);
+        }
+
+        bool get_value(uint64_t& v, icu::Formattable& fmt) const
+        {
+            UErrorCode err = U_ZERO_ERROR;
+            // ICU only supports int64_t as the largest integer type
+            const int64_t tmp = fmt.getInt64(err);
+            if(U_SUCCESS(err)) {
+                if(tmp < 0)
+                    return false;
+                v = static_cast<uint64_t>(tmp);
+                return true;
+            }
+            // Get value as a decimal number and parse that
+            err = U_ZERO_ERROR;
+            const auto decimals = fmt.getDecimalNumber(err);
             if(U_FAILURE(err))
-                return false;
-            return true;
+                return false; // Not a number
+            const auto res = boost::charconv::from_chars({decimals.data(), static_cast<size_t>(decimals.length())}, v);
+            return static_cast<bool>(res);
         }
 
         bool get_value(int32_t& v, icu::Formattable& fmt) const
         {
             UErrorCode err = U_ZERO_ERROR;
             v = fmt.getLong(err);
-            if(U_FAILURE(err))
-                return false;
-            return true;
+            return U_SUCCESS(err);
         }
 
         template<typename ValueType>
@@ -114,14 +152,11 @@ namespace boost { namespace locale { namespace impl_icu {
             icu_fmt_.setParseIntegerOnly(std::is_integral<ValueType>::value && isNumberOnly_);
             icu_fmt_.parse(tmp, val, pp);
 
-            ValueType tmp_v;
-
-            if(pp.getIndex() == 0 || !get_value(tmp_v, val))
+            if(pp.getIndex() == 0 || !get_value(v, val))
                 return 0;
             size_t cut = cvt_.cut(tmp, str.data(), str.data() + str.size(), pp.getIndex());
             if(cut == 0)
                 return 0;
-            v = tmp_v;
             return cut;
         }
 
@@ -136,11 +171,11 @@ namespace boost { namespace locale { namespace impl_icu {
         typedef std::basic_string<CharType> string_type;
 
         string_type format(double value, size_t& code_points) const override { return do_format(value, code_points); }
+        string_type format(uint64_t value, size_t& code_points) const override { return do_format(value, code_points); }
         string_type format(int64_t value, size_t& code_points) const override { return do_format(value, code_points); }
-
         string_type format(int32_t value, size_t& code_points) const override { return do_format(value, code_points); }
-
         size_t parse(const string_type& str, double& value) const override { return do_parse(str, value); }
+        size_t parse(const string_type& str, uint64_t& value) const override { return do_parse(str, value); }
         size_t parse(const string_type& str, int64_t& value) const override { return do_parse(str, value); }
         size_t parse(const string_type& str, int32_t& value) const override { return do_parse(str, value); }
 

--- a/src/icu/formatter.hpp
+++ b/src/icu/formatter.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -31,6 +32,8 @@ namespace boost { namespace locale { namespace impl_icu {
         /// Format the value and return the number of Unicode code points
         virtual string_type format(double value, size_t& code_points) const = 0;
         /// Format the value and return the number of Unicode code points
+        virtual string_type format(uint64_t value, size_t& code_points) const = 0;
+        /// Format the value and return the number of Unicode code points
         virtual string_type format(int64_t value, size_t& code_points) const = 0;
         /// Format the value and return the number of Unicode code points
         virtual string_type format(int32_t value, size_t& code_points) const = 0;
@@ -38,6 +41,9 @@ namespace boost { namespace locale { namespace impl_icu {
         /// Parse the string and return the number of used characters. If it returns 0
         /// then parsing failed.
         virtual size_t parse(const string_type& str, double& value) const = 0;
+        /// Parse the string and return the number of used characters. If it returns 0
+        /// then parsing failed.
+        virtual size_t parse(const string_type& str, uint64_t& value) const = 0;
         /// Parse the string and return the number of used characters. If it returns 0
         /// then parsing failed.
         virtual size_t parse(const string_type& str, int64_t& value) const = 0;

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -10,6 +10,12 @@
 #include <boost/locale/config.hpp>
 #include <boost/charconv/from_chars.hpp>
 #include <boost/core/detail/string_view.hpp>
+#include <algorithm>
+#include <array>
+#include <type_traits>
+#ifdef BOOST_LOCALE_WITH_ICU
+#    include <unicode/fmtable.h>
+#endif
 
 namespace boost { namespace locale { namespace util {
 
@@ -24,6 +30,80 @@ namespace boost { namespace locale { namespace util {
         const auto res = boost::charconv::from_chars(s, value);
         return res && res.ptr == (s.data() + s.size());
     }
+
+    /// Parse a string in scientific format to an integer.
+    /// In particular the "E notation" is used.
+    /// I.e. "\d.\d+E\d+", e.g. 5.12E3 == 5120; 5E2 == 500; 2E+1 == 20)
+    /// Additionally plain integers are recognized.
+    template<typename Integer>
+    bool try_scientific_to_int(const core::string_view s, Integer& value)
+    {
+        static_assert(std::is_integral<Integer>::value && std::is_unsigned<Integer>::value,
+                      "Must be an  unsigned integer");
+        if(s.size() < 3) // At least: iEj for E notation
+            return try_to_int(s, value);
+        if(s[0] == '-')
+            return false;
+        constexpr auto maxDigits = std::numeric_limits<Integer>::digits10 + 1;
+        std::array<char, maxDigits> buffer;
+        // Convert to a regular integer string without exponent or fractional
+        core::string_view string_value;
+
+        const auto expPos = s.find('E', 1);
+        if(s[1] == '.') { // "Shift" the dot to right according to exponent
+            int8_t exponent;
+            if(BOOST_UNLIKELY(expPos == core::string_view::npos || !try_to_int(s.substr(expPos + 1), exponent)))
+                return false;
+            const auto numSignificantDigits = expPos - 1; // Exclude dot
+            const auto numDigits = exponent + 1u;         // E0 -> 1 digit
+            if(BOOST_UNLIKELY(exponent < 0 || numDigits < numSignificantDigits))
+                return false; // Fractional
+            else if(BOOST_UNLIKELY(numDigits > maxDigits))
+                return false; // Too large
+
+            // Copy to buffer excluding dot
+            buffer[0] = s[0];
+            const auto bufPos = std::copy(s.begin() + 2, s.begin() + expPos, buffer.begin() + 1);
+            std::fill(bufPos, buffer.begin() + numDigits, '0');
+            string_value = core::string_view(buffer.data(), numDigits);
+        } else { // Pad with zeros according to exponent
+            if(expPos == core::string_view::npos)
+                return try_to_int(s, value); // Shortcut: Regular integer
+            const core::string_view significant = s.substr(0, expPos);
+            int8_t exponent;
+            if(BOOST_UNLIKELY(!try_to_int(s.substr(expPos + 1), exponent)))
+                return false;
+            else if(BOOST_UNLIKELY(exponent < 0))
+                return false; // Fractional
+            else if(BOOST_UNLIKELY(exponent == 0))
+                string_value = significant;
+            else {
+                const auto numDigits = significant.size() + exponent;
+                if(BOOST_UNLIKELY(numDigits > maxDigits))
+                    return false; // Too large
+                else {
+                    const auto bufPos = std::copy(significant.begin(), significant.end(), buffer.begin());
+                    std::fill(bufPos, buffer.begin() + numDigits, '0');
+                    string_value = core::string_view(buffer.data(), numDigits);
+                }
+            }
+        }
+        return try_to_int(string_value, value);
+    }
+
+#ifdef BOOST_LOCALE_WITH_ICU
+    template<typename Integer>
+    bool try_parse_icu(icu::Formattable& fmt, Integer& value)
+    {
+        // Get value as a decimal number and parse that
+        UErrorCode err = U_ZERO_ERROR;
+        const auto decimals = fmt.getDecimalNumber(err);
+        if(U_FAILURE(err))
+            return false; // Not a number
+        const core::string_view s(decimals.data(), decimals.length());
+        return try_scientific_to_int(s, value);
+    }
+#endif
 }}} // namespace boost::locale::util
 
 #endif

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -131,11 +131,13 @@ namespace boost { namespace locale { namespace util {
     template<typename Integer>
     bool try_parse_icu(icu::Formattable& fmt, Integer& value)
     {
+        if(!fmt.isNumeric())
+            return false;
         // Get value as a decimal number and parse that
         UErrorCode err = U_ZERO_ERROR;
         const auto decimals = fmt.getDecimalNumber(err);
         if(U_FAILURE(err))
-            return false; // Not a number
+            return false; // Memory error LCOV_EXCL_LINE
         const core::string_view s(decimals.data(), decimals.length());
         return try_scientific_to_int(s, value);
     }

--- a/test/formatting_common.hpp
+++ b/test/formatting_common.hpp
@@ -93,3 +93,39 @@ void test_parse_multi_number()
 #undef BOOST_LOCALE_CALL
 #undef BOOST_LOCALE_CALL_I
 }
+
+template<typename CharType>
+void test_format_large_number_by_char(const std::locale& locale)
+{
+    std::basic_ostringstream<CharType> output;
+    output.imbue(locale);
+    output << boost::locale::as::number;
+
+    constexpr int64_t high_signed64 = 9223372036854775807;
+    static_assert(high_signed64 == std::numeric_limits<int64_t>::max(), "Value must match");
+
+    empty_stream(output) << high_signed64;
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,775,807"));
+    empty_stream(output) << static_cast<uint64_t>(high_signed64);
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,775,807"));
+    empty_stream(output) << (static_cast<uint64_t>(high_signed64) + 1u);
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,775,808"));
+    empty_stream(output) << (static_cast<uint64_t>(high_signed64) + 579u);
+    TEST_EQ(output.str(), ascii_to<CharType>("9,223,372,036,854,776,386"));
+}
+
+void test_format_large_number()
+{
+    const auto locale = boost::locale::generator{}("en_US.UTF-8");
+
+    std::cout << "Testing char" << std::endl;
+    test_format_large_number_by_char<char>(locale);
+
+    std::cout << "Testing wchar_t" << std::endl;
+    test_format_large_number_by_char<wchar_t>(locale);
+
+#ifdef BOOST_LOCALE_ENABLE_CHAR16_T
+    std::cout << "Testing char16_t" << std::endl;
+    test_format_large_number_by_char<char16_t>(locale);
+#endif
+}

--- a/test/formatting_common.hpp
+++ b/test/formatting_common.hpp
@@ -75,18 +75,19 @@ void test_parse_multi_number()
 {
     const auto locale = boost::locale::generator{}("en_US.UTF-8");
 
-#define BOOST_LOCALE_CALL_I(T, I)      \
-    std::cout << "\t" #I << std::endl; \
-    test_parse_multi_number_by_char<T, I>(locale);
+#define BOOST_LOCALE_CALL_I(T, I)                      \
+    {                                                  \
+        TEST_CONTEXT("type" #T << ':' << #I);          \
+        test_parse_multi_number_by_char<T, I>(locale); \
+    }
 
-#define BOOST_LOCALE_CALL(T)                                 \
-    std::cout << "test_parse_multi_number " #T << std::endl; \
-    BOOST_LOCALE_CALL_I(T, int16_t);                         \
-    BOOST_LOCALE_CALL_I(T, uint16_t);                        \
-    BOOST_LOCALE_CALL_I(T, int32_t);                         \
-    BOOST_LOCALE_CALL_I(T, uint32_t);                        \
-    BOOST_LOCALE_CALL_I(T, int64_t);                         \
-    BOOST_LOCALE_CALL_I(T, uint64_t);
+#define BOOST_LOCALE_CALL(T)         \
+    BOOST_LOCALE_CALL_I(T, int16_t)  \
+    BOOST_LOCALE_CALL_I(T, uint16_t) \
+    BOOST_LOCALE_CALL_I(T, int32_t)  \
+    BOOST_LOCALE_CALL_I(T, uint32_t) \
+    BOOST_LOCALE_CALL_I(T, int64_t)  \
+    BOOST_LOCALE_CALL_I(T, uint64_t)
 
     BOOST_LOCALE_CALL(char);
     BOOST_LOCALE_CALL(wchar_t);
@@ -118,14 +119,19 @@ void test_format_large_number()
 {
     const auto locale = boost::locale::generator{}("en_US.UTF-8");
 
-    std::cout << "Testing char" << std::endl;
-    test_format_large_number_by_char<char>(locale);
+#define BOOST_LOCALE_CALL(T)                         \
+    {                                                \
+        TEST_CONTEXT("type " << #T);                 \
+        test_format_large_number_by_char<T>(locale); \
+    }
 
-    std::cout << "Testing wchar_t" << std::endl;
-    test_format_large_number_by_char<wchar_t>(locale);
-
+    BOOST_LOCALE_CALL(char);
+    BOOST_LOCALE_CALL(wchar_t);
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
-    std::cout << "Testing char16_t" << std::endl;
-    test_format_large_number_by_char<char16_t>(locale);
+    BOOST_LOCALE_CALL(char16_t);
 #endif
+#ifdef BOOST_LOCALE_ENABLE_CHAR32_T
+    BOOST_LOCALE_CALL(char32_t);
+#endif
+#undef BOOST_LOCALE_CALL
 }

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -67,8 +67,6 @@ void test_main(int /*argc*/, char** /*argv*/)
     std::cout << "- std::basic_string<char8_t>: ";
 #ifdef __cpp_lib_char8_t
     std::cout << "yes\n";
-#elif defined(__cpp_lib_char8_t)
-    std::cout << "partial\n";
 #else
     std::cout << "no\n";
 #endif

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -891,6 +891,7 @@ void test_main(int argc, char** argv)
     test_format_class<char32_t>();
 #endif
 
+    test_format_large_number();
     test_parse_multi_number();
 }
 

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -412,6 +412,7 @@ void test_manip(std::string e_charset = "UTF-8")
     TEST_PARSE_FAILS(as::percent, "1", double);
 
     TEST_FMT_PARSE_1(as::currency, 1345, "$1,345.00");
+    TEST_FMT_PARSE_1(as::currency, uint64_t(1345), "$1,345.00");
     TEST_FMT_PARSE_1(as::currency, 1345.34, "$1,345.34");
 
     TEST_PARSE_FAILS(as::currency, "$", double);
@@ -434,6 +435,7 @@ void test_manip(std::string e_charset = "UTF-8")
     TEST_FMT_PARSE_3_2(as::date, as::date_medium, as::gmt, a_datetime, "Feb 5, 1970", a_date);
     TEST_FMT_PARSE_3_2(as::date, as::date_long, as::gmt, a_datetime, "February 5, 1970", a_date);
     TEST_FMT_PARSE_3_2(as::date, as::date_full, as::gmt, a_datetime, "Thursday, February 5, 1970", a_date);
+    TEST_FMT_PARSE_2_2(as::date, as::gmt, uint64_t(a_datetime), "Feb 5, 1970", uint64_t(a_date));
 
     TEST_PARSE_FAILS(as::date >> as::date_short, "aa/bb/cc", double);
 
@@ -886,7 +888,7 @@ void test_uint64_format()
         icu::UnicodeString s;
         fmt->format(short_value, s, nullptr, err);
         if(U_FAILURE(err))
-            continue;
+            continue; // LCOV_EXCL_LINE
         const std::string icu_value = boost::locale::conv::utf_to_utf<char>(s.getBuffer(), s.getBuffer() + s.length());
         std::stringstream ss;
         ss.imbue(g(cur_locale->getName() + utf8));
@@ -897,9 +899,10 @@ void test_uint64_format()
 
         // Assumption: Either both the int32 and uint64 values are in POSIX format, or neither are
         // This is the case if separators are used and/or numbers are not ASCII
+        // All languages likely use separators so not running into the POSIX case is OK.
         empty_stream(ss) << value;
         if(icu_value == posix_short_value)
-            TEST_EQ(ss.str(), posix_value);
+            TEST_EQ(ss.str(), posix_value); // LCOV_EXCL_LINE
         else
             TEST_NE(ss.str(), posix_value);
 

--- a/test/test_formatting.cpp
+++ b/test/test_formatting.cpp
@@ -380,18 +380,22 @@ void test_manip(std::string e_charset = "UTF-8")
     TEST_MIN_MAX(int16_t, "-32,768", "32,767");
     TEST_MIN_MAX(uint16_t, "0", "65,535");
     TEST_PARSE_FAILS(as::number, "-1", uint16_t);
+    TEST_PARSE_FAILS(as::number, "-32,767", uint16_t);
     if(stdlib_correctly_errors_on_out_of_range_int16())
         TEST_PARSE_FAILS(as::number, "65,535", int16_t);
 
     TEST_MIN_MAX(int32_t, "-2,147,483,648", "2,147,483,647");
     TEST_MIN_MAX(uint32_t, "0", "4,294,967,295");
     TEST_PARSE_FAILS(as::number, "-1", uint32_t);
+    TEST_PARSE_FAILS(as::number, "-2,147,483,647", uint32_t);
     TEST_PARSE_FAILS(as::number, "4,294,967,295", int32_t);
 
     TEST_MIN_MAX(int64_t, "-9,223,372,036,854,775,808", "9,223,372,036,854,775,807");
-    // ICU does not support uint64, but we have a fallback to format it at least
-    TEST_MIN_MAX_FMT(as::number, uint64_t, "0", "18446744073709551615");
+    TEST_MIN_MAX(uint64_t, "0", "18,446,744,073,709,551,615");
     TEST_PARSE_FAILS(as::number, "-1", uint64_t);
+    TEST_PARSE_FAILS(as::number, "-9,223,372,036,854,775,807", uint64_t);
+    TEST_PARSE_FAILS(as::number, "18,446,744,073,709,551,615", int64_t);
+    TEST_PARSE_FAILS(as::number, "18,446,744,073,709,551,616", uint64_t);
 
     TEST_FMT_PARSE_3(as::number, std::left, std::setw(3), 15, "15 ");
     TEST_FMT_PARSE_3(as::number, std::right, std::setw(3), 15, " 15");
@@ -857,6 +861,55 @@ void test_format_class(std::string charset = "UTF-8")
     TEST_FORMAT_CLS("{1,gmt,ftime='%D'}", a_datetime, "12/31/13");
 }
 
+/// Test formatting and parsing of uint64_t values that are not natively supported by ICU.
+/// They use a custom code path which gets exercised by this.
+void test_uint64_format()
+{
+#ifdef BOOST_LOCALE_WITH_ICU
+    std::set<std::string> tested_langs;
+    int32_t count;
+    auto* cur_locale = icu::Locale::getAvailableLocales(count);
+    constexpr uint64_t value = std::numeric_limits<int64_t>::max() + uint64_t(3);
+    const std::string posix_value = as_posix_string(value);
+    constexpr int32_t short_value = std::numeric_limits<int32_t>::max();
+    const std::string posix_short_value = as_posix_string(short_value);
+    boost::locale::generator g;
+    const std::string utf8 = ".UTF-8";
+    // Test with each language supported by ICU to ensure the implementation really
+    // is independent of the language and doesn't fail e.g. for different separators.
+    for(int i = 0; i < count; i++, cur_locale++) {
+        if(!tested_langs.insert(cur_locale->getLanguage()).second)
+            continue;
+        TEST_CONTEXT(cur_locale->getName());
+        UErrorCode err{};
+        std::unique_ptr<icu::NumberFormat> fmt{icu::NumberFormat::createInstance(*cur_locale, err)};
+        icu::UnicodeString s;
+        fmt->format(short_value, s, nullptr, err);
+        if(U_FAILURE(err))
+            continue;
+        const std::string icu_value = boost::locale::conv::utf_to_utf<char>(s.getBuffer(), s.getBuffer() + s.length());
+        std::stringstream ss;
+        ss.imbue(g(cur_locale->getName() + utf8));
+        ss << boost::locale::as::number;
+        // Sanity check
+        ss << short_value;
+        TEST_EQ(ss.str(), icu_value);
+
+        // Assumption: Either both the int32 and uint64 values are in POSIX format, or neither are
+        // This is the case if separators are used and/or numbers are not ASCII
+        empty_stream(ss) << value;
+        if(icu_value == posix_short_value)
+            TEST_EQ(ss.str(), posix_value);
+        else
+            TEST_NE(ss.str(), posix_value);
+
+        uint64_t parsed_value{};
+        TEST(ss >> parsed_value);
+        TEST_EQ(parsed_value, value);
+    }
+#endif
+}
+
 BOOST_LOCALE_DISABLE_UNREACHABLE_CODE_WARNING
 void test_main(int argc, char** argv)
 {
@@ -867,6 +920,8 @@ void test_main(int argc, char** argv)
     std::cout << "ICU is not build... Skipping\n";
     return;
 #endif
+    test_uint64_format();
+
     boost::locale::time_zone::global("GMT+4:00");
     std::cout << "Testing char, UTF-8" << std::endl;
     test_manip<char>();

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -186,6 +186,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST(v == "12345,45" || v == "12 345,45" || v == "12.345,45");
         }
     }
+    test_format_large_number();
     test_parse_multi_number();
 }
 

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -186,8 +186,10 @@ void test_main(int /*argc*/, char** /*argv*/)
             TEST(v == "12345,45" || v == "12 345,45" || v == "12.345,45");
         }
     }
-    test_format_large_number();
-    test_parse_multi_number();
+    if(has_posix_locale("en_US.UTF-8")) {
+        test_format_large_number();
+        test_parse_multi_number();
+    }
 }
 
 // boostinspect:noascii

--- a/test/test_std_formatting.cpp
+++ b/test/test_std_formatting.cpp
@@ -233,8 +233,10 @@ void test_main(int /*argc*/, char** /*argv*/)
     }
     // Std backend silently falls back to the C locale when the locale is not supported
     // which breaks the test assumptions
-    if(has_std_locale("en_US.UTF-8"))
+    if(has_std_locale("en_US.UTF-8")) {
+        test_format_large_number();
         test_parse_multi_number();
+    }
 }
 
 // boostinspect:noascii

--- a/test/test_util_numeric_convert.cpp
+++ b/test/test_util_numeric_convert.cpp
@@ -91,7 +91,7 @@ void test_try_scientific_to_int()
           // clang-format off
             "-1.1E1",
             // Too large
-            "256", "256E0", "2.56E2", "3.0E2",
+            "256", "256E0", "2.56E2", "3.0E2", "3.00E2", "300", "399", "3.99E2", "999", "9.99E2",
             "1000","1000E0", "100E1", "10E2", "1E3","1.0E3",
             // negative
             "-1", "-1.1E1",
@@ -171,6 +171,11 @@ void test_try_parse_icu()
             uint64_t parsedVal{};
             TEST(!boost::locale::util::try_parse_icu(parsedByICU, parsedVal));
         }
+    }
+    {
+        icu::Formattable invalidNumber{"Str"};
+        uint64_t parsedVal{};
+        TEST(!boost::locale::util::try_parse_icu(invalidNumber, parsedVal));
     }
     // Test some numbers randomly to find missed cases
     std::mt19937_64 mt{std::random_device{}()};

--- a/test/test_util_numeric_convert.cpp
+++ b/test/test_util_numeric_convert.cpp
@@ -6,9 +6,14 @@
 
 #include "../src/util/numeric_conversion.hpp"
 #include "boostLocale/test/tools.hpp"
+#include <boost/charconv/limits.hpp>
+#include <boost/charconv/to_chars.hpp>
+#include <algorithm>
 #include <limits>
-#include <locale>
-#include <sstream>
+#ifdef BOOST_LOCALE_WITH_ICU
+#    include <random>
+#    include <unicode/numfmt.h>
+#endif
 
 void test_try_to_int()
 {
@@ -54,7 +59,132 @@ void test_try_to_int()
     TEST(!try_to_int(ss.str(), v));
 }
 
+void test_try_scientific_to_int()
+{
+    using boost::locale::util::try_scientific_to_int;
+
+    for(const auto s : {"255", "255E0", "2.55E2", "255E+0", "2.55E+2"}) {
+        TEST_CONTEXT(s);
+        uint8_t v;
+        if TEST(try_scientific_to_int(s, v))
+            TEST_EQ(v, 255);
+    }
+    for(const auto s : {"0", "0E0", "0.0E1", "0.0E2", "0.00E2"}) {
+        TEST_CONTEXT(s);
+        uint8_t v;
+        if TEST(try_scientific_to_int(s, v))
+            TEST_EQ(v, 0);
+    }
+    for(const auto s : {"3", "3E0", "0.3E1", "0.03E2"}) {
+        TEST_CONTEXT(s);
+        uint8_t v;
+        if TEST(try_scientific_to_int(s, v))
+            TEST_EQ(v, 3);
+    }
+    for(const auto s : {"50", "5E1", "0.5E2"}) {
+        TEST_CONTEXT(s);
+        uint8_t v;
+        if TEST(try_scientific_to_int(s, v))
+            TEST_EQ(v, 50);
+    }
+    for(const auto s : {
+          // clang-format off
+            "-1.1E1",
+            // Too large
+            "256", "256E0", "2.56E2", "3.0E2",
+            "1000","1000E0", "100E1", "10E2", "1E3","1.0E3",
+            // negative
+            "-1", "-1.1E1",
+            // Fractional
+            "1.1", "1.1E0", "1.01E1", "1.001E2", "1E-1", "1.1E-1", "0.1E-1",
+            // Possibly fractional: non-normalized E notation
+            "1.0", "1.0E0", "1.00E1", "1.000E2",
+            "0.0", "0.0E0", "0.00E1", "0.000E2",
+            "10E-1", "10.0E-1", "0.0E-1",
+            // Possibly fractional: Trailing zeros not covered by exponent
+            "1.10E1", "1.010E2", "0.10E1", "0.010E2", "0.0010E3", "0.00010E4",
+            // Bogus characters
+            "a",     "aE0",   "1.aE1",   "a.1E1",  "1Ea",   "1.1Ea",
+            "1a",   "1aE0",  "1.1aE1",  "1a.1E1",  "1E1a",  "1.1E1a",
+            "a1",   "a1E0",  "1.a1E1",  "a1.1E1",  "1Ea1",  "1.1Ea1",
+            "1a1", "1a1E0", "1.1a1E1", "1a1.1E1",  "1E1a1", "1.1E1a1",
+          // clang-format on
+        })
+    {
+        TEST_CONTEXT(s);
+        uint8_t v;
+        TEST(!try_scientific_to_int(s, v));
+    }
+}
+
+#ifdef BOOST_LOCALE_WITH_ICU
+template<typename T>
+void spotcheck_icu_parsing(icu::NumberFormat& parser, const T val)
+{
+    TEST_CONTEXT(val);
+    char buf[boost::charconv::limits<T>::max_chars10];
+    const auto r = boost::charconv::to_chars(buf, std::end(buf), val);
+    if(!TEST(r))
+        return; // LCOV_EXCL_LINE
+    UChar u_buf[boost::charconv::limits<T>::max_chars10];
+    std::copy(buf, r.ptr, u_buf);
+    icu::UnicodeString tmp(false, u_buf, static_cast<int32_t>(r.ptr - buf));
+
+    icu::Formattable parsedByICU;
+    UErrorCode err = U_ZERO_ERROR;
+    parser.parse(tmp, parsedByICU, err);
+    if TEST(U_SUCCESS(err)) {
+        T parsedVal{};
+        if TEST(boost::locale::util::try_parse_icu(parsedByICU, parsedVal))
+            TEST_EQ(parsedVal, val);
+    }
+}
+
+void test_try_parse_icu()
+{
+    UErrorCode err = U_ZERO_ERROR;
+    std::unique_ptr<icu::NumberFormat> parser(icu::NumberFormat::createInstance(icu::Locale::getEnglish(), err));
+    TEST_REQUIRE(U_SUCCESS(err));
+    using limits = std::numeric_limits<uint64_t>;
+    for(const uint64_t v : {limits::min(), limits::max(), limits::max() - 1, limits::max() / 2})
+        spotcheck_icu_parsing(*parser, v);
+    for(uint64_t v = 10, c = 1; c < limits::max() / 10; c = v, v *= 10) {
+        spotcheck_icu_parsing(*parser, v); // 100[...]0
+        const auto v1 = limits::max() / v;
+        const auto v2 = v1 * v; // Large with trailing zeros
+        spotcheck_icu_parsing(*parser, v1);
+        spotcheck_icu_parsing(*parser, v2);
+    }
+    // Unable to parse to uint64_t
+    const char16_t* bigVal1 = u"18446744073709551616";    // UINT64_MAX + 1
+    const char16_t* bigVal2 = u"184467440737095516150";   // UINT64_MAX * 10
+    const char16_t* signedVal1 = u"-9223372036854775808"; // INT64_MIN
+    const char16_t* signedVal2 = u"-9223372036854775809"; // INT64_MIN - 1
+    for(const auto* v : {bigVal1, bigVal2, signedVal1, signedVal2}) {
+        TEST_CONTEXT(v);
+        // ICU < 59 doesn't use char16_t but another 2 byte type
+        icu::UnicodeString tmp(true, reinterpret_cast<const UChar*>(v), -1);
+
+        icu::Formattable parsedByICU;
+        parser->parse(tmp, parsedByICU, err);
+        if TEST(U_SUCCESS(err)) {
+            uint64_t parsedVal{};
+            TEST(!boost::locale::util::try_parse_icu(parsedByICU, parsedVal));
+        }
+    }
+    // Test some numbers randomly to find missed cases
+    std::mt19937_64 mt{std::random_device{}()};
+    std::uniform_int_distribution<uint64_t> distr;
+    for(int i = 0; i < 42; ++i)
+        spotcheck_icu_parsing(*parser, distr(mt));
+}
+#endif
+
 void test_main(int /*argc*/, char** /*argv*/)
 {
     test_try_to_int();
+    test_try_scientific_to_int();
+#ifdef BOOST_LOCALE_WITH_ICU
+    test_try_parse_icu();
+#endif
 }

--- a/test/test_winapi_formatting.cpp
+++ b/test/test_winapi_formatting.cpp
@@ -177,6 +177,7 @@ void test_main(int /*argc*/, char** /*argv*/)
             test_by_char<wchar_t>(l, name, name_lcid.second);
         }
     }
+    test_format_large_number();
     test_parse_multi_number();
     std::cout << "- Testing strftime" << std::endl;
     test_date_time(gen("en_US.UTF-8"));


### PR DESCRIPTION
ICU doesn't support uint64_t directly but provides access to formatting and parsing of decimal number strings.

Use Boost.Charconv to interface with that such that values larger than `INT64_MAX` can be formatted correctly and parsed at all.

Fixes https://github.com/boostorg/locale/issues/235