### PR TITLE
Replace (semi-)absolute includes to implementation headers by relative ones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ add_library(boost_locale
 
 add_library(Boost::locale ALIAS boost_locale)
 
-target_include_directories(boost_locale PUBLIC include PRIVATE src)
+target_include_directories(boost_locale PUBLIC include)
 target_compile_features(boost_locale PUBLIC cxx_std_11)
 
 target_link_libraries(boost_locale

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -427,7 +427,6 @@ lib boost_locale
       $(cxx_requirements)
       <link>shared:<define>BOOST_LOCALE_DYN_LINK=1
       <define>BOOST_LOCALE_SOURCE
-      <include>$(TOP)/src
       <threading>multi
       <target-os>windows:<define>_CRT_SECURE_NO_WARNINGS
       <target-os>windows:<define>_SCL_SECURE_NO_WARNINGS

--- a/src/boost/locale/encoding/codepage.cpp
+++ b/src/boost/locale/encoding/codepage.cpp
@@ -1,24 +1,24 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2022-2023 Alexander Grund
+// Copyright (c) 2022-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/encoding.hpp>
-#include "boost/locale/util/make_std_unique.hpp"
+#include "../util/make_std_unique.hpp"
 
 #if BOOST_LOCALE_USE_WIN32_API
 #    define BOOST_LOCALE_WITH_WCONV
 #endif
 #ifdef BOOST_LOCALE_WITH_ICONV
-#    include "boost/locale/encoding/iconv_converter.hpp"
+#    include "iconv_converter.hpp"
 #endif
 #ifdef BOOST_LOCALE_WITH_ICU
-#    include "boost/locale/encoding/uconv_converter.hpp"
+#    include "uconv_converter.hpp"
 #endif
 #ifdef BOOST_LOCALE_WITH_WCONV
-#    include "boost/locale/encoding/wconv_converter.hpp"
+#    include "wconv_converter.hpp"
 #endif
 
 namespace boost { namespace locale { namespace conv {

--- a/src/boost/locale/encoding/iconv_converter.hpp
+++ b/src/boost/locale/encoding/iconv_converter.hpp
@@ -8,8 +8,8 @@
 #define BOOST_LOCALE_IMPL_ICONV_CODEPAGE_HPP
 
 #include <boost/locale/encoding.hpp>
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/iconv.hpp"
+#include "../util/encoding.hpp"
+#include "../util/iconv.hpp"
 #include <boost/assert.hpp>
 #include <cerrno>
 #include <string>

--- a/src/boost/locale/encoding/uconv_converter.hpp
+++ b/src/boost/locale/encoding/uconv_converter.hpp
@@ -8,8 +8,8 @@
 #define BOOST_LOCALE_IMPL_UCONV_CODEPAGE_HPP
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/hold_ptr.hpp>
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/uconv.hpp"
+#include "../icu/icu_util.hpp"
+#include "../icu/uconv.hpp"
 #include <unicode/ucnv.h>
 #include <unicode/ucnv_err.h>
 

--- a/src/boost/locale/encoding/wconv_converter.hpp
+++ b/src/boost/locale/encoding/wconv_converter.hpp
@@ -11,7 +11,7 @@
 #    define NOMINMAX
 #endif
 #include <boost/locale/encoding.hpp>
-#include "boost/locale/util/encoding.hpp"
+#include "../util/encoding.hpp"
 #include <algorithm>
 #include <cstddef>
 #include <cstring>

--- a/src/boost/locale/icu/boundary.cpp
+++ b/src/boost/locale/icu/boundary.cpp
@@ -1,17 +1,17 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2021-2022 Alexander Grund
+// Copyright (c) 2021-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/boundary.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/uconv.hpp"
-#include "boost/locale/util/encoding.hpp"
+#include "../util/encoding.hpp"
+#include "all_generator.hpp"
+#include "cdata.hpp"
+#include "icu_util.hpp"
+#include "uconv.hpp"
 #if BOOST_LOCALE_ICU_VERSION >= 5502
 #    include <unicode/utext.h>
 #endif

--- a/src/boost/locale/icu/codecvt.cpp
+++ b/src/boost/locale/icu/codecvt.cpp
@@ -1,20 +1,20 @@
 //
 // Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
-// Copyright (c) 2022-2023 Alexander Grund
+// Copyright (c) 2022-2025 Alexander Grund
 //
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/icu/codecvt.hpp"
+#include "codecvt.hpp"
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/encoding_errors.hpp>
 #include <boost/locale/hold_ptr.hpp>
 #include <boost/locale/util.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/uconv.hpp"
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/make_std_unique.hpp"
+#include "../util/encoding.hpp"
+#include "../util/make_std_unique.hpp"
+#include "all_generator.hpp"
+#include "icu_util.hpp"
+#include "uconv.hpp"
 #include <unicode/ucnv.h>
 #include <unicode/ucnv_err.h>
 

--- a/src/boost/locale/icu/collator.cpp
+++ b/src/boost/locale/icu/collator.cpp
@@ -7,12 +7,12 @@
 
 #include <boost/locale/collator.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/uconv.hpp"
-#include "boost/locale/shared/mo_hash.hpp"
-#include "boost/locale/shared/std_collate_adapter.hpp"
+#include "../shared/mo_hash.hpp"
+#include "../shared/std_collate_adapter.hpp"
+#include "all_generator.hpp"
+#include "cdata.hpp"
+#include "icu_util.hpp"
+#include "uconv.hpp"
 #include <boost/thread.hpp>
 #include <limits>
 #include <memory>

--- a/src/boost/locale/icu/conversion.cpp
+++ b/src/boost/locale/icu/conversion.cpp
@@ -6,10 +6,10 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/conversion.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/uconv.hpp"
+#include "all_generator.hpp"
+#include "cdata.hpp"
+#include "icu_util.hpp"
+#include "uconv.hpp"
 #include <limits>
 #include <unicode/locid.h>
 #include <unicode/normlzr.h>

--- a/src/boost/locale/icu/date_time.cpp
+++ b/src/boost/locale/icu/date_time.cpp
@@ -9,11 +9,11 @@
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/hold_ptr.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/time_zone.hpp"
-#include "boost/locale/icu/uconv.hpp"
+#include "all_generator.hpp"
+#include "cdata.hpp"
+#include "icu_util.hpp"
+#include "time_zone.hpp"
+#include "uconv.hpp"
 #include <boost/thread.hpp>
 #include <cmath>
 #include <memory>

--- a/src/boost/locale/icu/formatter.cpp
+++ b/src/boost/locale/icu/formatter.cpp
@@ -5,14 +5,14 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/icu/formatter.hpp"
+#include "formatter.hpp"
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/info.hpp>
-#include "boost/locale/icu/formatters_cache.hpp"
-#include "boost/locale/icu/icu_util.hpp"
-#include "boost/locale/icu/time_zone.hpp"
-#include "boost/locale/icu/uconv.hpp"
-#include "boost/locale/util/foreach_char.hpp"
+#include "../util/foreach_char.hpp"
+#include "formatters_cache.hpp"
+#include "icu_util.hpp"
+#include "time_zone.hpp"
+#include "uconv.hpp"
 #include <limits>
 #include <memory>
 #ifdef BOOST_MSVC

--- a/src/boost/locale/icu/formatters_cache.cpp
+++ b/src/boost/locale/icu/formatters_cache.cpp
@@ -5,7 +5,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/icu/formatters_cache.hpp"
+#include "formatters_cache.hpp"
 #include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <memory>

--- a/src/boost/locale/icu/formatters_cache.hpp
+++ b/src/boost/locale/icu/formatters_cache.hpp
@@ -9,7 +9,7 @@
 #define BOOST_LOCALE_PREDEFINED_FORMATTERS_HPP_INCLUDED
 
 #include <boost/locale/config.hpp>
-#include "boost/locale/icu/icu_util.hpp"
+#include "icu_util.hpp"
 #include <boost/thread/tss.hpp>
 #include <locale>
 

--- a/src/boost/locale/icu/icu_backend.cpp
+++ b/src/boost/locale/icu/icu_backend.cpp
@@ -5,14 +5,14 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/icu/icu_backend.hpp"
+#include "icu_backend.hpp"
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/locale/localization_backend.hpp>
 #include <boost/locale/util.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/shared/message.hpp"
-#include "boost/locale/util/make_std_unique.hpp"
+#include "../shared/message.hpp"
+#include "../util/make_std_unique.hpp"
+#include "all_generator.hpp"
+#include "cdata.hpp"
 
 #include <unicode/ucnv.h>
 

--- a/src/boost/locale/icu/numeric.cpp
+++ b/src/boost/locale/icu/numeric.cpp
@@ -5,10 +5,10 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/formatting.hpp>
-#include "boost/locale/icu/all_generator.hpp"
-#include "boost/locale/icu/cdata.hpp"
-#include "boost/locale/icu/formatter.hpp"
-#include "boost/locale/icu/formatters_cache.hpp"
+#include "all_generator.hpp"
+#include "cdata.hpp"
+#include "formatter.hpp"
+#include "formatters_cache.hpp"
 #include <algorithm>
 #include <ios>
 #include <limits>

--- a/src/boost/locale/icu/uconv.hpp
+++ b/src/boost/locale/icu/uconv.hpp
@@ -9,7 +9,7 @@
 #define BOOST_SRC_LOCALE_ICU_UCONV_HPP
 
 #include <boost/locale/encoding.hpp>
-#include "boost/locale/icu/icu_util.hpp"
+#include "icu_util.hpp"
 #include <boost/core/exchange.hpp>
 
 #include <memory>

--- a/src/boost/locale/posix/codecvt.cpp
+++ b/src/boost/locale/posix/codecvt.cpp
@@ -6,9 +6,9 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/encoding_errors.hpp>
-#include "boost/locale/posix/all_generator.hpp"
-#include "boost/locale/shared/iconv_codecvt.hpp"
-#include "boost/locale/util/encoding.hpp"
+#include "../shared/iconv_codecvt.hpp"
+#include "../util/encoding.hpp"
+#include "all_generator.hpp"
 #include <stdexcept>
 
 namespace boost { namespace locale { namespace impl_posix {

--- a/src/boost/locale/posix/collate.cpp
+++ b/src/boost/locale/posix/collate.cpp
@@ -8,6 +8,8 @@
 #if defined(__FreeBSD__)
 #    include <xlocale.h>
 #endif
+#include "../shared/mo_hash.hpp"
+#include "all_generator.hpp"
 #include <clocale>
 #include <cstring>
 #include <ios>
@@ -16,9 +18,6 @@
 #include <string>
 #include <vector>
 #include <wchar.h>
-
-#include "boost/locale/posix/all_generator.hpp"
-#include "boost/locale/shared/mo_hash.hpp"
 
 namespace boost { namespace locale { namespace impl_posix {
 

--- a/src/boost/locale/posix/converter.cpp
+++ b/src/boost/locale/posix/converter.cpp
@@ -7,7 +7,7 @@
 #include <boost/locale/conversion.hpp>
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale/util/encoding.hpp"
+#include "../util/encoding.hpp"
 #include <cctype>
 #include <cstring>
 #include <langinfo.h>
@@ -18,7 +18,7 @@
 #    include <xlocale.h>
 #endif
 
-#include "boost/locale/posix/all_generator.hpp"
+#include "all_generator.hpp"
 
 namespace boost { namespace locale { namespace impl_posix {
 

--- a/src/boost/locale/posix/numeric.cpp
+++ b/src/boost/locale/posix/numeric.cpp
@@ -27,8 +27,8 @@
 #include <vector>
 #include <wctype.h>
 
-#include "boost/locale/posix/all_generator.hpp"
-#include "boost/locale/util/numeric.hpp"
+#include "../util/numeric.hpp"
+#include "all_generator.hpp"
 
 namespace boost { namespace locale { namespace impl_posix {
 

--- a/src/boost/locale/posix/posix_backend.cpp
+++ b/src/boost/locale/posix/posix_backend.cpp
@@ -5,7 +5,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/posix/posix_backend.hpp"
+#include "posix_backend.hpp"
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/locale/info.hpp>
 #include <boost/locale/localization_backend.hpp>
@@ -19,10 +19,10 @@
 #    include <xlocale.h>
 #endif
 
-#include "boost/locale/posix/all_generator.hpp"
-#include "boost/locale/shared/message.hpp"
-#include "boost/locale/util/gregorian.hpp"
-#include "boost/locale/util/make_std_unique.hpp"
+#include "../shared/message.hpp"
+#include "../util/gregorian.hpp"
+#include "../util/make_std_unique.hpp"
+#include "all_generator.hpp"
 
 namespace boost { namespace locale { namespace impl_posix {
 

--- a/src/boost/locale/shared/format.cpp
+++ b/src/boost/locale/shared/format.cpp
@@ -7,7 +7,7 @@
 #include <boost/locale/format.hpp>
 #include <boost/locale/generator.hpp>
 #include <boost/locale/info.hpp>
-#include "boost/locale/util/numeric.hpp"
+#include "../util/numeric.hpp"
 #include <algorithm>
 #include <iostream>
 #include <limits>

--- a/src/boost/locale/shared/formatting.cpp
+++ b/src/boost/locale/shared/formatting.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/locale/date_time.hpp>
 #include <boost/locale/formatting.hpp>
-#include "boost/locale/shared/ios_prop.hpp"
+#include "ios_prop.hpp"
 
 namespace boost { namespace locale {
     ios_info::ios_info() : flags_(0), domain_id_(0), time_zone_(time_zone::global()) {}

--- a/src/boost/locale/shared/iconv_codecvt.cpp
+++ b/src/boost/locale/shared/iconv_codecvt.cpp
@@ -12,9 +12,9 @@
 #include <limits>
 #include <vector>
 #ifdef BOOST_LOCALE_WITH_ICONV
-#    include "boost/locale/util/encoding.hpp"
-#    include "boost/locale/util/iconv.hpp"
-#    include "boost/locale/util/make_std_unique.hpp"
+#    include "../util/encoding.hpp"
+#    include "../util/iconv.hpp"
+#    include "../util/make_std_unique.hpp"
 #endif
 
 namespace boost { namespace locale {

--- a/src/boost/locale/shared/ids.cpp
+++ b/src/boost/locale/shared/ids.cpp
@@ -11,7 +11,7 @@
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/info.hpp>
 #include <boost/locale/message.hpp>
-#include "boost/locale/util/foreach_char.hpp"
+#include "../util/foreach_char.hpp"
 #include <boost/core/ignore_unused.hpp>
 
 namespace boost { namespace locale {

--- a/src/boost/locale/shared/localization_backend.cpp
+++ b/src/boost/locale/shared/localization_backend.cpp
@@ -12,19 +12,19 @@
 #include <vector>
 
 #ifdef BOOST_LOCALE_WITH_ICU
-#    include "boost/locale/icu/icu_backend.hpp"
+#    include "../icu/icu_backend.hpp"
 #endif
 
 #ifndef BOOST_LOCALE_NO_POSIX_BACKEND
-#    include "boost/locale/posix/posix_backend.hpp"
+#    include "../posix/posix_backend.hpp"
 #endif
 
 #ifndef BOOST_LOCALE_NO_STD_BACKEND
-#    include "boost/locale/std/std_backend.hpp"
+#    include "../std/std_backend.hpp"
 #endif
 
 #ifndef BOOST_LOCALE_NO_WINAPI_BACKEND
-#    include "boost/locale/win32/win_backend.hpp"
+#    include "../win32/win_backend.hpp"
 #endif
 
 namespace boost { namespace locale {

--- a/src/boost/locale/shared/message.cpp
+++ b/src/boost/locale/shared/message.cpp
@@ -20,11 +20,11 @@
 
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/message.hpp>
-#include "boost/locale/shared/message.hpp"
-#include "boost/locale/shared/mo_hash.hpp"
-#include "boost/locale/shared/mo_lambda.hpp"
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/foreach_char.hpp"
+#include "../util/encoding.hpp"
+#include "../util/foreach_char.hpp"
+#include "message.hpp"
+#include "mo_hash.hpp"
+#include "mo_lambda.hpp"
 #include <boost/assert.hpp>
 #include <boost/utility/string_view.hpp>
 #include <cstdio>

--- a/src/boost/locale/shared/mo_lambda.cpp
+++ b/src/boost/locale/shared/mo_lambda.cpp
@@ -5,7 +5,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/shared/mo_lambda.hpp"
+#include "mo_lambda.hpp"
 #include <boost/assert.hpp>
 #include <algorithm>
 #include <cstdlib>

--- a/src/boost/locale/std/codecvt.cpp
+++ b/src/boost/locale/std/codecvt.cpp
@@ -5,7 +5,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/util.hpp>
-#include "boost/locale/std/all_generator.hpp"
+#include "all_generator.hpp"
 #include <locale>
 
 namespace boost { namespace locale { namespace impl_std {

--- a/src/boost/locale/std/collate.cpp
+++ b/src/boost/locale/std/collate.cpp
@@ -5,7 +5,7 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/encoding.hpp>
-#include "boost/locale/std/all_generator.hpp"
+#include "all_generator.hpp"
 #include <boost/assert.hpp>
 #include <ios>
 #include <locale>

--- a/src/boost/locale/std/converter.cpp
+++ b/src/boost/locale/std/converter.cpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include "boost/locale/std/all_generator.hpp"
+#include "all_generator.hpp"
 
 namespace boost { namespace locale { namespace impl_std {
 

--- a/src/boost/locale/std/numeric.cpp
+++ b/src/boost/locale/std/numeric.cpp
@@ -14,8 +14,8 @@
 #include <sstream>
 #include <string>
 
-#include "boost/locale/std/all_generator.hpp"
-#include "boost/locale/util/numeric.hpp"
+#include "../util/numeric.hpp"
+#include "all_generator.hpp"
 
 namespace boost { namespace locale { namespace impl_std {
     /// Forwarding time_put facet

--- a/src/boost/locale/std/std_backend.cpp
+++ b/src/boost/locale/std/std_backend.cpp
@@ -5,7 +5,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/std/std_backend.hpp"
+#include "std_backend.hpp"
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/locale/localization_backend.hpp>
 #include <boost/locale/util.hpp>
@@ -20,15 +20,15 @@
 #    ifndef NOMINMAX
 #        define NOMINMAX
 #    endif
-#    include "boost/locale/win32/lcid.hpp"
+#    include "../win32/lcid.hpp"
 #    include <windows.h>
 #endif
-#include "boost/locale/shared/message.hpp"
-#include "boost/locale/std/all_generator.hpp"
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/gregorian.hpp"
-#include "boost/locale/util/make_std_unique.hpp"
-#include "boost/locale/util/numeric.hpp"
+#include "../shared/message.hpp"
+#include "../util/encoding.hpp"
+#include "../util/gregorian.hpp"
+#include "../util/make_std_unique.hpp"
+#include "../util/numeric.hpp"
+#include "all_generator.hpp"
 
 namespace {
 struct windows_name {

--- a/src/boost/locale/util/codecvt_converter.cpp
+++ b/src/boost/locale/util/codecvt_converter.cpp
@@ -15,8 +15,8 @@
 #include <cstddef>
 #include <cstring>
 
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/make_std_unique.hpp"
+#include "encoding.hpp"
+#include "make_std_unique.hpp"
 
 #ifdef BOOST_MSVC
 #    pragma warning(disable : 4244) // loose data

--- a/src/boost/locale/util/encoding.cpp
+++ b/src/boost/locale/util/encoding.cpp
@@ -5,10 +5,10 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/string.hpp"
+#include "encoding.hpp"
+#include <boost/locale/util/string.hpp>
 #if BOOST_LOCALE_USE_WIN32_API
-#    include "boost/locale/util/win_codepages.hpp"
+#    include "win_codepages.hpp"
 #    ifndef NOMINMAX
 #        define NOMINMAX
 #    endif

--- a/src/boost/locale/util/gregorian.cpp
+++ b/src/boost/locale/util/gregorian.cpp
@@ -4,11 +4,11 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/util/gregorian.hpp"
+#include "gregorian.hpp"
 #include <boost/locale/date_time.hpp>
 #include <boost/locale/date_time_facet.hpp>
 #include <boost/locale/hold_ptr.hpp>
-#include "boost/locale/util/timezone.hpp"
+#include "timezone.hpp"
 #include <boost/assert.hpp>
 #include <algorithm>
 #include <cstdlib>

--- a/src/boost/locale/util/locale_data.cpp
+++ b/src/boost/locale/util/locale_data.cpp
@@ -6,8 +6,8 @@
 // https://www.boost.org/LICENSE_1_0.txt
 
 #include <boost/locale/util/locale_data.hpp>
-#include "boost/locale/util/encoding.hpp"
-#include "boost/locale/util/string.hpp"
+#include <boost/locale/util/string.hpp>
+#include "encoding.hpp"
 #include <boost/assert.hpp>
 #include <algorithm>
 #include <stdexcept>

--- a/src/boost/locale/win32/api.hpp
+++ b/src/boost/locale/win32/api.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 
-#include "boost/locale/win32/lcid.hpp"
+#include "lcid.hpp"
 
 #ifndef NOMINMAX
 #    define NOMINMAX

--- a/src/boost/locale/win32/collate.cpp
+++ b/src/boost/locale/win32/collate.cpp
@@ -6,9 +6,9 @@
 
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale/shared/mo_hash.hpp"
-#include "boost/locale/shared/std_collate_adapter.hpp"
-#include "boost/locale/win32/api.hpp"
+#include "../shared/mo_hash.hpp"
+#include "../shared/std_collate_adapter.hpp"
+#include "api.hpp"
 #include <ios>
 #include <locale>
 #include <string>

--- a/src/boost/locale/win32/converter.cpp
+++ b/src/boost/locale/win32/converter.cpp
@@ -7,8 +7,8 @@
 #include <boost/locale/conversion.hpp>
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale/win32/all_generator.hpp"
-#include "boost/locale/win32/api.hpp"
+#include "all_generator.hpp"
+#include "api.hpp"
 #include <cstring>
 #include <locale>
 #include <stdexcept>

--- a/src/boost/locale/win32/lcid.cpp
+++ b/src/boost/locale/win32/lcid.cpp
@@ -8,7 +8,7 @@
 #    define NOMINMAX
 #endif
 
-#include "boost/locale/win32/lcid.hpp"
+#include "lcid.hpp"
 #include <boost/locale/util/locale_data.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>

--- a/src/boost/locale/win32/numeric.cpp
+++ b/src/boost/locale/win32/numeric.cpp
@@ -4,12 +4,12 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/util/numeric.hpp"
+#include "../util/numeric.hpp"
 #include <boost/locale/encoding.hpp>
 #include <boost/locale/formatting.hpp>
 #include <boost/locale/generator.hpp>
-#include "boost/locale/win32/all_generator.hpp"
-#include "boost/locale/win32/api.hpp"
+#include "all_generator.hpp"
+#include "api.hpp"
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>

--- a/src/boost/locale/win32/win_backend.cpp
+++ b/src/boost/locale/win32/win_backend.cpp
@@ -5,17 +5,17 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include "boost/locale/win32/win_backend.hpp"
+#include "win_backend.hpp"
 #include <boost/locale/gnu_gettext.hpp>
 #include <boost/locale/info.hpp>
 #include <boost/locale/localization_backend.hpp>
 #include <boost/locale/util.hpp>
 #include <boost/locale/util/locale_data.hpp>
-#include "boost/locale/shared/message.hpp"
-#include "boost/locale/util/gregorian.hpp"
-#include "boost/locale/util/make_std_unique.hpp"
-#include "boost/locale/win32/all_generator.hpp"
-#include "boost/locale/win32/api.hpp"
+#include "../shared/message.hpp"
+#include "../util/gregorian.hpp"
+#include "../util/make_std_unique.hpp"
+#include "all_generator.hpp"
+#include "api.hpp"
 #include <algorithm>
 #include <iterator>
 #include <vector>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,13 +4,8 @@
 
 include(BoostTestJamfile)
 
-add_library(boost_locale_test INTERFACE)
-# Add test folder to include directories, especially for systems
-# where the current folder is not automatically added to the search path
-target_include_directories(boost_locale_test INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
-
 set(BOOST_TEST_COMPILE_DEFINITIONS "")
-set(BOOST_TEST_LINK_LIBRARIES Boost::locale boost_locale_test)
+set(BOOST_TEST_LINK_LIBRARIES Boost::locale)
 set(BOOST_TEST_COMPILE_OPTIONS ${BOOST_LOCALE_WARNING_OPTIONS})
 if(MSVC OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)

--- a/test/boostLocale/test/tools.hpp
+++ b/test/boostLocale/test/tools.hpp
@@ -8,8 +8,8 @@
 #define BOOST_LOCALE_TEST_TOOLS_HPP
 
 #include <boost/locale/encoding.hpp>
-#include "boostLocale/test/posix_tools.hpp"
-#include "boostLocale/test/unit_test.hpp"
+#include "posix_tools.hpp"
+#include "unit_test.hpp"
 #include <cstdio>
 #include <ctime>
 #include <fstream>

--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -17,7 +17,7 @@
 #    endif
 #endif
 
-#include <boostLocale/test/test_helpers.hpp>
+#include "boostLocale/test/test_helpers.hpp"
 #include <cstdlib>
 #ifdef BOOST_WINDOWS
 #    include <list>


### PR DESCRIPTION
Makes it easier to see the distinction, especially for tools.

Partial revert of https://github.com/Return-To-The-Roots/s25client/pull/1727