### PR TITLE
Refactor for speed and consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(boost_locale
   src/util/locale_data.cpp
   src/util/make_std_unique.hpp
   src/util/numeric.hpp
+  src/util/numeric_conversion.hpp
   src/util/timezone.hpp
   ${headers}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(boost_locale
     Boost::iterator
     Boost::utility
   PRIVATE
+    Boost::charconv
     Boost::predef
     Boost::thread
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2020, 2021 Peter Dimov
-# Copyright 2022-2024 Alexander Grund
+# Copyright 2022-2025 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
@@ -51,7 +51,6 @@ target_link_libraries(boost_locale
     Boost::config
     Boost::core
     Boost::iterator
-    Boost::utility
   PRIVATE
     Boost::charconv
     Boost::predef

--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,5 @@
 # Copyright René Ferdinand Rivera Morell 2023-2024
+# Copyright(c) 2025 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -20,7 +21,7 @@ constant boost_dependencies :
     /boost/config//boost_config
     /boost/core//boost_core
     /boost/iterator//boost_iterator
-    /boost/utility//boost_utility ;
+    ;
 
 project /boost/locale
     : common-requirements

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -16,6 +16,7 @@ import toolset ;
 path-constant TOP : .. ;
 
 constant boost_dependencies_private :
+    /boost/charconv//boost_charconv
     /boost/predef//boost_predef
     /boost/thread//boost_thread
     ;

--- a/include/boost/locale/boundary/boundary_point.hpp
+++ b/include/boost/locale/boundary/boundary_point.hpp
@@ -100,7 +100,7 @@ namespace boost { namespace locale { namespace boundary {
 
     typedef boundary_point<std::string::const_iterator> sboundary_point;   ///< convenience typedef
     typedef boundary_point<std::wstring::const_iterator> wsboundary_point; ///< convenience typedef
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     typedef boundary_point<std::u8string::const_iterator> u8sboundary_point; ///< convenience typedef
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T

--- a/include/boost/locale/boundary/index.hpp
+++ b/include/boost/locale/boundary/index.hpp
@@ -868,7 +868,7 @@ namespace boost { namespace locale { namespace boundary {
 
     typedef segment_index<std::string::const_iterator> ssegment_index;   ///< convenience typedef
     typedef segment_index<std::wstring::const_iterator> wssegment_index; ///< convenience typedef
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     typedef segment_index<std::u8string::const_iterator> u8ssegment_index; ///< convenience typedef
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -892,7 +892,7 @@ namespace boost { namespace locale { namespace boundary {
 
     typedef boundary_point_index<std::string::const_iterator> sboundary_point_index;   ///< convenience typedef
     typedef boundary_point_index<std::wstring::const_iterator> wsboundary_point_index; ///< convenience typedef
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     typedef boundary_point_index<std::u8string::const_iterator> u8sboundary_point_index; ///< convenience typedef
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T

--- a/include/boost/locale/boundary/segment.hpp
+++ b/include/boost/locale/boundary/segment.hpp
@@ -340,7 +340,7 @@ namespace boost { namespace locale { namespace boundary {
 
     typedef segment<std::string::const_iterator> ssegment;   ///< convenience typedef
     typedef segment<std::wstring::const_iterator> wssegment; ///< convenience typedef
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     typedef segment<std::u8string::const_iterator> u8ssegment; ///< convenience typedef
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T

--- a/include/boost/locale/config.hpp
+++ b/include/boost/locale/config.hpp
@@ -89,11 +89,6 @@
 #    define BOOST_LOCALE_NO_SANITIZE(what)
 #endif
 
-#if !defined(__cpp_lib_char8_t) || BOOST_WORKAROUND(BOOST_CLANG_VERSION, < 150000)
-// No std::basic_string<char8_t> or bug in Clang: https://github.com/llvm/llvm-project/issues/55560
-#    define BOOST_LOCALE_NO_CXX20_STRING8
-#endif
-
 /// \endcond
 
 #endif // boost/locale/config.hpp

--- a/include/boost/locale/detail/any_string.hpp
+++ b/include/boost/locale/detail/any_string.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Alexander Grund
+// Copyright (c) 2023-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -9,7 +9,7 @@
 
 #include <boost/locale/config.hpp>
 #include <boost/assert.hpp>
-#include <boost/utility/string_view.hpp>
+#include <boost/core/detail/string_view.hpp>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -31,7 +31,7 @@ namespace boost { namespace locale { namespace detail {
         };
         template<typename Char>
         struct BOOST_SYMBOL_VISIBLE impl : base {
-            explicit impl(const boost::basic_string_view<Char> value) : s(value) {}
+            explicit impl(const core::basic_string_view<Char> value) : s(value) {}
             impl* clone() const override { return new impl(*this); }
             std::basic_string<Char> s;
         };
@@ -49,7 +49,7 @@ namespace boost { namespace locale { namespace detail {
         }
 
         template<typename Char>
-        void set(const boost::basic_string_view<Char> s)
+        void set(const core::basic_string_view<Char> s)
         {
             BOOST_ASSERT(!s.empty());
             s_.reset(new impl<Char>(s));

--- a/include/boost/locale/detail/encoding.hpp
+++ b/include/boost/locale/detail/encoding.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022-2023 Alexander Grund
+// Copyright (c) 2022-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -9,7 +9,7 @@
 
 #include <boost/locale/config.hpp>
 #include <boost/locale/encoding_errors.hpp>
-#include <boost/utility/string_view.hpp>
+#include <boost/core/detail/string_view.hpp>
 #include <memory>
 #include <string>
 
@@ -24,7 +24,7 @@ namespace boost { namespace locale { namespace conv { namespace detail {
 
         virtual ~charset_converter() = default;
         virtual string_type convert(const CharIn* begin, const CharIn* end) = 0;
-        string_type convert(const boost::basic_string_view<CharIn> text)
+        string_type convert(const core::basic_string_view<CharIn> text)
         {
             return convert(text.data(), text.data() + text.length());
         }

--- a/include/boost/locale/detail/encoding.hpp
+++ b/include/boost/locale/detail/encoding.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace locale { namespace conv { namespace detail {
 
         virtual ~charset_converter() = default;
         virtual string_type convert(const CharIn* begin, const CharIn* end) = 0;
-        string_type convert(const boost::basic_string_view<CharIn>& text)
+        string_type convert(const boost::basic_string_view<CharIn> text)
         {
             return convert(text.data(), text.data() + text.length());
         }

--- a/include/boost/locale/encoding.hpp
+++ b/include/boost/locale/encoding.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -240,11 +241,11 @@ namespace boost { namespace locale {
             /// Convert \a text to UTF
             ///
             /// \throws conversion_error: Conversion failed
-            string_type convert(const boost::string_view text) const { return impl_->convert(text); }
+            string_type convert(const core::string_view text) const { return impl_->convert(text); }
             /// Convert \a text to UTF
             ///
             /// \throws conversion_error: Conversion failed
-            string_type operator()(const boost::string_view text) const { return convert(text); }
+            string_type operator()(const core::string_view text) const { return convert(text); }
         };
 
         /// Converter class to decode an UTF string and encode it using a local encoding
@@ -254,7 +255,7 @@ namespace boost { namespace locale {
 
         public:
             using char_type = CharType;
-            using stringview_type = boost::basic_string_view<CharType>;
+            using stringview_type = core::basic_string_view<CharType>;
 
             /// Create an instance to convert UTF text to text encoded with \a charset according to policy \a how
             ///
@@ -298,11 +299,11 @@ namespace boost { namespace locale {
             /// Convert \a text
             ///
             /// \throws conversion_error: Conversion failed
-            std::string convert(const boost::string_view text) const { return impl_->convert(text); }
+            std::string convert(const core::string_view text) const { return impl_->convert(text); }
             /// Convert \a text
             ///
             /// \throws conversion_error: Conversion failed
-            std::string operator()(const boost::string_view text) const { return convert(text); }
+            std::string operator()(const core::string_view text) const { return convert(text); }
         };
     } // namespace conv
 }}    // namespace boost::locale

--- a/include/boost/locale/encoding.hpp
+++ b/include/boost/locale/encoding.hpp
@@ -240,11 +240,11 @@ namespace boost { namespace locale {
             /// Convert \a text to UTF
             ///
             /// \throws conversion_error: Conversion failed
-            string_type convert(const boost::string_view& text) const { return impl_->convert(text); }
+            string_type convert(const boost::string_view text) const { return impl_->convert(text); }
             /// Convert \a text to UTF
             ///
             /// \throws conversion_error: Conversion failed
-            string_type operator()(const boost::string_view& text) const { return convert(text); }
+            string_type operator()(const boost::string_view text) const { return convert(text); }
         };
 
         /// Converter class to decode an UTF string and encode it using a local encoding
@@ -298,11 +298,11 @@ namespace boost { namespace locale {
             /// Convert \a text
             ///
             /// \throws conversion_error: Conversion failed
-            std::string convert(const boost::string_view& text) const { return impl_->convert(text); }
+            std::string convert(const boost::string_view text) const { return impl_->convert(text); }
             /// Convert \a text
             ///
             /// \throws conversion_error: Conversion failed
-            std::string operator()(const boost::string_view& text) const { return convert(text); }
+            std::string operator()(const boost::string_view text) const { return convert(text); }
         };
     } // namespace conv
 }}    // namespace boost::locale

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2021-2023 Alexander Grund
+// Copyright (c) 2021-2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt

--- a/include/boost/locale/format.hpp
+++ b/include/boost/locale/format.hpp
@@ -418,7 +418,7 @@ namespace boost { namespace locale {
     typedef basic_format<char> format;
     /// Definition of wchar_t based format
     typedef basic_format<wchar_t> wformat;
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     /// Definition of char8_t based format
     typedef basic_format<char8_t> u8format;
 #endif

--- a/include/boost/locale/formatting.hpp
+++ b/include/boost/locale/formatting.hpp
@@ -122,7 +122,7 @@ namespace boost { namespace locale {
         /// Set time zone for formatting dates and time
         void time_zone(const std::string&);
         /// Get time zone for formatting dates and time
-        std::string time_zone() const;
+        const std::string& time_zone() const;
 
         /// Set date/time pattern (strftime like)
         template<typename CharType>

--- a/include/boost/locale/message.hpp
+++ b/include/boost/locale/message.hpp
@@ -341,7 +341,7 @@ namespace boost { namespace locale {
     typedef basic_message<char> message;
     /// Convenience typedef for wchar_t
     typedef basic_message<wchar_t> wmessage;
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     /// Convenience typedef for char8_t
     typedef basic_message<char8_t> u8message;
 #endif

--- a/src/encoding/codepage.cpp
+++ b/src/encoding/codepage.cpp
@@ -224,7 +224,7 @@ namespace boost { namespace locale { namespace conv {
     BOOST_LOCALE_INSTANTIATE(char);
     BOOST_LOCALE_INSTANTIATE_NO_CHAR(wchar_t);
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     BOOST_LOCALE_INSTANTIATE_NO_CHAR(char8_t);
 #endif
 

--- a/src/icu/conversion.cpp
+++ b/src/icu/conversion.cpp
@@ -198,7 +198,7 @@ namespace boost { namespace locale { namespace impl_icu {
                     return std::locale(in, new utf8_converter_impl<char>(cd));
                 return std::locale(in, new converter_impl<char>(cd));
             case char_facet_t::wchar_f: return std::locale(in, new converter_impl<wchar_t>(cd));
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
             case char_facet_t::char8_f: return std::locale(in, new utf8_converter_impl<char8_t>(cd));
 #elif defined(__cpp_char8_t)
             case char_facet_t::char8_f: break;

--- a/src/posix/converter.cpp
+++ b/src/posix/converter.cpp
@@ -125,7 +125,7 @@ namespace boost { namespace locale { namespace impl_posix {
                 return std::locale(in, new std_converter<char>(std::move(lc)));
             }
             case char_facet_t::wchar_f: return std::locale(in, new std_converter<wchar_t>(std::move(lc)));
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
             case char_facet_t::char8_f: return std::locale(in, new utf8_converter<char8_t>(std::move(lc)));
 #elif defined(__cpp_char8_t)
             case char_facet_t::char8_f: break;

--- a/src/shared/format.cpp
+++ b/src/shared/format.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+// Copyright (c) 2024 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -7,7 +8,7 @@
 #include <boost/locale/format.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/info.hpp>
-#include "../util/numeric.hpp"
+#include "../util/numeric_conversion.hpp"
 #include <algorithm>
 #include <iostream>
 #include <limits>

--- a/src/shared/format.cpp
+++ b/src/shared/format.cpp
@@ -64,10 +64,9 @@ namespace boost { namespace locale { namespace detail {
     {
         if(key.empty())
             return;
-        int position;
-        if(util::try_to_int(key, position) && position > 0) {
-            static_assert(sizeof(unsigned) <= sizeof(decltype(d->position)), "Possible lossy conversion");
-            d->position = static_cast<unsigned>(position - 1);
+        decltype(d->position) position;
+        if(util::try_to_int(key, position) && position > 0u) {
+            d->position = position - 1u;
         } else if(key == "num" || key == "number") {
             as::number(ios_);
 

--- a/src/shared/formatting.cpp
+++ b/src/shared/formatting.cpp
@@ -65,7 +65,7 @@ namespace boost { namespace locale {
     {
         time_zone_ = tz;
     }
-    std::string ios_info::time_zone() const
+    const std::string& ios_info::time_zone() const
     {
         return time_zone_;
     }

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -620,7 +620,7 @@ namespace boost { namespace locale { namespace detail {
             case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, gnu_gettext::create_messages_facet<char>(minf));
             case char_facet_t::wchar_f: return std::locale(in, gnu_gettext::create_messages_facet<wchar_t>(minf));
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
             case char_facet_t::char8_f: return std::locale(in, gnu_gettext::create_messages_facet<char8_t>(minf));
 #elif defined(__cpp_char8_t)
             case char_facet_t::char8_f: break;

--- a/src/shared/message.cpp
+++ b/src/shared/message.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2015 Artyom Beilis (Tonkikh)
-// Copyright (c) 2021-2023 Alexander Grund
+// Copyright (c) 2021-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -26,7 +26,7 @@
 #include "mo_hash.hpp"
 #include "mo_lambda.hpp"
 #include <boost/assert.hpp>
-#include <boost/utility/string_view.hpp>
+#include <boost/core/detail/string_view.hpp>
 #include <cstdio>
 #include <map>
 #include <memory>
@@ -141,7 +141,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
             hash_offset_ = get(24);
         }
 
-        string_view find(const char* context_in, const char* key_in) const
+        core::string_view find(const char* context_in, const char* key_in) const
         {
             if(!has_hash())
                 return {};
@@ -192,13 +192,13 @@ namespace boost { namespace locale { namespace gnu_gettext {
             return data_.data() + off;
         }
 
-        string_view value(unsigned id) const
+        core::string_view value(unsigned id) const
         {
             const uint32_t len = get(translations_offset_ + id * 8);
             const uint32_t off = get(translations_offset_ + id * 8 + 4);
             if(len > data_.size() || off > data_.size() - len)
                 throw std::runtime_error("Bad mo-file format");
-            return string_view(&data_[off], len);
+            return core::string_view(&data_[off], len);
         }
 
         bool has_hash() const { return hash_size_ != 0; }
@@ -233,7 +233,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
     template<typename CharType>
     struct mo_file_use_traits {
         static constexpr bool in_use = false;
-        using string_view_type = basic_string_view<CharType>;
+        using string_view_type = core::basic_string_view<CharType>;
         static string_view_type use(const mo_file&, const CharType*, const CharType*)
         {
             throw std::logic_error("Unexpected call"); // LCOV_EXCL_LINE
@@ -243,7 +243,7 @@ namespace boost { namespace locale { namespace gnu_gettext {
     template<>
     struct mo_file_use_traits<char> {
         static constexpr bool in_use = true;
-        using string_view_type = basic_string_view<char>;
+        using string_view_type = core::basic_string_view<char>;
         static string_view_type use(const mo_file& mo, const char* context, const char* key)
         {
             return mo.find(context, key);
@@ -254,10 +254,10 @@ namespace boost { namespace locale { namespace gnu_gettext {
     template<>
     struct mo_file_use_traits<char8_t> {
         static constexpr bool in_use = true;
-        using string_view_type = basic_string_view<char8_t>;
+        using string_view_type = core::basic_string_view<char8_t>;
         static string_view_type use(const mo_file& mo, const char8_t* context, const char8_t* key)
         {
-            string_view res = mo.find(reinterpret_cast<const char*>(context), reinterpret_cast<const char*>(key));
+            core::string_view res = mo.find(reinterpret_cast<const char*>(context), reinterpret_cast<const char*>(key));
             return {reinterpret_cast<const char8_t*>(res.data()), res.size()};
         }
     };
@@ -551,10 +551,10 @@ namespace boost { namespace locale { namespace gnu_gettext {
             return true;
         }
 
-        static std::string extract(boost::string_view meta, const std::string& key, const boost::string_view separators)
+        static std::string extract(core::string_view meta, const std::string& key, const core::string_view separators)
         {
             const size_t pos = meta.find(key);
-            if(pos == boost::string_view::npos)
+            if(pos == core::string_view::npos)
                 return "";
             meta.remove_prefix(pos + key.size());
             const size_t end_pos = meta.find_first_of(separators);

--- a/src/std/converter.cpp
+++ b/src/std/converter.cpp
@@ -104,7 +104,7 @@ namespace boost { namespace locale { namespace impl_std {
                 else
                     return std::locale(in, new std_converter<char>(locale_name));
             case char_facet_t::wchar_f: return std::locale(in, new std_converter<wchar_t>(locale_name));
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
             case char_facet_t::char8_f: return std::locale(in, new utf8_converter<char8_t>(locale_name));
 #elif defined(__cpp_char8_t)
             case char_facet_t::char8_f: break;

--- a/src/std/std_backend.cpp
+++ b/src/std/std_backend.cpp
@@ -27,7 +27,7 @@
 #include "../util/encoding.hpp"
 #include "../util/gregorian.hpp"
 #include "../util/make_std_unique.hpp"
-#include "../util/numeric.hpp"
+#include "../util/numeric_conversion.hpp"
 #include "all_generator.hpp"
 
 namespace {

--- a/src/util/encoding.cpp
+++ b/src/util/encoding.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2022-2023 Alexander Grund
+// Copyright (c) 2022-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -18,7 +18,7 @@
 #include <cstring>
 
 namespace boost { namespace locale { namespace util {
-    std::string normalize_encoding(const string_view encoding)
+    std::string normalize_encoding(const core::string_view encoding)
     {
         std::string result;
         result.reserve(encoding.length());
@@ -51,7 +51,7 @@ namespace boost { namespace locale { namespace util {
         return -1;
     }
 
-    int encoding_to_windows_codepage(const string_view encoding)
+    int encoding_to_windows_codepage(const core::string_view encoding)
     {
         return normalized_encoding_to_windows_codepage(normalize_encoding(encoding));
     }

--- a/src/util/encoding.hpp
+++ b/src/util/encoding.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2022-2023 Alexander Grund
+// Copyright (c) 2022-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -9,7 +9,7 @@
 #define BOOST_LOCALE_UTIL_ENCODING_HPP
 
 #include <boost/locale/config.hpp>
-#include <boost/utility/string_view.hpp>
+#include <boost/core/detail/string_view.hpp>
 #include <cstdint>
 #include <string>
 #include <type_traits>
@@ -48,7 +48,7 @@ namespace boost { namespace locale { namespace util {
 #endif
 
     /// Make encoding lowercase and remove all non-alphanumeric characters
-    BOOST_LOCALE_DECL std::string normalize_encoding(string_view encoding);
+    BOOST_LOCALE_DECL std::string normalize_encoding(core::string_view encoding);
     /// True if the normalized encodings are equal
     inline bool are_encodings_equal(const std::string& l, const std::string& r)
     {
@@ -58,10 +58,10 @@ namespace boost { namespace locale { namespace util {
     BOOST_LOCALE_DECL std::vector<std::string> get_simple_encodings();
 
 #if BOOST_LOCALE_USE_WIN32_API
-    int encoding_to_windows_codepage(string_view encoding);
+    int encoding_to_windows_codepage(core::string_view encoding);
 #else
     // Requires WinAPI -> Dummy returning invalid
-    inline int encoding_to_windows_codepage(string_view) // LCOV_EXCL_LINE
+    inline int encoding_to_windows_codepage(core::string_view) // LCOV_EXCL_LINE
     {
         return -1; // LCOV_EXCL_LINE
     }

--- a/src/util/foreach_char.hpp
+++ b/src/util/foreach_char.hpp
@@ -9,7 +9,7 @@
 
 #include <boost/locale/config.hpp>
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
 #    define BOOST_LOCALE_FOREACH_CHAR_I_CHAR8_T(F) F(char8_t)
 #    define BOOST_LOCALE_FOREACH_CHAR_I2_CHAR8_T(F) F(char8_t)
 #elif defined(__cpp_char8_t)

--- a/src/util/numeric.hpp
+++ b/src/util/numeric.hpp
@@ -10,11 +10,8 @@
 #include <boost/locale/info.hpp>
 #include <boost/predef/os.h>
 #include <algorithm>
-#include <cerrno>
-#include <cstdlib>
 #include <ctime>
 #include <ios>
-#include <limits>
 #include <locale>
 #include <sstream>
 #include <string>
@@ -23,22 +20,6 @@
 #include "timezone.hpp"
 
 namespace boost { namespace locale { namespace util {
-
-    inline bool try_to_int(const std::string& s, int& res)
-    {
-        if(s.empty())
-            return false;
-        errno = 0;
-        char* end_char{};
-        const auto v = std::strtol(s.c_str(), &end_char, 10);
-        if(errno == ERANGE || end_char != s.c_str() + s.size())
-            return false;
-        if(v < std::numeric_limits<int>::min() || v > std::numeric_limits<int>::max())
-            return false;
-        res = v;
-        return true;
-    }
-
     template<typename CharType>
     struct formatting_size_traits {
         static size_t size(const std::basic_string<CharType>& s, const std::locale& /*l*/) { return s.size(); }

--- a/src/util/numeric.hpp
+++ b/src/util/numeric.hpp
@@ -175,11 +175,11 @@ namespace boost { namespace locale { namespace util {
         iter_type
         format_time(iter_type out, std::ios_base& ios, CharType fill, std::time_t time, const string_type& format) const
         {
-            std::string tz = ios_info::get(ios).time_zone();
-            std::tm tm;
-#if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
-            std::vector<char> tmp_buf(tz.c_str(), tz.c_str() + tz.size() + 1);
+            const std::string& tz = ios_info::get(ios).time_zone();
+#if BOOST_OS_BSD_FREE || defined(__APPLE__)
+            std::vector<char> tz_nonconst;
 #endif
+            std::tm tm;
             if(tz.empty()) {
 #ifdef BOOST_WINDOWS
                 // Windows uses TLS
@@ -200,8 +200,13 @@ namespace boost { namespace locale { namespace util {
 #if BOOST_OS_LINUX || BOOST_OS_BSD_FREE || defined(__APPLE__)
                 // These have extra fields to specify timezone
                 if(gmtoff != 0) {
+#    if BOOST_OS_BSD_FREE || defined(__APPLE__)
                     // bsd and apple want tm_zone be non-const
-                    tm.tm_zone = tmp_buf.data();
+                    tz_nonconst.assign(tz.begin(), tz.end());
+                    tm.tm_zone = tz_nonconst.data();
+#    else
+                    tm.tm_zone = tz.data();
+#    endif
                     tm.tm_gmtoff = gmtoff;
                 }
 #endif

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2024 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_LOCALE_IMPL_UTIL_NUMERIC_CONVERSIONS_HPP
+#define BOOST_LOCALE_IMPL_UTIL_NUMERIC_CONVERSIONS_HPP
+
+#include <boost/locale/config.hpp>
+#include <boost/utility/string_view.hpp>
+#include <cstdlib>
+#include <errno>
+#include <limits>
+
+namespace boost { namespace locale { namespace util {
+
+    bool try_to_int(const string_view s, int value)
+    {
+        if(s.empty())
+            return false;
+        errno = 0;
+        char* end_char{};
+        const auto v = std::strtol(s.c_str(), &end_char, 10);
+        if(errno == ERANGE || end_char != s.c_str() + s.size())
+            return false;
+        if(v < std::numeric_limits<int>::min() || v > std::numeric_limits<int>::max())
+            return false;
+        res = v;
+        return true;
+    }
+}}} // namespace boost::locale::util
+
+#endif

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -13,7 +13,8 @@
 
 namespace boost { namespace locale { namespace util {
 
-    bool try_to_int(const string_view s, int value)
+    template<typename Integer>
+    bool try_to_int(const string_view s, Integer& value)
     {
         if(s.empty())
             return false;

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -8,10 +8,8 @@
 #define BOOST_LOCALE_IMPL_UTIL_NUMERIC_CONVERSIONS_HPP
 
 #include <boost/locale/config.hpp>
+#include <boost/charconv/from_chars.hpp>
 #include <boost/utility/string_view.hpp>
-#include <cstdlib>
-#include <errno>
-#include <limits>
 
 namespace boost { namespace locale { namespace util {
 
@@ -19,15 +17,8 @@ namespace boost { namespace locale { namespace util {
     {
         if(s.empty())
             return false;
-        errno = 0;
-        char* end_char{};
-        const auto v = std::strtol(s.c_str(), &end_char, 10);
-        if(errno == ERANGE || end_char != s.c_str() + s.size())
-            return false;
-        if(v < std::numeric_limits<int>::min() || v > std::numeric_limits<int>::max())
-            return false;
-        res = v;
-        return true;
+        const auto res = boost::charconv::from_chars(s, value);
+        return res && res.ptr == (s.data() + s.size());
     }
 }}} // namespace boost::locale::util
 

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -14,10 +14,13 @@
 namespace boost { namespace locale { namespace util {
 
     template<typename Integer>
-    bool try_to_int(const string_view s, Integer& value)
+    bool try_to_int(string_view s, Integer& value)
     {
-        if(s.empty())
-            return false;
+        if(s.size() >= 2 && s[0] == '+') {
+            if(s[1] == '-') // "+-" is not allowed, invalid "+<number>" is detected by parser
+                return false;
+            s.remove_prefix(1);
+        }
         const auto res = boost::charconv::from_chars(s, value);
         return res && res.ptr == (s.data() + s.size());
     }

--- a/src/util/numeric_conversion.hpp
+++ b/src/util/numeric_conversion.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Alexander Grund
+// Copyright (c) 2024-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
@@ -9,12 +9,12 @@
 
 #include <boost/locale/config.hpp>
 #include <boost/charconv/from_chars.hpp>
-#include <boost/utility/string_view.hpp>
+#include <boost/core/detail/string_view.hpp>
 
 namespace boost { namespace locale { namespace util {
 
     template<typename Integer>
-    bool try_to_int(string_view s, Integer& value)
+    bool try_to_int(core::string_view s, Integer& value)
     {
         if(s.size() >= 2 && s[0] == '+') {
             if(s[1] == '-') // "+-" is not allowed, invalid "+<number>" is detected by parser

--- a/src/win32/converter.cpp
+++ b/src/win32/converter.cpp
@@ -62,7 +62,7 @@ namespace boost { namespace locale { namespace impl_win {
             case char_facet_t::nochar: break;
             case char_facet_t::char_f: return std::locale(in, new utf8_converter<char>(lc));
             case char_facet_t::wchar_f: return std::locale(in, new wide_converter(lc));
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
             case char_facet_t::char8_f: return std::locale(in, new utf8_converter<char8_t>(lc));
 #elif defined(__cpp_char8_t)
             case char_facet_t::char8_f: break;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2022 Alexander Grund
+# Copyright 2022-2024 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
@@ -32,6 +32,7 @@ if(NOT BOOST_LOCALE_ENABLE_POSIX)
 endif()
 
 boost_test_jamfile(FILE Jamfile.v2)
+target_link_libraries(boost_locale-test_util_numeric_convert Boost::charconv)
 
 # Those require to be run in the test directory
 foreach(name test_formatting test_message)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -37,6 +37,7 @@ run test_catalog.cpp ;
 run test_encoding.cpp ;
 run test_utf.cpp ;
 run test_util.cpp test_helpers.cpp ;
+run test_util_numeric_convert.cpp ;
 run test_date_time.cpp ;
 run test_ios_info.cpp ;
 run test_ios_prop.cpp ;

--- a/test/boostLocale/test/tools.hpp
+++ b/test/boostLocale/test/tools.hpp
@@ -113,7 +113,7 @@ std::basic_string<Char> to(const std::string& utf8)
     return out;
 }
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
 template<>
 std::basic_string<char8_t> to(const std::string& utf8)
 {

--- a/test/boostLocale/test/unit_test.hpp
+++ b/test/boostLocale/test/unit_test.hpp
@@ -88,28 +88,24 @@ namespace boost { namespace locale { namespace test {
         if(++boost::locale::test::results().error_counter > BOOST_LOCALE_ERROR_LIMIT)
             throw std::runtime_error("Error limits reached, stopping unit test");
     }
+
+    template<bool require = false>
+    bool test_impl(const char* expr, const char* file, int line, const bool v)
+    {
+        boost::locale::test::results().test_counter++;
+        if(!v) {
+            boost::locale::test::report_error(expr, file, line);
+            throw std::runtime_error("Critical test " + std::string(expr) + " failed");
+        }
+        return v;
+    }
 }}} // namespace boost::locale::test
 
 #define BOOST_LOCALE_TEST_REPORT_ERROR(expr) boost::locale::test::report_error(expr, __FILE__, __LINE__)
 
-#define TEST(X)                                        \
-    do {                                               \
-        boost::locale::test::results().test_counter++; \
-        if(X)                                          \
-            break;                                     \
-        BOOST_LOCALE_TEST_REPORT_ERROR(#X);            \
-        BOOST_LOCALE_START_CONST_CONDITION             \
-    } while(0) BOOST_LOCALE_END_CONST_CONDITION
+#define TEST(X) (::boost::locale::test::test_impl(#X, __FILE__, __LINE__, (X) ? true : false))
 
-#define TEST_REQUIRE(X)                                          \
-    do {                                                         \
-        boost::locale::test::results().test_counter++;           \
-        if(X)                                                    \
-            break;                                               \
-        BOOST_LOCALE_TEST_REPORT_ERROR(#X);                      \
-        throw std::runtime_error("Critical test " #X " failed"); \
-        BOOST_LOCALE_START_CONST_CONDITION                       \
-    } while(0) BOOST_LOCALE_END_CONST_CONDITION
+#define TEST_REQUIRE(X) (::boost::locale::test::test_impl<true>(#X, __FILE__, __LINE__, (X) ? true : false))
 
 #define TEST_THROWS(X, E)                              \
     do {                                               \

--- a/test/formatting_common.hpp
+++ b/test/formatting_common.hpp
@@ -30,37 +30,43 @@ void test_parse_multi_number_by_char(const std::locale& locale)
     stream >> boost::locale::as::number;
 
     IntType value;
-    TEST_REQUIRE(stream >> value);
-    TEST_EQ(value, IntType(42));
-    TEST_EQ(static_cast<char>(stream.get()), '.');
-    TEST_REQUIRE(stream >> value);
-    TEST_EQ(value, expectedInt);
-    TEST_REQUIRE(!(stream >> value));
-    TEST(stream.eof());
+    if TEST(stream >> value) {
+        TEST_EQ(value, IntType(42));
+        TEST_EQ(static_cast<char>(stream.get()), '.');
+        if TEST(stream >> value) {
+            TEST_EQ(value, expectedInt);
+            if TEST(!(stream >> value))
+                TEST(stream.eof());
+        }
+    }
 
     stream.str(ascii_to<CharType>("42.25,678"));
     stream.clear();
     float fValue;
-    TEST_REQUIRE(stream >> fValue);
-    TEST_EQ(fValue, 42.25);
-    TEST_EQ(static_cast<char>(stream.get()), ',');
-    TEST_REQUIRE(stream >> value);
-    TEST_EQ(value, IntType(678));
-    TEST_REQUIRE(!(stream >> value));
-    TEST(stream.eof());
+    if TEST(stream >> fValue) {
+        TEST_EQ(fValue, 42.25);
+        TEST_EQ(static_cast<char>(stream.get()), ',');
+        if TEST(stream >> value) {
+            TEST_EQ(value, IntType(678));
+            if TEST(!(stream >> value))
+                TEST(stream.eof());
+        }
+    }
 
     // Parsing a floating point currency to integer truncates the floating point value but fully parses it
     stream.str(ascii_to<CharType>("USD1,234.55,67.89"));
     stream.clear();
-    TEST_REQUIRE(!(stream >> value));
-    stream.clear();
-    stream >> boost::locale::as::currency >> boost::locale::as::currency_iso;
-    if(stream >> value) { // Parsing currencies not fully supported by WinAPI backend
-        TEST_EQ(value, IntType(1234));
-        TEST_EQ(static_cast<char>(stream.get()), ',');
-        TEST_REQUIRE(stream >> boost::locale::as::number >> value);
-        TEST_EQ(value, IntType(67));
-        TEST(!stream.eof());
+    if TEST(!(stream >> value)) {
+        stream.clear();
+        stream >> boost::locale::as::currency >> boost::locale::as::currency_iso;
+        if(stream >> value) { // Parsing currencies not fully supported by WinAPI backend
+            TEST_EQ(value, IntType(1234));
+            TEST_EQ(static_cast<char>(stream.get()), ',');
+            if TEST(stream >> boost::locale::as::number >> value) {
+                TEST_EQ(value, IntType(67));
+                TEST(!stream.eof());
+            }
+        }
     }
 }
 

--- a/test/show_config.cpp
+++ b/test/show_config.cpp
@@ -65,7 +65,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     std::cout << "no\n";
 #endif
     std::cout << "- std::basic_string<char8_t>: ";
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "yes\n";
 #elif defined(__cpp_lib_char8_t)
     std::cout << "partial\n";

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -37,9 +37,10 @@ void run_segment_iterator_test(const lb::segment_index<Iterator>& map,
         unsigned i = 0;
         typename lb::segment_index<Iterator>::iterator p;
         for(p = map.begin(); p != map.end(); ++p, i++) {
-            TEST_REQUIRE(i < masks.size());
-            TEST_EQ(p->str(), chunks[i]);
-            TEST_EQ(p->rule(), masks[i]);
+            if TEST(i < masks.size()) {
+                TEST_EQ(p->str(), chunks[i]);
+                TEST_EQ(p->rule(), masks[i]);
+            }
         }
         TEST_EQ(i, chunks.size());
 
@@ -88,9 +89,10 @@ void run_break_iterator_test(const lb::boundary_point_index<Iterator>& map,
     unsigned i = 0;
     typename lb::boundary_point_index<Iterator>::iterator p;
     for(p = map.begin(); p != map.end(); ++p, i++) {
-        TEST_REQUIRE(i < masks.size());
-        TEST(p->iterator() == iters[i]);
-        TEST_EQ(p->rule(), masks[i]);
+        if TEST(i < masks.size()) {
+            TEST(p->iterator() == iters[i]);
+            TEST_EQ(p->rule(), masks[i]);
+        }
     }
 
     TEST_EQ(i, iters.size());
@@ -117,12 +119,13 @@ void verify_index(const lb::boundary_point_index<Iterator>& map,
                   const masks_t& masks)
 {
     BOOST_ASSERT(iters.size() == masks.size());
-    TEST_REQUIRE(static_cast<size_t>(std::distance(map.begin(), map.end())) == masks.size());
-    size_t i = 0;
-    for(const auto& b_point : map) {
-        TEST(b_point.iterator() == iters[i]);
-        TEST_EQ(b_point.rule(), masks[i]);
-        ++i;
+    if TEST(static_cast<size_t>(std::distance(map.begin(), map.end())) == masks.size()) {
+        size_t i = 0;
+        for(const auto& b_point : map) {
+            TEST(b_point.iterator() == iters[i]);
+            TEST_EQ(b_point.rule(), masks[i]);
+            ++i;
+        }
     }
 }
 
@@ -130,12 +133,13 @@ template<typename Iterator, typename Char>
 void verify_index(const lb::segment_index<Iterator>& map, const chunks_t<Char>& chunks, const masks_t& masks)
 {
     BOOST_ASSERT(chunks.size() == masks.size());
-    TEST_REQUIRE(static_cast<size_t>(std::distance(map.begin(), map.end())) == masks.size());
-    size_t i = 0;
-    for(const auto& seg : map) {
-        TEST_EQ(seg.str(), chunks[i]);
-        TEST_EQ(seg.rule(), masks[i]);
-        ++i;
+    if TEST(static_cast<size_t>(std::distance(map.begin(), map.end())) == masks.size()) {
+        size_t i = 0;
+        for(const auto& seg : map) {
+            TEST_EQ(seg.str(), chunks[i]);
+            TEST_EQ(seg.rule(), masks[i]);
+            ++i;
+        }
     }
 }
 

--- a/test/test_boundary.cpp
+++ b/test/test_boundary.cpp
@@ -310,7 +310,7 @@ void test_boundaries(std::string* all, int* first, int* second, lb::boundary_typ
     run_word<char>(all, first, second, nullptr, nullptr, nullptr, g("he_IL.cp1255"), t);
     std::cout << " wchar_t" << std::endl;
     run_word<wchar_t>(all, first, second, nullptr, nullptr, nullptr, g("he_IL.UTF-8"), t);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << " char8_t" << std::endl;
     run_word<char8_t>(all, first, second, nullptr, nullptr, nullptr, g("he_IL.UTF-8"), t);
 #endif
@@ -373,7 +373,7 @@ void word_boundary()
     run_word<wchar_t>(txt_simple, none_simple, zero, word_simple, zero, zero, utf8_en_locale);
     run_word<wchar_t>(txt_all, none_all, num_all, word_all, kana_all, ideo_all, utf8_jp_locale);
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << " char8_t" << std::endl;
     run_word<char8_t>(txt_empty, zero, zero, zero, zero, zero, g("ja_JP.UTF-8"));
     run_word<char8_t>(txt_simple, none_simple, zero, word_simple, zero, zero, utf8_en_locale);

--- a/test/test_codepage_converter.cpp
+++ b/test/test_codepage_converter.cpp
@@ -86,167 +86,167 @@ void test_main(int /*argc*/, char** /*argv*/)
     TEST(!create_simple_converter("UTF-8"));
     std::unique_ptr<base_converter> cvt = create_utf8_converter();
 
-    TEST_REQUIRE(cvt);
-    TEST(cvt->is_thread_safe());
-    TEST_EQ(cvt->max_len(), 4);
+    if TEST(cvt) {
+        TEST(cvt->is_thread_safe());
+        TEST_EQ(cvt->max_len(), 4);
 
-    std::cout << "-- Correct" << std::endl;
+        std::cout << "-- Correct" << std::endl;
 
-    TEST_TO("\x7f", 0x7f);
-    TEST_TO("\xC2\x80", 0x80);
-    TEST_TO("\xdf\xBF", 0x7FF);
-    TEST_TO("\xe0\xa0\x80", 0x800);
-    TEST_TO("\xef\xbf\xbf", 0xFFFF);
-    TEST_TO("\xf0\x90\x80\x80", 0x10000);
-    TEST_TO("\xf4\x8f\xbf\xbf", 0x10FFFF);
+        TEST_TO("\x7f", 0x7f);
+        TEST_TO("\xC2\x80", 0x80);
+        TEST_TO("\xdf\xBF", 0x7FF);
+        TEST_TO("\xe0\xa0\x80", 0x800);
+        TEST_TO("\xef\xbf\xbf", 0xFFFF);
+        TEST_TO("\xf0\x90\x80\x80", 0x10000);
+        TEST_TO("\xf4\x8f\xbf\xbf", 0x10FFFF);
 
-    std::cout << "-- Too big" << std::endl;
-    TEST_TO("\xf4\x9f\x80\x80", illegal);         //  11 0000
-    TEST_TO("\xfb\xbf\xbf\xbf", illegal);         // 3FF FFFF
-    TEST_TO("\xf8\x90\x80\x80\x80", illegal);     // 400 0000
-    TEST_TO("\xfd\xbf\xbf\xbf\xbf\xbf", illegal); // 7fff ffff
+        std::cout << "-- Too big" << std::endl;
+        TEST_TO("\xf4\x9f\x80\x80", illegal);         //  11 0000
+        TEST_TO("\xfb\xbf\xbf\xbf", illegal);         // 3FF FFFF
+        TEST_TO("\xf8\x90\x80\x80\x80", illegal);     // 400 0000
+        TEST_TO("\xfd\xbf\xbf\xbf\xbf\xbf", illegal); // 7fff ffff
 
-    std::cout << "-- Invalid trail" << std::endl;
-    TEST_TO("\xC2\x7F", illegal);
-    TEST_TO("\xdf\x7F", illegal);
-    TEST_TO("\xe0\x7F\x80", illegal);
-    TEST_TO("\xef\xbf\x7F", illegal);
-    TEST_TO("\xe0\x7F\x80", illegal);
-    TEST_TO("\xef\xbf\x7F", illegal);
-    TEST_TO("\xf0\x7F\x80\x80", illegal);
-    TEST_TO("\xf4\x7f\xbf\xbf", illegal);
-    TEST_TO("\xf0\x90\x7F\x80", illegal);
-    TEST_TO("\xf4\x8f\x7F\xbf", illegal);
-    TEST_TO("\xf0\x90\x80\x7F", illegal);
-    TEST_TO("\xf4\x8f\xbf\x7F", illegal);
+        std::cout << "-- Invalid trail" << std::endl;
+        TEST_TO("\xC2\x7F", illegal);
+        TEST_TO("\xdf\x7F", illegal);
+        TEST_TO("\xe0\x7F\x80", illegal);
+        TEST_TO("\xef\xbf\x7F", illegal);
+        TEST_TO("\xe0\x7F\x80", illegal);
+        TEST_TO("\xef\xbf\x7F", illegal);
+        TEST_TO("\xf0\x7F\x80\x80", illegal);
+        TEST_TO("\xf4\x7f\xbf\xbf", illegal);
+        TEST_TO("\xf0\x90\x7F\x80", illegal);
+        TEST_TO("\xf4\x8f\x7F\xbf", illegal);
+        TEST_TO("\xf0\x90\x80\x7F", illegal);
+        TEST_TO("\xf4\x8f\xbf\x7F", illegal);
 
-    std::cout << "-- Invalid length" << std::endl;
+        std::cout << "-- Invalid length" << std::endl;
 
-    // Test that this actually works
-    TEST_TO(make2(0x80), 0x80);
-    TEST_TO(make2(0x7ff), 0x7ff);
+        // Test that this actually works
+        TEST_TO(make2(0x80), 0x80);
+        TEST_TO(make2(0x7ff), 0x7ff);
 
-    TEST_TO(make3(0x800), 0x800);
-    TEST_TO(make3(0xffff), 0xffff);
+        TEST_TO(make3(0x800), 0x800);
+        TEST_TO(make3(0xffff), 0xffff);
 
-    TEST_TO(make4(0x10000), 0x10000);
-    TEST_TO(make4(0x10ffff), 0x10ffff);
+        TEST_TO(make4(0x10000), 0x10000);
+        TEST_TO(make4(0x10ffff), 0x10ffff);
 
-    TEST_TO(make4(0x110000), illegal);
-    TEST_TO(make4(0x1fffff), illegal);
+        TEST_TO(make4(0x110000), illegal);
+        TEST_TO(make4(0x1fffff), illegal);
 
-    TEST_TO(make2(0), illegal);
-    TEST_TO(make3(0), illegal);
-    TEST_TO(make4(0), illegal);
-    TEST_TO(make2(0x7f), illegal);
-    TEST_TO(make3(0x7f), illegal);
-    TEST_TO(make4(0x7f), illegal);
+        TEST_TO(make2(0), illegal);
+        TEST_TO(make3(0), illegal);
+        TEST_TO(make4(0), illegal);
+        TEST_TO(make2(0x7f), illegal);
+        TEST_TO(make3(0x7f), illegal);
+        TEST_TO(make4(0x7f), illegal);
 
-    TEST_TO(make3(0x80), illegal);
-    TEST_TO(make4(0x80), illegal);
-    TEST_TO(make3(0x7ff), illegal);
-    TEST_TO(make4(0x7ff), illegal);
+        TEST_TO(make3(0x80), illegal);
+        TEST_TO(make4(0x80), illegal);
+        TEST_TO(make3(0x7ff), illegal);
+        TEST_TO(make4(0x7ff), illegal);
 
-    TEST_TO(make4(0x8000), illegal);
-    TEST_TO(make4(0xffff), illegal);
+        TEST_TO(make4(0x8000), illegal);
+        TEST_TO(make4(0xffff), illegal);
 
-    std::cout << "-- Invalid surrogate" << std::endl;
+        std::cout << "-- Invalid surrogate" << std::endl;
 
-    TEST_TO(make3(0xD800), illegal);
-    TEST_TO(make3(0xDBFF), illegal);
-    TEST_TO(make3(0xDC00), illegal);
-    TEST_TO(make3(0xDFFF), illegal);
+        TEST_TO(make3(0xD800), illegal);
+        TEST_TO(make3(0xDBFF), illegal);
+        TEST_TO(make3(0xDC00), illegal);
+        TEST_TO(make3(0xDFFF), illegal);
 
-    TEST_TO(make4(0xD800), illegal);
-    TEST_TO(make4(0xDBFF), illegal);
-    TEST_TO(make4(0xDC00), illegal);
-    TEST_TO(make4(0xDFFF), illegal);
+        TEST_TO(make4(0xD800), illegal);
+        TEST_TO(make4(0xDBFF), illegal);
+        TEST_TO(make4(0xDC00), illegal);
+        TEST_TO(make4(0xDFFF), illegal);
 
-    std::cout << "-- Incomplete" << std::endl;
+        std::cout << "-- Incomplete" << std::endl;
 
-    TEST_TO("\x80", illegal);
-    TEST_TO("\xC2", incomplete);
+        TEST_TO("\x80", illegal);
+        TEST_TO("\xC2", incomplete);
 
-    TEST_TO("\xdf", incomplete);
+        TEST_TO("\xdf", incomplete);
 
-    TEST_TO("\xe0", incomplete);
-    TEST_TO("\xe0\xa0", incomplete);
+        TEST_TO("\xe0", incomplete);
+        TEST_TO("\xe0\xa0", incomplete);
 
-    TEST_TO("\xef\xbf", incomplete);
-    TEST_TO("\xef", incomplete);
+        TEST_TO("\xef\xbf", incomplete);
+        TEST_TO("\xef", incomplete);
 
-    TEST_TO("\xf0\x90\x80", incomplete);
-    TEST_TO("\xf0\x90", incomplete);
-    TEST_TO("\xf0", incomplete);
+        TEST_TO("\xf0\x90\x80", incomplete);
+        TEST_TO("\xf0\x90", incomplete);
+        TEST_TO("\xf0", incomplete);
 
-    TEST_TO("\xf4\x8f\xbf", incomplete);
-    TEST_TO("\xf4\x8f", incomplete);
-    TEST_TO("\xf4", incomplete);
+        TEST_TO("\xf4\x8f\xbf", incomplete);
+        TEST_TO("\xf4\x8f", incomplete);
+        TEST_TO("\xf4", incomplete);
 
-    std::cout << "- To UTF-8\n";
+        std::cout << "- To UTF-8\n";
 
-    std::cout << "-- Test correct" << std::endl;
+        std::cout << "-- Test correct" << std::endl;
 
-    TEST_FROM("\x7f", 0x7f);
-    TEST_FROM("\xC2\x80", 0x80);
-    TEST_FROM("\xdf\xBF", 0x7FF);
-    TEST_INC(0x7FF, 1);
-    TEST_FROM("\xe0\xa0\x80", 0x800);
-    TEST_INC(0x800, 2);
-    TEST_INC(0x800, 1);
-    TEST_FROM("\xef\xbf\xbf", 0xFFFF);
-    TEST_INC(0x10000, 3);
-    TEST_INC(0x10000, 2);
-    TEST_INC(0x10000, 1);
-    TEST_FROM("\xf0\x90\x80\x80", 0x10000);
-    TEST_FROM("\xf4\x8f\xbf\xbf", 0x10FFFF);
+        TEST_FROM("\x7f", 0x7f);
+        TEST_FROM("\xC2\x80", 0x80);
+        TEST_FROM("\xdf\xBF", 0x7FF);
+        TEST_INC(0x7FF, 1);
+        TEST_FROM("\xe0\xa0\x80", 0x800);
+        TEST_INC(0x800, 2);
+        TEST_INC(0x800, 1);
+        TEST_FROM("\xef\xbf\xbf", 0xFFFF);
+        TEST_INC(0x10000, 3);
+        TEST_INC(0x10000, 2);
+        TEST_INC(0x10000, 1);
+        TEST_FROM("\xf0\x90\x80\x80", 0x10000);
+        TEST_FROM("\xf4\x8f\xbf\xbf", 0x10FFFF);
 
-    std::cout << "-- Test no surrogate " << std::endl;
+        std::cout << "-- Test no surrogate " << std::endl;
 
-    TEST_FROM(nullptr, 0xD800);
-    TEST_FROM(nullptr, 0xDBFF);
-    TEST_FROM(nullptr, 0xDC00);
-    TEST_FROM(nullptr, 0xDFFF);
+        TEST_FROM(nullptr, 0xD800);
+        TEST_FROM(nullptr, 0xDBFF);
+        TEST_FROM(nullptr, 0xDC00);
+        TEST_FROM(nullptr, 0xDFFF);
 
-    std::cout << "-- Test invalid " << std::endl;
+        std::cout << "-- Test invalid " << std::endl;
 
-    TEST_FROM(nullptr, 0x110000);
-    TEST_FROM(nullptr, 0x1FFFFF);
-
+        TEST_FROM(nullptr, 0x110000);
+        TEST_FROM(nullptr, 0x1FFFFF);
+    }
     std::cout << "Test windows-1255" << std::endl;
 
     cvt = create_simple_converter("windows-1255");
 
-    TEST_REQUIRE(cvt);
-    TEST(cvt->is_thread_safe());
-    TEST_EQ(cvt->max_len(), 1);
+    if TEST(cvt) {
+        TEST(cvt->is_thread_safe());
+        TEST_EQ(cvt->max_len(), 1);
 
-    std::cout << "- From 1255" << std::endl;
+        std::cout << "- From 1255" << std::endl;
 
-    TEST_TO("\xa4", 0x20aa);
-    TEST_TO("\xe0", 0x05d0);
-    TEST_TO("\xc4", 0x5b4);
-    TEST_TO("\xfb", illegal);
-    TEST_TO("\xdd", illegal);
-    TEST_TO("\xff", illegal);
-    TEST_TO("\xfe", 0x200f);
+        TEST_TO("\xa4", 0x20aa);
+        TEST_TO("\xe0", 0x05d0);
+        TEST_TO("\xc4", 0x5b4);
+        TEST_TO("\xfb", illegal);
+        TEST_TO("\xdd", illegal);
+        TEST_TO("\xff", illegal);
+        TEST_TO("\xfe", 0x200f);
 
-    std::cout << "- To 1255" << std::endl;
+        std::cout << "- To 1255" << std::endl;
 
-    TEST_FROM("\xa4", 0x20aa);
-    TEST_FROM("\xe0", 0x05d0);
-    TEST_FROM("\xc4", 0x5b4);
-    TEST_FROM("\xfe", 0x200f);
+        TEST_FROM("\xa4", 0x20aa);
+        TEST_FROM("\xe0", 0x05d0);
+        TEST_FROM("\xc4", 0x5b4);
+        TEST_FROM("\xfe", 0x200f);
 
-    TEST_FROM(nullptr, 0xe4);
-    TEST_FROM(nullptr, 0xd0);
-
+        TEST_FROM(nullptr, 0xe4);
+        TEST_FROM(nullptr, 0xd0);
+    }
 #ifdef BOOST_LOCALE_WITH_ICU
     std::cout << "Testing Shift-JIS using ICU/uconv" << std::endl;
 
     cvt = boost::locale::impl_icu::create_uconv_converter("Shift-JIS");
-    TEST_REQUIRE(cvt);
-    test_shiftjis(cvt);
+    if TEST(cvt)
+        test_shiftjis(cvt);
 #endif
 
     std::cout << "Testing Shift-JIS using POSIX/iconv" << std::endl;

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -25,7 +25,7 @@ void test_norm(std::string orig, std::string normal, boost::locale::norm_type ty
 {
     test_normc<char>(orig, normal, type);
     test_normc<wchar_t>(to<wchar_t>(orig), to<wchar_t>(normal), type);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     test_normc<char8_t>(to<char8_t>(orig), to<char8_t>(normal), type);
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T
@@ -105,7 +105,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     TEST_ALL_CASES;
 #undef TEST_V
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
 #    define TEST_V(how, source_s, dest_s) TEST_A(char8_t, how, to<char8_t>(source_s), to<char8_t>(dest_s))
     TEST_ALL_CASES;
 #    undef TEST_V

--- a/test/test_encoding.cpp
+++ b/test/test_encoding.cpp
@@ -425,7 +425,7 @@ void test_utf_to_utf_for()
     test_from_utf_for_impls(utf<Char>(utf8_string), utf8_string, "UTF-8");
     std::cout << "---- wchar_t\n";
     test_utf_to_utf_for<Char, wchar_t>(utf8_string);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "---- char8_t\n";
     test_utf_to_utf_for<Char, char8_t>(utf8_string);
 #endif
@@ -446,7 +446,7 @@ void test_utf_to_utf()
     test_utf_to_utf_for<char>();
     std::cout << "-- wchar_t\n";
     test_utf_to_utf_for<wchar_t>();
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "-- char8_t\n";
     test_utf_to_utf_for<char8_t>();
 #endif
@@ -643,7 +643,7 @@ void test_latin1_conversions()
     test_latin1_conversions_for<char>();
     std::cout << "-- wchar_t\n";
     test_latin1_conversions_for<wchar_t>();
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "-- char8_t\n";
     test_latin1_conversions_for<char8_t>();
 #endif
@@ -781,7 +781,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     test_utf_for<char>();
     std::cout << "  wchar_t" << std::endl;
     test_utf_for<wchar_t>();
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "  char8_t" << std::endl;
     test_utf_for<char8_t>();
 #endif

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -329,7 +329,7 @@ void test_main(int /*argc*/, char** /*argv*/)
 #else
 #    define TEST_FOR_CHAR8(check) (void)0
 #endif
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
 #    define TEST_FOR_STRING8(check) TEST(check)
 #else
 #    define TEST_FOR_STRING8(check) (void)0

--- a/test/test_ios_info.cpp
+++ b/test/test_ios_info.cpp
@@ -222,7 +222,7 @@ void test_any_string()
     TEST_EQ(s.get<char32_t>(), ascii_to<char32_t>("Char32 Pattern"));
     TEST_THROWS(s.get<char16_t>(), std::bad_cast);
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     s.set<char8_t>(ascii_to<char8_t>("Char8 Pattern"));
     TEST_EQ(s.get<char8_t>(), ascii_to<char8_t>("Char8 Pattern"));
     TEST_THROWS(s.get<char32_t>(), std::bad_cast);

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -84,7 +84,7 @@ std::wstring same_w(std::wstring s)
     return s;
 }
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
 std::basic_string<char8_t> same_u8(std::basic_string<char8_t> s)
 {
     return s;
@@ -376,7 +376,7 @@ void test_cntranslate(const std::string& c,
     impl::test_cntranslate<char>(c, s, p, n, expected, l, domain);
     std::cout << "  wchar_t" << std::endl;
     impl::test_cntranslate<wchar_t>(c, s, p, n, expected, l, domain);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "  char8_t" << std::endl;
     impl::test_cntranslate<char8_t>(c, s, p, n, expected, l, domain);
 #endif
@@ -401,7 +401,7 @@ void test_ntranslate(const std::string& s,
     impl::test_ntranslate<char>(s, p, n, expected, l, domain);
     std::cout << "  wchar_t" << std::endl;
     impl::test_ntranslate<wchar_t>(s, p, n, expected, l, domain);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "  char8_t" << std::endl;
     impl::test_ntranslate<char8_t>(s, p, n, expected, l, domain);
 #endif
@@ -425,7 +425,7 @@ void test_ctranslate(const std::string& c,
     impl::test_ctranslate<char>(c, original, expected, l, domain);
     std::cout << "  wchar_t" << std::endl;
     impl::test_ctranslate<wchar_t>(c, original, expected, l, domain);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "  char8_t" << std::endl;
     impl::test_ctranslate<char8_t>(c, original, expected, l, domain);
 #endif
@@ -448,7 +448,7 @@ void test_translate(const std::string& original,
     impl::test_translate<char>(original, expected, l, domain);
     std::cout << "  wchar_t" << std::endl;
     impl::test_translate<wchar_t>(original, expected, l, domain);
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "  char8_t" << std::endl;
     impl::test_translate<char8_t>(original, expected, l, domain);
 #endif
@@ -570,7 +570,7 @@ void test_main(int argc, char** argv)
         TEST_EQ(same_s(bl::translate("hello")), "שלום");
         TEST_EQ(same_w(bl::translate(to<wchar_t>("hello"))), to<wchar_t>("שלום"));
 
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
         TEST_EQ(same_u8(bl::translate(to<char8_t>("hello"))), to<char8_t>("שלום"));
 #endif
 #ifdef BOOST_LOCALE_ENABLE_CHAR16_T

--- a/test/test_posix_convert.cpp
+++ b/test/test_posix_convert.cpp
@@ -52,13 +52,14 @@ void test_char()
     else {
         std::cout << "Testing " << name << std::endl;
         locale_holder cl(newlocale(LC_ALL_MASK, name.c_str(), nullptr));
-        TEST_REQUIRE(cl);
+        if TEST(cl) {
 #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-        if(towupper_l(L'i', cl) == 0x130)
-            test_one<CharType>(gen(name), "i", "i", "İ");
-        else
-            std::cout << "  Turkish locale is not supported well" << std::endl; // LCOV_EXCL_LINE
+            if(towupper_l(L'i', cl) == 0x130)
+                test_one<CharType>(gen(name), "i", "i", "İ");
+            else
+                std::cout << "  Turkish locale is not supported well" << std::endl; // LCOV_EXCL_LINE
 #endif
+        }
     }
 }
 

--- a/test/test_posix_formatting.cpp
+++ b/test/test_posix_formatting.cpp
@@ -164,13 +164,13 @@ void test_main(int /*argc*/, char** /*argv*/)
         else {
             std::locale generated_locale = gen(locale_name);
             locale_holder real_locale(newlocale(LC_ALL_MASK, locale_name.c_str(), nullptr));
-            TEST_REQUIRE(real_locale);
+            if TEST(real_locale) {
+                std::cout << "UTF-8" << std::endl;
+                test_by_char<char>(generated_locale, real_locale);
 
-            std::cout << "UTF-8" << std::endl;
-            test_by_char<char>(generated_locale, real_locale);
-
-            std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
-            test_by_char<wchar_t>(generated_locale, real_locale);
+                std::cout << "Wide UTF-" << sizeof(wchar_t) * 8 << std::endl;
+                test_by_char<wchar_t>(generated_locale, real_locale);
+            }
         }
     }
     {

--- a/test/test_std_convert.cpp
+++ b/test/test_std_convert.cpp
@@ -84,7 +84,7 @@ void test_main(int /*argc*/, char** /*argv*/)
     test_char<char>();
     std::cout << "Testing wchar_t" << std::endl;
     test_char<wchar_t>();
-#ifndef BOOST_LOCALE_NO_CXX20_STRING8
+#ifdef __cpp_lib_char8_t
     std::cout << "Testing char8_t" << std::endl;
     test_char<char8_t>();
 #endif

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -370,50 +370,9 @@ void test_locale_data()
     verify_against_icu();
 }
 
-#include "../src/util/numeric.hpp"
-#include <limits>
-#include <locale>
-#include <sstream>
-
-void test_try_to_int()
-{
-    using boost::locale::util::try_to_int;
-
-    int v = 1337;
-    TEST(try_to_int("0", v));
-    TEST_EQ(v, 0);
-
-    TEST(try_to_int("42", v));
-    TEST_EQ(v, 42);
-
-    TEST(try_to_int("-1337", v));
-    TEST_EQ(v, -1337);
-
-    std::ostringstream ss;
-    ss.imbue(std::locale::classic());
-    empty_stream(ss) << std::numeric_limits<int>::min();
-    TEST(try_to_int(ss.str(), v));
-    TEST_EQ(v, std::numeric_limits<int>::min());
-    empty_stream(ss) << std::numeric_limits<int>::max();
-    TEST(try_to_int(ss.str(), v));
-    TEST_EQ(v, std::numeric_limits<int>::max());
-
-    TEST(!try_to_int("", v));
-    TEST(!try_to_int("a", v));
-    TEST(!try_to_int("1.", v));
-    TEST(!try_to_int("1a", v));
-    TEST(!try_to_int("a1", v));
-    static_assert(sizeof(long long) > sizeof(int), "Value below under/overflows!");
-    empty_stream(ss) << static_cast<long long>(std::numeric_limits<int>::min()) - 1;
-    TEST(!try_to_int(ss.str(), v));
-    empty_stream(ss) << static_cast<long long>(std::numeric_limits<int>::max()) + 1;
-    TEST(!try_to_int(ss.str(), v));
-}
-
 void test_main(int /*argc*/, char** /*argv*/)
 {
     test_hold_ptr();
     test_get_system_locale();
     test_locale_data();
-    test_try_to_int();
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -37,31 +37,33 @@ void test_hold_ptr()
         auto* raw = new Dummy(42);
         boost::locale::hold_ptr<Dummy> ptr(raw);
         const boost::locale::hold_ptr<Dummy>& const_ptr = ptr;
-        TEST_REQUIRE(ptr);
-        TEST(ptr.get() == raw);
-        TEST(const_ptr.get() == raw);
-        // const propagation
-        TEST_EQ((*ptr).foo(), raw->i_);
-        TEST_EQ((*const_ptr).foo(), -raw->i_);
-        TEST_EQ(ptr->foo(), raw->i_);
-        TEST_EQ(const_ptr->foo(), -raw->i_);
-        TEST_EQ(ptr.get()->foo(), raw->i_);
-        TEST_EQ(const_ptr.get()->foo(), -raw->i_);
-        // move construct
-        boost::locale::hold_ptr<Dummy> ptr2 = std::move(ptr);
-        TEST(!ptr);
-        TEST_REQUIRE(ptr2);
-        TEST(ptr2.get() == raw);
-        // move assign
-        ptr = std::move(ptr2);
-        TEST(ptr);
-        TEST_REQUIRE(!ptr2);
-        TEST(ptr.get() == raw);
-        // Swap
-        boost::locale::hold_ptr<Dummy> ptr3(new Dummy(1337));
-        ptr.swap(ptr3);
-        TEST_EQ(ptr->foo(), 1337);
-        TEST_EQ(ptr3->foo(), 42);
+        if TEST(ptr) {
+            TEST(ptr.get() == raw);
+            TEST(const_ptr.get() == raw);
+            // const propagation
+            TEST_EQ((*ptr).foo(), raw->i_);
+            TEST_EQ((*const_ptr).foo(), -raw->i_);
+            TEST_EQ(ptr->foo(), raw->i_);
+            TEST_EQ(const_ptr->foo(), -raw->i_);
+            TEST_EQ(ptr.get()->foo(), raw->i_);
+            TEST_EQ(const_ptr.get()->foo(), -raw->i_);
+            // move construct
+            boost::locale::hold_ptr<Dummy> ptr2 = std::move(ptr);
+            TEST(!ptr);
+            if TEST(ptr2) {
+                TEST(ptr2.get() == raw);
+                // move assign
+                ptr = std::move(ptr2);
+                TEST(ptr);
+                TEST(!ptr2);
+                TEST(ptr.get() == raw);
+                // Swap
+                boost::locale::hold_ptr<Dummy> ptr3(new Dummy(1337));
+                ptr.swap(ptr3);
+                TEST_EQ(ptr->foo(), 1337);
+                TEST_EQ(ptr3->foo(), 42);
+            }
+        }
     }
     TEST_EQ(Dummy::ctr, 0);
     auto* raw = new Dummy(42);

--- a/test/test_util_numeric_convert.cpp
+++ b/test/test_util_numeric_convert.cpp
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2022-2025 Alexander Grund
+//
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include "../src/util/numeric_conversion.hpp"
+#include "boostLocale/test/tools.hpp"
+#include <limits>
+#include <locale>
+#include <sstream>
+
+void test_try_to_int()
+{
+    using boost::locale::util::try_to_int;
+
+    int v = 1337;
+    TEST(try_to_int("0", v));
+    TEST_EQ(v, 0);
+
+    TEST(try_to_int("42", v));
+    TEST_EQ(v, 42);
+
+    TEST(try_to_int("-1337", v));
+    TEST_EQ(v, -1337);
+
+    std::ostringstream ss;
+    ss.imbue(std::locale::classic());
+    empty_stream(ss) << std::numeric_limits<int>::min();
+    TEST(try_to_int(ss.str(), v));
+    TEST_EQ(v, std::numeric_limits<int>::min());
+    empty_stream(ss) << std::numeric_limits<int>::max();
+    TEST(try_to_int(ss.str(), v));
+    TEST_EQ(v, std::numeric_limits<int>::max());
+
+    TEST(!try_to_int("", v));
+    TEST(!try_to_int("a", v));
+    TEST(!try_to_int("1.", v));
+    TEST(!try_to_int("1a", v));
+    TEST(!try_to_int("a1", v));
+    static_assert(sizeof(long long) > sizeof(int), "Value below under/overflows!");
+    empty_stream(ss) << static_cast<long long>(std::numeric_limits<int>::min()) - 1;
+    TEST(!try_to_int(ss.str(), v));
+    empty_stream(ss) << static_cast<long long>(std::numeric_limits<int>::max()) + 1;
+    TEST(!try_to_int(ss.str(), v));
+}
+
+void test_main(int /*argc*/, char** /*argv*/)
+{
+    test_try_to_int();
+}

--- a/test/test_util_numeric_convert.cpp
+++ b/test/test_util_numeric_convert.cpp
@@ -15,23 +15,23 @@ void test_try_to_int()
     using boost::locale::util::try_to_int;
 
     int v = 1337;
-    TEST(try_to_int("0", v));
-    TEST_EQ(v, 0);
+    if TEST(try_to_int("0", v))
+        TEST_EQ(v, 0);
 
-    TEST(try_to_int("42", v));
-    TEST_EQ(v, 42);
+    if TEST(try_to_int("42", v))
+        TEST_EQ(v, 42);
 
-    TEST(try_to_int("-1337", v));
-    TEST_EQ(v, -1337);
+    if TEST(try_to_int("-1337", v))
+        TEST_EQ(v, -1337);
 
     std::ostringstream ss;
     ss.imbue(std::locale::classic());
     empty_stream(ss) << std::numeric_limits<int>::min();
-    TEST(try_to_int(ss.str(), v));
-    TEST_EQ(v, std::numeric_limits<int>::min());
+    if TEST(try_to_int(ss.str(), v))
+        TEST_EQ(v, std::numeric_limits<int>::min());
     empty_stream(ss) << std::numeric_limits<int>::max();
-    TEST(try_to_int(ss.str(), v));
-    TEST_EQ(v, std::numeric_limits<int>::max());
+    if TEST(try_to_int(ss.str(), v))
+        TEST_EQ(v, std::numeric_limits<int>::max());
 
     TEST(!try_to_int("", v));
     TEST(!try_to_int("a", v));

--- a/test/test_util_numeric_convert.cpp
+++ b/test/test_util_numeric_convert.cpp
@@ -24,6 +24,9 @@ void test_try_to_int()
     if TEST(try_to_int("-1337", v))
         TEST_EQ(v, -1337);
 
+    if TEST(try_to_int("+1337", v))
+        TEST_EQ(v, +1337);
+
     std::ostringstream ss;
     ss.imbue(std::locale::classic());
     empty_stream(ss) << std::numeric_limits<int>::min();
@@ -34,6 +37,12 @@ void test_try_to_int()
         TEST_EQ(v, std::numeric_limits<int>::max());
 
     TEST(!try_to_int("", v));
+    TEST(!try_to_int("+", v));
+    TEST(!try_to_int("-", v));
+    TEST(!try_to_int("++", v));
+    TEST(!try_to_int("+-", v));
+    TEST(!try_to_int("++1", v));
+    TEST(!try_to_int("+-1", v));
     TEST(!try_to_int("a", v));
     TEST(!try_to_int("1.", v));
     TEST(!try_to_int("1a", v));


### PR DESCRIPTION
1. Consistently pass string_view by value as is best practice with it being a pointer-size pair
2. Move `try_to_int` to new header moving it out of a header containing the large `base_num_format`.
3. Use Boost.Charconv in `try_to_int`
4. Allow `try_to_int` to be used with other integer types, e.g. the `unsigned` as used with in one other place
5. Avoid superflous copies of the time zone string: First into a local variable, then into a `vector` to have it non-const. The latter is only required for FreeBSD and apple, not for all Linux systems.
6. Test only: Return the success state in `TEST` macro to allow depending on the return value for further tests