### PR TITLE
make header `src/shread/mo_hash.hpp` guarded

### DIFF
--- a/src/shared/mo_hash.hpp
+++ b/src/shared/mo_hash.hpp
@@ -4,6 +4,9 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
+#ifndef BOOST_SRC_LOCALE_MO_HASH_HPP
+#define BOOST_SRC_LOCALE_MO_HASH_HPP
+
 #include <cstdint>
 
 namespace boost { namespace locale { namespace gnu_gettext {
@@ -49,3 +52,5 @@ namespace boost { namespace locale { namespace gnu_gettext {
         return state;
     }
 }}} // namespace boost::locale::gnu_gettext
+
+#endif


### PR DESCRIPTION
Header `src/shared/mo_hash.hpp` is unguarded. 

Most times it works. But recently I'm trying to compile `boost/locale` into a [`C++20 module`](https://cppreference.com/w/cpp/language/modules.html). I found this file better be guarded in this compiling-case, as `C++20 module` treats function-declarations in `.hpp` files as translatable ones (which cannot be multi-defined).

One tiny change: `#ifdef xxx #define xxx` to make header `mo_hash.hpp` guarded.

Thank you!
*This is an amazing library and I will start it :)*