### PR TITLE
Move Boost dependencies to library instead of project requirements

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -421,8 +421,8 @@ lib boost_locale
       util/info.cpp
       util/locale_data.cpp
     : requirements
-      <library>$(boost_dependencies_private)
-      <library>$(boost_dependencies)
+      <library>$(boost_dependencies_private)/<warnings-as-errors>off
+      <library>$(boost_dependencies)/<warnings-as-errors>off
       $(cxx_requirements)
       <link>shared:<define>BOOST_LOCALE_DYN_LINK=1
       <define>BOOST_LOCALE_SOURCE
@@ -432,7 +432,7 @@ lib boost_locale
       # Meanwhile remove this
       <conditional>@configure
     : usage-requirements
-      <library>$(boost_dependencies)
+      <library>$(boost_dependencies)/<warnings-as-errors>off
       $(cxx_requirements)
       <link>shared:<define>BOOST_LOCALE_DYN_LINK=1
       <define>BOOST_LOCALE_NO_LIB=1


### PR DESCRIPTION
Otherwise all test builds and imported libs will link to those too. This causes e.g. Boost.Thread to be build and installed as a shared library due to e.g. `<library>icuuc/<link>shared`