### PR TITLE
Error build if ICU or IConv support was requested but is not available. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,10 +360,17 @@ jobs:
         if: matrix.coverage
         run: ci/codecov.sh "collect" && mv coverage.info coverage.iconv.info
 
+      - name: Check ICU
+        if: '!matrix.coverity'
+        run: 'ci/build.sh || true'
+        env:
+          B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=off --debug-configuration
+          B2_TARGETS: libs/locale/build//has_icu
       - name: Run tests with ICU only
         if: '!matrix.coverity'
         run: ci/build.sh
         env: {B2_FLAGS: -a boost.locale.icu=on  boost.locale.iconv=off}
+
       - name: Collect coverage
         if: matrix.coverage
         run: ci/codecov.sh "collect" && mv coverage.info coverage.icu.info
@@ -451,6 +458,18 @@ jobs:
           B2_TOOLSET: ${{matrix.toolset}}
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+
+      - name: Check ICU
+        if: '!matrix.coverage'
+        run: |
+          set B2_FLAGS=boost.locale.icu=on boost.locale.iconv=off boost.locale.std=off boost.locale.winapi=off --debug-configuration
+          ci\build.bat
+          rmdir /s /q bin.v2
+        env:
+          B2_TOOLSET: ${{matrix.toolset}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_ADDRESS_MODEL: ${{matrix.addrmd}}
+          B2_TARGETS: libs/locale/build//has_icu
 
       - name: Run tests (ICU, without coverage)
         if: '!matrix.coverage'

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -244,6 +244,9 @@ rule configure-full ( properties * : flags-only )
             # ICU might introduce an own iconv, so check for that.
             internal_iconv_target = has_iconv_with_icu ;
             external_iconv_target = has_external_iconv_with_icu ;
+        } else if <boost.locale.icu>on in $(properties)
+        {
+            errors.user-error : "ICU support was requested but not found" ;
         }
     }
 
@@ -259,6 +262,9 @@ rule configure-full ( properties * : flags-only )
         {
             found-iconv = true ;
             result += <library>iconv ;
+        } else if <boost.locale.iconv>on in $(properties)
+        {
+            errors.user-error : "Iconv support was requested but not found" ;
         }
     }
     if $(found-iconv)


### PR DESCRIPTION
This checks for the explicit commandline setting.