### PR TITLE
Refactor test_formatting

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -403,21 +403,9 @@ rule configure-flags ( properties * )
 alias build_flags : : : : <conditional>@configure-flags ;
 
 local cxx_requirements = [ requires
-      cxx11_auto_declarations
-      cxx11_decltype
-      cxx11_defaulted_functions
       cxx11_defaulted_moves
-      cxx11_hdr_functional
       cxx11_hdr_type_traits
-      cxx11_noexcept
-      cxx11_nullptr
       cxx11_override
-      cxx11_range_based_for
-      cxx11_rvalue_references
-      cxx11_scoped_enums
-      cxx11_smart_ptr
-      cxx11_static_assert
-      cxx11_variadic_templates
     ] ;
 
 lib boost_locale

--- a/test/formatting_common.hpp
+++ b/test/formatting_common.hpp
@@ -10,7 +10,6 @@
 #include <limits>
 #include <sstream>
 
-#include "../src/boost/locale/util/foreach_char.hpp"
 #include "boostLocale/test/tools.hpp"
 #include "boostLocale/test/unit_test.hpp"
 


### PR DESCRIPTION
- Make spelling of "ICU" consistently uppercase (except at start of names)
- Move definitions related to existance of ICU together and sort by name